### PR TITLE
[JRO] Pull notification preferences out to partial

### DIFF
--- a/app/views/thredded/shared/_notification_preferences.html.erb
+++ b/app/views/thredded/shared/_notification_preferences.html.erb
@@ -1,0 +1,7 @@
+<% if messageboard.try(:persisted?) %>
+  <li>
+    <%= link_to edit_messageboard_preferences_path(messageboard) do %>
+      <span>Notification Settings</span>
+    <% end %>
+  </li>
+<% end %>

--- a/app/views/thredded/shared/_top_nav.html.erb
+++ b/app/views/thredded/shared/_top_nav.html.erb
@@ -14,13 +14,8 @@
           </li>
         <% end %>
 
-        <% if messageboard.try(:persisted?) %>
-          <li>
-            <%= link_to edit_messageboard_preferences_path(messageboard) do %>
-              <span>Notification Settings</span>
-            <% end %>
-          </li>
-        <% end %>
+        <%= render 'thredded/shared/notification_preferences',
+          messageboard: messageboard %>
 
         <% if Thredded.standalone_layout? %>
           <li>


### PR DESCRIPTION
At the (literal) top of the thredded views there's only one thing I
would initially want to pull out to the parent app's layout, or even
just hide - and that's the notification preferences link. Everything
else up there is just fine as it is.

By pulling this chunk of html out to a partial I can safely override it
in my parent app views and move it somewhere else (in my layout, for
instance) where it makes sense. For example:

![](https://www.evernote.com/l/AUohCPw7TVhMAbfvBlo--NrNJfsd8t8sSiIB/image.png)