### PR TITLE
[JRO] Remove all calls to name on user

### DIFF
--- a/app/decorators/thredded/post_decorator.rb
+++ b/app/decorators/thredded/post_decorator.rb
@@ -9,7 +9,7 @@ module Thredded
 
     def user_name
       if user
-        user.name
+        user.to_s
       else
         'Anonymous'
       end

--- a/app/decorators/thredded/topic_decorator.rb
+++ b/app/decorators/thredded/topic_decorator.rb
@@ -23,7 +23,7 @@ module Thredded
       if last_user.nil?
         'Anonymous'
       else
-        "<a href='/users/#{last_user.name}'>#{last_user.name}</a>".html_safe
+        "<a href='/users/#{last_user}'>#{last_user}</a>".html_safe
       end
     end
 

--- a/app/helpers/thredded/messageboard_helper.rb
+++ b/app/helpers/thredded/messageboard_helper.rb
@@ -43,7 +43,7 @@ module Thredded
 
     def latest_user_for(messageboard)
       if messageboard.topics.first.present? && messageboard.topics.first.user.present?
-        messageboard.topics.first.last_user.name
+        messageboard.topics.first.last_user.to_s
       else
         ''
       end

--- a/app/models/thredded/messageboard_decorator.rb
+++ b/app/models/thredded/messageboard_decorator.rb
@@ -8,11 +8,11 @@ module Thredded
     end
 
     def category_options
-      messageboard.categories.collect { |cat| [cat.name, cat.id] }
+      messageboard.categories.map { |cat| [cat.name, cat.id] }
     end
 
     def users_options
-      messageboard.users.collect{ |user| [user.name, user.id] }
+      messageboard.users.map { |user| [user.to_s, user.id] }
     end
   end
 end

--- a/app/models/thredded/null_user.rb
+++ b/app/models/thredded/null_user.rb
@@ -24,6 +24,10 @@ module Thredded
       'Anonymous User'
     end
 
+    def to_s
+      name
+    end
+
     def valid?
       false
     end

--- a/app/models/thredded/private_topic.rb
+++ b/app/models/thredded/private_topic.rb
@@ -36,7 +36,7 @@ module Thredded
     end
 
     def users_to_sentence
-      users.map{ |user| user.name.capitalize }.to_sentence
+      users.map{ |user| user.to_s.capitalize }.to_sentence
     end
   end
 end

--- a/app/views/thredded/post_mailer/at_notification.html.erb
+++ b/app/views/thredded/post_mailer/at_notification.html.erb
@@ -5,7 +5,7 @@
 <hr />
 
 <p>
-  This email was sent to you because <%= @post.user.name %> mentioned you in
+  This email was sent to you because <%= @post.user %> mentioned you in
   "<%= link_to @post.topic.title, messageboard_topic_posts_url(@post.messageboard, @post.topic, anchor: "post_#{@post.id}") %>"
   Feel free to reply above or <%= link_to 'head to the thread', messageboard_topic_posts_url(@post.messageboard, @post.topic) %>
   to view the conversation.

--- a/app/views/thredded/post_mailer/at_notification.text.erb
+++ b/app/views/thredded/post_mailer/at_notification.text.erb
@@ -4,7 +4,7 @@
 
 ---
 
-This email was sent to you because <%= @post.user.name %> mentioned you in
+This email was sent to you because <%= @post.user %> mentioned you in
 "<%= @post.topic.title %>". Feel free to reply above or head to the following
 to view the conversation:
   <%= messageboard_topic_posts_url @post.messageboard, @post.topic, anchor: "post_#{@post.id}" %>

--- a/app/views/thredded/shared/_currently_online.html.erb
+++ b/app/views/thredded/shared/_currently_online.html.erb
@@ -2,8 +2,8 @@
   <div class="online">
     <h3>Currently Online</h3>
     <ul>
-      <% messageboard.active_users.each do |u| %>
-       <li><%= u.name %></li>
+      <% messageboard.active_users.each do |user| %>
+       <li><%= user %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/thredded/topic_mailer/message_notification.html.erb
+++ b/app/views/thredded/topic_mailer/message_notification.html.erb
@@ -5,7 +5,7 @@
 <hr />
 
 <p>
-  This email was sent to you because <%= @topic.user.name %> included you in a
+  This email was sent to you because <%= @topic.user %> included you in a
   private topic, "<%= link_to @topic.title, messageboard_topic_posts_url(@topic.messageboard, @topic) %>".
   Feel free to reply above or <%= link_to 'head to the thread', messageboard_topic_posts_url(@topic.messageboard, @topic) %>
   to view the conversation.

--- a/app/views/thredded/topic_mailer/message_notification.text.erb
+++ b/app/views/thredded/topic_mailer/message_notification.text.erb
@@ -4,7 +4,7 @@
 
 ---
 
-This email was sent to you because <%= @topic.user.name %>
+This email was sent to you because <%= @topic.user %>
 included you in the private topic "<%= @topic.title %>". Feel free to reply
 above or head to the following to view the conversation:
   <%= messageboard_topic_posts_url(@topic.messageboard, @topic) %>

--- a/lib/thredded/at_users.rb
+++ b/lib/thredded/at_users.rb
@@ -7,8 +7,8 @@ module Thredded
       members = messageboard.members_from_list(at_names)
 
       members.each do |member|
-        content.gsub!(/@#{member.name}/i,
-          %Q{<a href="/users/#{member.name}">@#{member.name}</a>})
+        content.gsub!(/@#{member.to_s}/i,
+          %Q{<a href="/users/#{member.to_s}">@#{member.to_s}</a>})
       end
 
       content

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
 
     <div id='header'>
       <% if signed_in? %>
-        <%= current_user.name %> | <%= link_to 'Sign out', session_path, method: :delete %>
+        <%= current_user %> | <%= link_to 'Sign out', session_path, method: :delete %>
       <% else %>
         <%= link_to 'Sign in', sessions_new_path %>
       <% end %>

--- a/spec/models/thredded/topic_spec.rb
+++ b/spec/models/thredded/topic_spec.rb
@@ -35,8 +35,8 @@ module Thredded
     it 'provides anon user object when user not avail' do
       topic = build_stubbed(:topic, last_user_id: 1000)
 
-      topic.last_user.should be_instance_of NullUser
-      topic.last_user.name.should == 'Anonymous User'
+      expect(topic.last_user).to be_instance_of NullUser
+      expect(topic.last_user.to_s).to eq 'Anonymous User'
     end
 
     it 'returns the last user to post to this thread' do

--- a/spec/support/features/page_object/messageboard_preferences.rb
+++ b/spec/support/features/page_object/messageboard_preferences.rb
@@ -10,7 +10,7 @@ module PageObject
     end
 
     def visit_preferences
-      signs_in_as(user.name)
+      signs_in_as(user.to_s)
       visit edit_messageboard_preferences_path(messageboard)
     end
 

--- a/spec/support/features/page_object/messageboards.rb
+++ b/spec/support/features/page_object/messageboards.rb
@@ -3,7 +3,7 @@ require 'support/features/page_object/base'
 module PageObject
   class Messageboards < Base
     def visit_index_as(user)
-      signs_in_as(user.name)
+      signs_in_as(user.to_s)
       visit root_path
     end
 

--- a/spec/support/features/page_object/user.rb
+++ b/spec/support/features/page_object/user.rb
@@ -13,7 +13,7 @@ module PageObject
 
     def log_in
       visit new_session_path
-      fill_in 'name', with: user.name
+      fill_in 'name', with: user.to_s
       click_button 'Sign in'
     end
 
@@ -22,11 +22,11 @@ module PageObject
     end
 
     def displaying_the_profile?
-      has_content?(@user.name)
+      has_content?(@user.to_s)
     end
 
     def has_redirected_with_error?
-      has_content?("No user exists named #{@user.name}")
+      has_content?("No user exists named #{@user.to_s}")
     end
   end
 end

--- a/spec/support/features/page_object/visitor.rb
+++ b/spec/support/features/page_object/visitor.rb
@@ -13,7 +13,7 @@ module PageObject
     end
 
     def has_redirected_with_error?
-      has_content?("No user exists named #{@visitor.name}")
+      has_content?("No user exists named #{@visitor.to_s}")
     end
 
     def links_github_with_existing_account


### PR DESCRIPTION
Instead, lean on `#to_s` as it's the method we specify and ask for in the
README. Some parent apps may have no name method or AR property/column,
therefore would break.
