### PR TITLE
Development web server rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,3 +29,18 @@ RSpec::Core::RakeTask.new(:spec)
 task default: :spec
 
 Bundler::GemHelper.install_tasks
+
+desc 'Start development web server'
+task :dev do
+  host = 'localhost'
+  port = ENV['PORT'] || 9292
+  require 'rails/commands/server'
+  ENV['RACK_ENV'] = ENV['RAILS_ENV'] = 'development'
+  Dir.chdir 'spec/dummy'
+  Rack::Server.start(
+      environment: 'development',
+      Host: host,
+      Port: port,
+      config: 'config.ru'
+  )
+end


### PR DESCRIPTION
`rake dev` to start a development web server using spec/dummy

``` console
$ rake dev
INFO  WEBrick 1.3.1
INFO  ruby 2.1.3
INFO  WEBrick::HTTPServer#start: pid=65828 port=9292
```
