### PR TITLE
[JRO] Allow delegates to call against nil object

### DIFF
--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -21,7 +21,7 @@ module Thredded
                foreign_key: :postable_id, inverse_of: :posts
 
     belongs_to :user, class_name: Thredded.user_class
-    delegate :email, :anonymous?, to: :user, prefix: true
+    delegate :email, :anonymous?, to: :user, prefix: true, allow_nil: true
     has_many :attachments, dependent: :destroy
     has_many :post_notifications, dependent: :destroy
 

--- a/spec/models/thredded/post_spec.rb
+++ b/spec/models/thredded/post_spec.rb
@@ -14,6 +14,17 @@ module Thredded
     it { should belong_to(:user_detail) }
   end
 
+  context 'when a parent user is nil' do
+    describe Post, '#user_email and #anonymous?' do
+      it 'is nil' do
+        post = build_stubbed(:post, user: nil)
+
+        expect(post.user_email).to eq nil
+        expect(post.user_anonymous?).to eq nil
+      end
+    end
+  end
+
   describe Post, '#create' do
     after(:each) do
       Timecop.return


### PR DESCRIPTION
Cover our butts when calling delegate methods against a possible nil
User object. (Posts CAN have no user ... like if a user nukes their
profile)
