### PR TITLE
Case-insensitive string matching for MySQL and PG

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -1,4 +1,4 @@
-# Thredded [![Code Climate](https://codeclimate.com/github/jayroh/thredded/badges/gpa.svg)](https://codeclimate.com/github/jayroh/thredded) [![Travis-CI](https://api.travis-ci.org/jayroh/thredded.svg?branch=master)](https://travis-ci.org/jayroh/thredded/) 
+# Thredded [![Code Climate](https://codeclimate.com/github/jayroh/thredded/badges/gpa.svg)](https://codeclimate.com/github/jayroh/thredded) [![Travis-CI](https://api.travis-ci.org/jayroh/thredded.svg?branch=master)](https://travis-ci.org/jayroh/thredded/)
 
 Thredded is a rails 4+ forum/messageboard engine. Its goal is to be as
 simple and feature rich as possible.

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -77,7 +77,7 @@ module Thredded
     end
 
     def members_from_list(user_list)
-      users.where('lower(name) in (?)', user_list.map(&:downcase))
+      CaseInsensitiveStringFinder.new(users, Thredded.user_name_column).find(user_list)
     end
 
     def posting_for_anonymous?

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -6,6 +6,9 @@
 # for your user class - change it here.
 Thredded.user_class = 'User'
 
+# User name column, used in @mention syntax and should be unique.
+Thredded.user_name_column = :name
+
 # The path (or URL) you will use to link to your users' profiles.
 # When linking to a user, Thredded will use this lambda to spit out
 # the path or url to your user.

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -14,9 +14,11 @@ require 'thredded/post_user_permissions'
 require 'thredded/private_topic_user_permissions'
 require 'thredded/topic_user_permissions'
 require 'thredded/search_sql_builder'
+require 'thredded/case_insensitive_string_finder'
 
 module Thredded
   mattr_accessor :user_class,
+    :user_name_column,
     :email_incoming_host,
     :email_from,
     :email_outgoing_prefix,
@@ -29,6 +31,7 @@ module Thredded
     :queue_memory_log_level,
     :queue_inline
 
+  self.user_name_column = :name
   self.file_storage = :file # or :fog
   self.asset_root = '' # or fully qualified URI to assets
   self.layout = 'thredded'
@@ -57,5 +60,10 @@ module Thredded
     else
       '/'
     end
+  end
+
+  def self.use_adapter!(db_adapter)
+    TableSqlBuilder.use_adapter! db_adapter
+    CaseInsensitiveStringFinder.use_adapter! db_adapter
   end
 end

--- a/lib/thredded/case_insensitive_string_finder.rb
+++ b/lib/thredded/case_insensitive_string_finder.rb
@@ -1,0 +1,29 @@
+module Thredded
+  # Exact case-insensitive string matching
+  class CaseInsensitiveStringFinder
+    # @return [Class<ActiveRecord::Base, ActiveRecord::Relation>]
+    attr_reader :scope
+    # @return [Symbol]
+    attr_reader :column
+
+    # @param [Class<ActiveRecord::Base, ActiveRecord::Relation>] scope
+    # @param [Symbol] column
+    def initialize(scope, column)
+      @scope  = scope
+      @column = column
+    end
+
+    def self.use_adapter!(db_adapter)
+      case db_adapter
+        when /mysql/
+          require 'thredded/case_insensitive_string_finder/mysql_builder'
+          include MySQLBuilder
+        when /postgresql/
+          require 'thredded/case_insensitive_string_finder/postgresql_builder'
+          include PostgreSQLBuilder
+        else
+          fail "Please define CaseInsensitiveStringFinder for #{db_adapter}"
+      end
+    end
+  end
+end

--- a/lib/thredded/case_insensitive_string_finder/mysql_builder.rb
+++ b/lib/thredded/case_insensitive_string_finder/mysql_builder.rb
@@ -1,0 +1,11 @@
+module Thredded
+  class CaseInsensitiveStringFinder
+    module MySQLBuilder
+      # @param [String, Array<String>] values
+      # @return [ActiveRecord::Relation]
+      def find(values)
+        scope.where(column => values)
+      end
+    end
+  end
+end

--- a/lib/thredded/case_insensitive_string_finder/postgresql_builder.rb
+++ b/lib/thredded/case_insensitive_string_finder/postgresql_builder.rb
@@ -1,0 +1,11 @@
+module Thredded
+  class CaseInsensitiveStringFinder
+    module PostgreSQLBuilder
+      # @param [String, Array<String>] values
+      # @return [ActiveRecord::Relation]
+      def find(values)
+        scope.where("lower(#{column}) IN (?)", Array(values).map(&:downcase))
+      end
+    end
+  end
+end

--- a/lib/thredded/engine.rb
+++ b/lib/thredded/engine.rb
@@ -25,7 +25,7 @@ module Thredded
     end
 
     initializer 'thredded.set_adapter' do
-      TableSqlBuilder.use_adapter! Thredded::Post.connection_config[:adapter]
+      Thredded.use_adapter! Thredded::Post.connection_config[:adapter]
     end
   end
 end

--- a/lib/thredded/table_sql_builder.rb
+++ b/lib/thredded/table_sql_builder.rb
@@ -38,15 +38,8 @@ module Thredded
         @search_categories
       else
         if @terms['in']
-          @terms['in'].each do |category_name|
-            category = Category
-            .where('lower(name) = ?', category_name.downcase).first
-            if category
-              @search_categories << category.id
-            end
-          end
+          @search_categories.concat CaseInsensitiveStringFinder.new(Category, :name).find(@terms['in']).pluck(:id)
         end
-
         @search_categories
       end
     end
@@ -55,17 +48,9 @@ module Thredded
       if @search_users.any?
         @search_users
       else
-
         if @terms['by']
-          @terms['by'].each do |username|
-            user = Thredded.user_class.where('lower(name) = ?', username.downcase).first
-
-            if user
-              @search_users << user.id
-            end
-          end
+          @search_user.concat CaseInsensitiveStringFinder.new(Thredded.user_class, Thredded.user_name_column).find(@terms['by']).pluck(:id)
         end
-
         @search_users
       end
     end


### PR DESCRIPTION
The last mile for MySQL support. Also adds `Thredded.user_name_column` configuration variable.

---

On MySQL text columns are case-insensitive.
On PostgreSQL, they are case-sensitive by default.
