### PR TITLE
[JRO] Rename current_user to thredded_current_user

### DIFF
--- a/app/controllers/thredded/application_controller.rb
+++ b/app/controllers/thredded/application_controller.rb
@@ -29,7 +29,7 @@ module Thredded
       end
 
     def signed_in?
-      !current_user.thredded_anonymous?
+      !thredded_current_user.thredded_anonymous?
     end
 
     private
@@ -39,7 +39,7 @@ module Thredded
         .joins(:private_users)
         .where(
           thredded_private_users: {
-            user_id: current_user.id,
+            user_id: thredded_current_user.id,
             read: false
           })
         .count
@@ -72,12 +72,12 @@ module Thredded
 
       Thredded::ActivityUpdaterJob.queue.update_user_activity(
         'messageboard_id' => messageboard.id,
-        'user_id' => current_user.id
+        'user_id' => thredded_current_user.id
       )
     end
 
     def current_ability
-      @current_ability ||= Ability.new(current_user)
+      @current_ability ||= Ability.new(thredded_current_user)
     end
 
     def messageboard
@@ -85,11 +85,11 @@ module Thredded
     end
 
     def preferences
-      @preferences ||= current_user.thredded_user_preference
+      @preferences ||= thredded_current_user.thredded_user_preference
     end
 
-    def current_user
-      super || NullUser.new
+    def thredded_current_user
+      current_user || NullUser.new
     end
 
     def active_users
@@ -98,7 +98,7 @@ module Thredded
               else
                 Thredded.user_class.joins(:thredded_user_detail).merge(Thredded::UserDetail.recently_active).to_a
               end.to_a
-      users.push(current_user) unless current_user.is_a?(NullUser)
+      users.push(thredded_current_user) unless thredded_current_user.is_a?(NullUser)
       users.uniq
     end
   end

--- a/app/controllers/thredded/messageboards_controller.rb
+++ b/app/controllers/thredded/messageboards_controller.rb
@@ -39,8 +39,8 @@ module Thredded
     def topic_params
       {
         messageboard: @messageboard,
-        user: current_user,
-        last_user: current_user,
+        user: thredded_current_user,
+        last_user: thredded_current_user,
         title: "Welcome to your messageboard's very first thread",
       }
     end
@@ -51,7 +51,7 @@ module Thredded
         postable: @topic,
         content: "There's not a whole lot here for now.",
         ip: request.ip,
-        user: current_user,
+        user: thredded_current_user,
       }
     end
   end

--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -38,14 +38,14 @@ module Thredded
     end
 
     def reset_read_status
-      Thredded::UserResetsPrivateTopicToUnread.new(parent_topic, current_user).run
+      Thredded::UserResetsPrivateTopicToUnread.new(parent_topic, thredded_current_user).run
     end
 
     def post_params
       params
         .require(:post)
         .permit(:content)
-        .merge!(user: current_user, ip: request.remote_ip)
+        .merge!(user: thredded_current_user, ip: request.remote_ip)
         .tap { |p| p.merge!(messageboard: messageboard) unless for_a_private_topic? }
     end
 

--- a/app/controllers/thredded/preferences_controller.rb
+++ b/app/controllers/thredded/preferences_controller.rb
@@ -13,7 +13,7 @@ module Thredded
 
     def preference
       @preference ||= NotificationPreference
-        .where(messageboard_id: messageboard.id, user_id: current_user.id)
+        .where(messageboard_id: messageboard.id, user_id: thredded_current_user.id)
         .first_or_create!
     end
 

--- a/app/controllers/thredded/private_topics_controller.rb
+++ b/app/controllers/thredded/private_topics_controller.rb
@@ -3,20 +3,20 @@ module Thredded
     helper_method :private_topic
 
     def index
-      @new_private_topic = PrivateTopicForm.new(user: current_user)
+      @new_private_topic = PrivateTopicForm.new(user: thredded_current_user)
       @private_topics = PrivateTopic
                           .uniq
-                          .for_user(current_user)
+                          .for_user(thredded_current_user)
                           .order('updated_at DESC')
                           .on_page(params[:page])
                           .load
       @decorated_private_topics = Thredded::UserPrivateTopicDecorator
-        .decorate_all(current_user, @private_topics)
+        .decorate_all(thredded_current_user, @private_topics)
     end
 
     def show
       authorize! :read, private_topic
-      UserReadsPrivateTopic.new(private_topic, current_user).run
+      UserReadsPrivateTopic.new(private_topic, thredded_current_user).run
 
       @posts = private_topic
         .posts
@@ -27,7 +27,7 @@ module Thredded
     end
 
     def new
-      @private_topic = PrivateTopicForm.new(user: current_user)
+      @private_topic = PrivateTopicForm.new(user: thredded_current_user)
       authorize_creating @private_topic.private_topic
     end
 
@@ -39,7 +39,7 @@ module Thredded
           .send_notifications(@private_topic.private_topic.id)
 
         UserResetsPrivateTopicToUnread
-          .new(@private_topic.private_topic, current_user)
+          .new(@private_topic.private_topic, thredded_current_user)
           .run
 
         redirect_to @private_topic.private_topic
@@ -59,7 +59,7 @@ module Thredded
         .require(:private_topic)
         .permit(:title, :locked, :sticky, :content, user_ids: [], category_ids: [])
         .merge(
-          user: current_user,
+          user: thredded_current_user,
           ip: request.remote_ip)
     end
   end

--- a/app/controllers/thredded/setups_controller.rb
+++ b/app/controllers/thredded/setups_controller.rb
@@ -34,8 +34,8 @@ module Thredded
     def topic_params
       {
         messageboard: @messageboard,
-        user: current_user,
-        last_user: current_user,
+        user: thredded_current_user,
+        last_user: thredded_current_user,
         title: "Welcome to your messageboard's very first thread",
       }
     end
@@ -46,7 +46,7 @@ module Thredded
         postable: @topic,
         content: "There's not a whole lot here for now.",
         ip: request.ip,
-        user: current_user,
+        user: thredded_current_user,
       }
     end
   end

--- a/app/controllers/thredded/theme_previews_controller.rb
+++ b/app/controllers/thredded/theme_previews_controller.rb
@@ -8,7 +8,7 @@ module Thredded
       @topics = messageboard.topics.on_page(current_page).limit(3)
       @decorated_topics = UserTopicDecorator.decorate_all(user, @topics)
       @decorated_private_topics = Thredded::UserPrivateTopicDecorator
-        .decorate_all(current_user, user.thredded_private_topics)
+        .decorate_all(thredded_current_user, user.thredded_private_topics)
       @topic = @topics.find { |t| t.posts.present? } || @topics.first ||
         @messageboard.topics.build(title: 'Hello', slug: 'hello', user: user)
       @user_topic = UserTopicDecorator.new(user, @topic)
@@ -49,10 +49,10 @@ module Thredded
     end
 
     def user
-      @user ||= if current_user.thredded_anonymous?
+      @user ||= if thredded_current_user.thredded_anonymous?
                   Thredded.user_class.first_or_create!(slug: 'joe', name: 'joe', email: 'joe@example.com')
                 else
-                  current_user
+                  thredded_current_user
                 end
     end
   end

--- a/app/views/thredded/shared/_top_nav.html.erb
+++ b/app/views/thredded/shared/_top_nav.html.erb
@@ -8,8 +8,8 @@
       <% if signed_in? %>
         <% if Thredded.standalone_layout? %>
           <li>
-            <%= link_to user_path(current_user) do %>
-              <span><%= current_user %></span>
+            <%= link_to user_path(thredded_current_user) do %>
+              <span><%= thredded_current_user %></span>
             <% end %>
           </li>
         <% end %>


### PR DESCRIPTION
There's no confusing what context we're in now.

This DOES reach into `current_user`, which is owned by the parent
application though. Possible TODO item(s) here is/are either allowing
configuration of the method called or expecting the parent application
to implement a `current_user` method.

This addresses issue #171 