### PR TITLE
MySQL compatible migrations

### DIFF
--- a/db/migrate/20130425230852_create_thredded_tables.rb
+++ b/db/migrate/20130425230852_create_thredded_tables.rb
@@ -25,7 +25,7 @@ class CreateThreddedTables < ActiveRecord::Migration
 
     create_table :thredded_messageboards do |t|
       t.string   :name, null: false
-      t.string   :slug
+      t.string   :slug, limit: 191
       t.text     :description
       t.string   :security, default: 'public'
       t.string   :posting_permission, default: 'anonymous'
@@ -93,15 +93,15 @@ class CreateThreddedTables < ActiveRecord::Migration
       t.integer  :user_id, null: false
       t.integer  :last_user_id, null: false
       t.string   :title, null: false
-      t.string   :slug, null: false
+      t.string   :slug, null: false, limit: 191
       t.integer  :messageboard_id, null: false
       t.integer  :posts_count, default: 0
       t.string   :attribs, default: '[]'
       t.boolean  :sticky, default: false
       t.boolean  :locked, default: false
-      t.string   :hash_id, null: false
+      t.string   :hash_id, null: false, limit: 191
       t.string   :state, default: 'approved', null: false
-      t.string   :type
+      t.string   :type, limit: 191
       t.timestamps
     end
 
@@ -119,7 +119,7 @@ class CreateThreddedTables < ActiveRecord::Migration
 
     create_table :thredded_user_preferences do |t|
       t.integer :user_id, null: false
-      t.string :time_zone, default: 'Eastern Time (US & Canada)'
+      t.string :time_zone, default: 'Eastern Time (US & Canada)', limit: 191
       t.timestamps
     end
 

--- a/db/migrate/20140508012243_create_thredded_private_topics.rb
+++ b/db/migrate/20140508012243_create_thredded_private_topics.rb
@@ -4,10 +4,10 @@ class CreateThreddedPrivateTopics < ActiveRecord::Migration
       t.integer :user_id, null: false
       t.integer :last_user_id, null: false
       t.string :title, null: false
-      t.string :slug, null: false
+      t.string :slug, null: false, limit: 191
       t.integer :messageboard_id, null: false
       t.integer :posts_count, default: 0
-      t.string :hash_id, null: false
+      t.string :hash_id, null: false, limit: 191
 
       t.timestamps
     end

--- a/db/migrate/20140519003131_move_topics_into_private_topics.rb
+++ b/db/migrate/20140519003131_move_topics_into_private_topics.rb
@@ -17,13 +17,15 @@ class MoveTopicsIntoPrivateTopics < ActiveRecord::Migration
   def delete_topic_categories_associated_with_private_topics
     execute <<-SQL
       DELETE FROM thredded_topic_categories
-      WHERE topic_id IN
-        (
+      WHERE topic_id IN (
+        SELECT tids.id FROM (
           SELECT DISTINCT t.id
-          FROM thredded_topic_categories c, thredded_topics t
-          WHERE c.topic_id=t.id
-          AND t.type='Thredded::PrivateTopic'
-        )
+          FROM thredded_topics t
+          INNER JOIN thredded_topic_categories cat
+          ON cat.topic_id=t.id
+          WHERE t.type='Thredded::PrivateTopic'
+        ) AS tids
+      )
     SQL
   end
 
@@ -48,8 +50,7 @@ class MoveTopicsIntoPrivateTopics < ActiveRecord::Migration
 
   def delete_old_private_topics_from_thredded_topics
     execute <<-SQL
-      DELETE FROM thredded_topics
-      WHERE type = 'Thredded::PrivateTopic'
+      DELETE FROM thredded_topics WHERE thredded_topics.type = 'Thredded::PrivateTopic'
     SQL
   end
 end

--- a/db/migrate/20140525011049_add_polymorphic_assoc_to_posts.rb
+++ b/db/migrate/20140525011049_add_polymorphic_assoc_to_posts.rb
@@ -1,13 +1,11 @@
-# This migration comes from thredded (originally 20140525011049)
 class AddPolymorphicAssocToPosts < ActiveRecord::Migration
   def up
-    add_column :thredded_posts, :postable_type, :string
+    add_column :thredded_posts, :postable_type, :string, limit: 191
 
     execute <<-SQL
-      UPDATE thredded_posts
-      SET postable_type = 'Thredded::PrivateTopic'
-      FROM  thredded_private_topics
-      WHERE thredded_private_topics.id = thredded_posts.topic_id
+      UPDATE thredded_posts tp
+      INNER JOIN thredded_private_topics tpt ON tpt.id = tp.topic_id
+      SET tp.postable_type = 'Thredded::PrivateTopic'
     SQL
 
     execute <<-SQL

--- a/db/migrate/20140721134719_set_older_private_topics_as_read.rb
+++ b/db/migrate/20140721134719_set_older_private_topics_as_read.rb
@@ -1,16 +1,9 @@
 class SetOlderPrivateTopicsAsRead < ActiveRecord::Migration
   def up
-    execute <<-EOSQL
-      UPDATE thredded_private_users
-      SET read=true
-      WHERE (updated_at < '#{60.days.ago}')
-    EOSQL
+    Thredded::PrivateUser.where('updated_at < ?', 60.days.ago).update_all(read: true)
   end
 
   def down
-    execute <<-EOSQL
-      UPDATE thredded_private_users
-      SET read=false
-    EOSQL
+    Thredded::PrivateUser.update_all(read: false)
   end
 end

--- a/db/migrate/20140829155857_add_slug_to_thredded_categories.rb
+++ b/db/migrate/20140829155857_add_slug_to_thredded_categories.rb
@@ -2,7 +2,7 @@ require 'thredded/category'
 
 class AddSlugToThreddedCategories < ActiveRecord::Migration
   def up
-    add_column :thredded_categories, :slug, :string
+    add_column :thredded_categories, :slug, :string, limit: 191
     add_index :thredded_categories, [:messageboard_id, :slug], unique: true
 
     if defined?(Thredded::Category)


### PR DESCRIPTION
Make migrations run on MySQL.

The `limit: 191` on indexed string fields is due to [a mysql limitation](http://dev.mysql.com/doc/refman/5.5/en/charset-unicode-upgrading.html):

> InnoDB has a maximum index length of 767 bytes, so for utf8 or utf8mb4 columns, you can index a maximum of 255 or 191 characters, respectively. 

`utf8mb4` is required for emoji support, thus 191.

@jayroh By the way, have you seen how [Comfortable Mexican Sofa](https://github.com/comfy/comfortable-mexican-sofa) gem handles schema and migrations?
