### PR TITLE
Fix UserDetail association and use counter_cache

### DIFF
--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -10,6 +10,12 @@ module Thredded
     belongs_to :messageboard, counter_cache: true
     belongs_to :postable, polymorphic: true, counter_cache: true
 
+    belongs_to :user_detail,
+               primary_key:   :user_id,
+               foreign_key:   :user_id,
+               inverse_of:    :posts,
+               counter_cache: true
+
     # Postable types to enable joins, e.g. Thredded::Post.joins(:private_topic)
     belongs_to :private_topic, -> _p { where(thredded_posts: {postable_type: 'Thredded::PrivateTopic'}) },
                foreign_key: :postable_id, inverse_of: :posts
@@ -19,7 +25,6 @@ module Thredded
     belongs_to :user, class_name: Thredded.user_class
     has_many :attachments, dependent: :destroy
     has_many :post_notifications, dependent: :destroy
-    has_one :user_detail, through: :user, source: :thredded_user_detail
 
     validates :content, presence: true
     validates :messageboard_id, presence: true
@@ -106,7 +111,6 @@ module Thredded
     end
 
     def modify_parent_posts_counts
-      user_detail.increment!(:posts_count) if user_detail
       postable.last_user = user
       postable.touch
       postable.save

--- a/app/models/thredded/topic.rb
+++ b/app/models/thredded/topic.rb
@@ -6,6 +6,12 @@ module Thredded
     extend FriendlyId
     friendly_id :title, use: [:history, :scoped], scope: :messageboard
 
+    belongs_to :user_detail,
+               primary_key:   :user_id,
+               foreign_key:   :user_id,
+               inverse_of:    :topics,
+               counter_cache: :topics_count
+
     has_many :posts,
       -> { includes :attachments },
       as: :postable,
@@ -13,9 +19,6 @@ module Thredded
     has_many :topic_categories, dependent: :destroy
     has_many :categories, through: :topic_categories
     has_many :user_topic_reads, dependent: :destroy
-    has_one :user_detail, through: :user, source: :thredded_user_detail
-
-    after_create :increment_topics_count
 
     def self.stuck
       where(sticky: true)
@@ -94,12 +97,6 @@ module Thredded
 
     def should_generate_new_friendly_id?
       title_changed?
-    end
-
-    private
-
-    def increment_topics_count
-      user_detail.increment!(:topics_count) if user_detail
     end
   end
 end

--- a/app/models/thredded/user_detail.rb
+++ b/app/models/thredded/user_detail.rb
@@ -2,5 +2,8 @@ module Thredded
   class UserDetail < ActiveRecord::Base
     belongs_to :user, class_name: Thredded.user_class
     validates :user_id, presence: true
+
+    has_many :topics, class_name: 'Thredded::Topic', foreign_key: :user_id, primary_key: :user_id
+    has_many :posts, class_name: 'Thredded::Post', foreign_key: :user_id, primary_key: :user_id
   end
 end

--- a/spec/models/thredded/post_spec.rb
+++ b/spec/models/thredded/post_spec.rb
@@ -11,7 +11,7 @@ module Thredded
   describe Post, 'associations' do
     it { should have_many(:post_notifications).dependent(:destroy) }
     it { should have_many(:attachments).dependent(:destroy) }
-    it { should have_one(:user_detail).through(:user) }
+    it { should belong_to(:user_detail) }
   end
 
   describe Post, '#create' do


### PR DESCRIPTION
1. Let Rails handle counter_cache
2. Use belongs_to instead of has_one through
#### Before

``` console
> Thredded::Post.first.user_detail
SELECT `thredded_user_details`.* FROM `thredded_user_details` 
INNER JOIN `accounts` ON `thredded_user_details`.`user_id` = `accounts`.`id` 
WHERE `accounts`.`id` = 127 LIMIT 1
```
#### After

``` console
> Thredded::Post.first.user_detail
SELECT `thredded_user_details`.* FROM `thredded_user_details` 
WHERE `thredded_user_details`.`user_id` = 127 LIMIT 1
```
