### PR TITLE
[JRO] Small fixes after testing on a live data set.

### DIFF
--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -87,6 +87,8 @@ module Thredded
     end
 
     def update_parent_last_user_and_timestamp
+      return unless postable && user
+
       postable.update!(last_user: user, updated_at: Time.zone.now)
     end
 

--- a/db/migrate/20160323025225_split_private_posts.rb
+++ b/db/migrate/20160323025225_split_private_posts.rb
@@ -30,12 +30,13 @@ class SplitPrivatePosts < ActiveRecord::Migration
       each do |(id, user_id, content, ip, filter, postable_id, created_at, updated_at)|
       private_post              = Thredded::PrivatePost.create!(
         user_id:     user_id,
-        content:     content,
+        content:     content.blank? ? '...' : content,
         ip:          ip,
         filter:      filter,
         postable_id: postable_id,
         created_at:  created_at,
-        updated_at:  updated_at)
+        updated_at:  updated_at,
+      )
       old_private_notifications = Thredded::PostNotification.where(post_id: id)
       old_private_notifications.each do |old_private_notification|
         Thredded::PostNotification.create!(email: old_private_notification.email, post: private_post)


### PR DESCRIPTION
Running the latest migration that splits posts into normal and private
posts bubbled up some small edge cases in the data for thredded.com.
There's an argument to be made for data normalization and enforcement of
data integrity at the main web app, but for the purposes of this commit,
we can guard against some of those integrities with the code itself.

1. There are some posts that have been orphaned by either the parent
   topic, or the parent user - and thus will break on
   `Post#update_parent_last_user_and_timestamp`. This commit adds a guard
   clause to ensure that we're updating an existing record with an existing
   user
2. Posts require *some* sort of content and will fail to save if content
   is empty. This update will add an ellipsis as the content if the content
   string is blank.