### PR TITLE
[JRO] Explicitly require user permissions modules

### DIFF
--- a/app/models/thredded/null_user.rb
+++ b/app/models/thredded/null_user.rb
@@ -1,3 +1,9 @@
+require_relative './user_permissions/read/all'
+require_relative './user_permissions/write/none'
+require_relative './user_permissions/message/readers_of_writeable_boards'
+require_relative './user_permissions/moderate/none'
+require_relative './user_permissions/admin/none'
+
 module Thredded
   class NullUser
     include ::Thredded::UserPermissions::Read::All

--- a/app/models/thredded/user_extender.rb
+++ b/app/models/thredded/user_extender.rb
@@ -1,3 +1,9 @@
+require_relative './user_permissions/read/all'
+require_relative './user_permissions/write/all'
+require_relative './user_permissions/message/readers_of_writeable_boards'
+require_relative './user_permissions/moderate/if_moderator_column_true'
+require_relative './user_permissions/admin/if_admin_column_true'
+
 module Thredded
   module UserExtender
     extend ActiveSupport::Concern


### PR DESCRIPTION
When pulling this into thredded.com I ran into some issues with rails'
auto-loading of the user permissions modules. By explicitly requiring
the files we reduce the work rails (sometimes incorrectly) will do to
pull in the right files.

Also, aliasing `thredded_anonymous?` to `anonymous?` in the NullUser
class fixes an issue where the null user will be substituted for a real
user class and will be asked if it's anonymous.