### PR TITLE
Replace Q gem with ActiveJob (and backport)

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -60,19 +60,6 @@ Include thredded JavaScripts in your `application.js`:
 
 [initializer]: https://github.com/thredded/thredded/blob/master/lib/generators/thredded/install/templates/initializer.rb
 
-
-## Background Job Requirements
-
-This gem has several gem agnostic background jobs. Currently resque, sidekiq, delayed_job, and a threaded in-memory queue are supported thanks to [Richard Schneeman's Q gem](https://github.com/schneems/Q). The configuration detailed above allows you to specify which job queue you prefer with `Thredded.queue_backend`. The available options are one of the following symbols - `:threaded_in_memory_queue`, `:sidekiq`, `:resque`, or `:delayed_job`.
-
-When using the threaded in-memory queue you may *optionally* update its log-level for more granular debugging with the `Thredded.queue_memory_log_level` setting.
-
-When running the app in a test environment you may want to set your queue to run the jobs inline. In your config you may want to set the option based on environment. EG:
-
-```ruby
-Thredded.queue_inline = Rails.env.test?
-```
-
 ## Get Your Parent App Ready
 
 There are a few things you need in your app to get things looking just right.
@@ -209,12 +196,24 @@ Finally, run the development server with either `DB=postgresql` or `DB=mysql2`:
 $ DB=postgresql rake dev:server
 ```
 
+## Rails 4.1 and ActiveJob Support
+
+If you're currently using Rails 4.1 make sure to add ...
+
+```ruby
+gem 'activejob_backport'
+```
+
+... to your Gemfile before thredded. ActiveJob is now the main background job
+abstraction layer in Thredded. It was not introduced to rails until 4.2 so
+you'll need the backport to provide the support for it.
+
 ## Developing and Testing with [Docker Compose](http://docs.docker.com/compose/)
 
 To quickly try out _Thredded_ with the included dummy app, clone the source and
 start the included docker-compose.yml file with:
 
-```
+```console
 docker-compose build
 docker-compose up -d
 ```

--- a/app/commands/thredded/notify_mentioned_users.rb
+++ b/app/commands/thredded/notify_mentioned_users.rb
@@ -1,5 +1,7 @@
 module Thredded
   class NotifyMentionedUsers
+    DELIVER_METHOD = Rails.version < '4.2.0' ? :deliver : :deliver_later
+
     def initialize(post)
       @post = post
     end
@@ -9,7 +11,9 @@ module Thredded
       return unless members.present?
 
       user_emails = members.map(&:email)
-      (post.private_topic_post? ? PrivatePostMailer : PostMailer).at_notification(post.id, user_emails).deliver
+      (post.private_topic_post? ? PrivatePostMailer : PostMailer)
+        .at_notification(post.id, user_emails)
+        .send(DELIVER_METHOD)
       MembersMarkedNotified.new(post, members).run
     end
 

--- a/app/commands/thredded/notify_private_topic_users.rb
+++ b/app/commands/thredded/notify_private_topic_users.rb
@@ -1,5 +1,7 @@
 module Thredded
   class NotifyPrivateTopicUsers
+    DELIVER_METHOD = Rails.version < '4.2.0' ? :deliver : :deliver_later
+
     def initialize(private_topic)
       @post = private_topic.posts.first || Post.new
       @private_topic = private_topic
@@ -10,7 +12,9 @@ module Thredded
 
       return unless members.present?
       user_emails = members.map(&:email)
-      PrivateTopicMailer.message_notification(private_topic.id, user_emails).deliver
+      PrivateTopicMailer
+        .message_notification(private_topic.id, user_emails)
+        .send(DELIVER_METHOD)
       mark_notified(members)
     end
 

--- a/app/controllers/thredded/application_controller.rb
+++ b/app/controllers/thredded/application_controller.rb
@@ -70,9 +70,9 @@ module Thredded
     def update_user_activity
       return if messageboard.nil?
 
-      Thredded::ActivityUpdaterJob.queue.update_user_activity(
-        'messageboard_id' => messageboard.id,
-        'user_id' => thredded_current_user.id
+      Thredded::ActivityUpdaterJob.perform_later(
+        thredded_current_user.id,
+        messageboard.id
       )
     end
 

--- a/app/controllers/thredded/private_topics_controller.rb
+++ b/app/controllers/thredded/private_topics_controller.rb
@@ -35,8 +35,7 @@ module Thredded
       @private_topic = PrivateTopicForm.new(new_private_topic_params)
       if @private_topic.save
         NotifyPrivateTopicUsersJob
-          .queue
-          .send_notifications(@private_topic.private_topic.id)
+          .perform_later(@private_topic.private_topic.id)
 
         UserResetsPrivateTopicToUnread
           .new(@private_topic.private_topic, thredded_current_user)

--- a/app/jobs/thredded/activity_updater_job.rb
+++ b/app/jobs/thredded/activity_updater_job.rb
@@ -1,17 +1,20 @@
 module Thredded
-  class ActivityUpdaterJob
-    include Q::Methods
+  class ActivityUpdaterJob < ::ActiveJob::Base
+    queue_as :default
 
-    queue(:update_user_activity) do |options|
+    def perform(user_id, messageboard_id)
       now = Time.zone.now
-      ActiveRecord::Base.connection_pool.with_connection do
-        user_detail = Thredded::UserDetail.for_user_id(options['user_id'])
-        user_detail.update_column(:last_seen_at, now)
-        Thredded::MessageboardUser
-          .where(thredded_messageboard_id: options['messageboard_id'], thredded_user_detail_id: user_detail.id)
-          .first_or_initialize
-          .update!(last_seen_at: now)
-      end
+
+      user_detail = Thredded::UserDetail.for_user_id(user_id)
+      user_detail.update_column(:last_seen_at, now)
+
+      Thredded::MessageboardUser
+        .where(
+          thredded_messageboard_id: messageboard_id,
+          thredded_user_detail_id: user_detail.id
+        )
+        .first_or_initialize
+        .update!(last_seen_at: now)
     end
   end
 end

--- a/app/jobs/thredded/at_notifier_job.rb
+++ b/app/jobs/thredded/at_notifier_job.rb
@@ -1,11 +1,11 @@
 module Thredded
-  class AtNotifierJob
-    include Q::Methods
+  class AtNotifierJob < ::ActiveJob::Base
+    queue_as :default
 
-    queue(:send_at_notifications) do |post_type, post_id|
-      ActiveRecord::Base.connection_pool.with_connection do
-        NotifyMentionedUsers.new(post_type.to_s.constantize.find(post_id)).run
-      end
+    def perform(post_type, post_id)
+      post = post_type.to_s.constantize.find(post_id)
+
+      NotifyMentionedUsers.new(post).run
     end
   end
 end

--- a/app/jobs/thredded/notify_private_topic_users_job.rb
+++ b/app/jobs/thredded/notify_private_topic_users_job.rb
@@ -1,12 +1,11 @@
 module Thredded
-  class NotifyPrivateTopicUsersJob
-    include Q::Methods
+  class NotifyPrivateTopicUsersJob < ::ActiveJob::Base
+    queue_as :default
 
-    queue(:send_notifications) do |private_topic_id|
-      ActiveRecord::Base.connection_pool.with_connection do
-        private_topic = PrivateTopic.find(private_topic_id)
-        NotifyPrivateTopicUsers.new(private_topic).run if private_topic
-      end
+    def perform(private_topic_id)
+      private_topic = Thredded::PrivateTopic.find(private_topic_id)
+
+      NotifyPrivateTopicUsers.new(private_topic).run
     end
   end
 end

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -93,7 +93,7 @@ module Thredded
     end
 
     def notify_at_users
-      AtNotifierJob.queue.send_at_notifications(self.class.name, id)
+      AtNotifierJob.perform_later(self.class.name, id)
     end
 
     module ClassMethods

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -46,28 +46,6 @@ Thredded.admin_column = :admin
 # Reply to field for email notifications
 # Thredded.email_reply_to = -> postable { "#{postable.hash_id}@#{Thredded.email_incoming_host}" }
 
-# ==> Background Job/Queue Configuration
-# Thredded uses the 'Q' gem, which provides a common interface for several
-# different background job / queueing libraries. The supported queue
-# backends are:
-#
-#   :threaded_in_memory_queue
-#   :sidekiq
-#   :resque
-#   :delayed_job
-#
-# By default, the in-memory queue is turned on, but we recommend sidekiq.
-Thredded.queue_backend = :threaded_in_memory_queue
-
-# Whether or not to inline the jobs being processed. Typically you would only
-# want to turn this on for when the test suite is being run.
-Thredded.queue_inline = Rails.env.test?
-
-# If using the threaded in-memory queue it will default its log level to
-# `Logger::WARN` but if you would like more information, change it to
-# `Logger::INFO` or `Logger::DEBUG`.
-# Thredded.queue_memory_log_level = Logger::WARN
-
 # ==> View Configuration
 # Set the layout for rendering the thredded views.
 Thredded.layout = 'thredded/application'

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -7,8 +7,7 @@ require 'html/pipeline/at_mention_filter'
 require 'html/pipeline/bbcode_filter'
 require 'kaminari'
 require 'rb-gravatar'
-require 'q'
-require 'threaded_in_memory_queue'
+require 'active_job'
 
 # Asset compilation
 require 'autoprefixer-rails'
@@ -39,9 +38,6 @@ module Thredded
     :file_storage,
     :asset_root,
     :layout,
-    :queue_backend,
-    :queue_memory_log_level,
-    :queue_inline,
     :active_user_threshold
 
   # @return [Symbol] The name of the moderator flag column on the users table for the default permissions model
@@ -56,9 +52,6 @@ module Thredded
   self.file_storage = :file # or :fog
   self.asset_root = '' # or fully qualified URI to assets
   self.layout = 'thredded/application'
-  self.queue_backend = :threaded_in_memory_queue
-  self.queue_memory_log_level = Logger::WARN
-  self.queue_inline = false
   self.email_reply_to = -> postable { "#{postable.hash_id}@#{Thredded.email_incoming_host}" }
   self.moderator_column = :admin
   self.admin_column = :admin

--- a/lib/thredded/engine.rb
+++ b/lib/thredded/engine.rb
@@ -22,13 +22,6 @@ module Thredded
         # Delegate all main_app routes to allow calling them directly.
         ::Thredded::ApplicationController.helper ::Thredded::MainAppRouteDelegator
       end
-
-      Q.setup do |config|
-        config.queue = Thredded.queue_backend
-        config.queue_config.inline = Thredded.queue_inline
-      end
-
-      ThreadedInMemoryQueue.logger.level = Thredded.queue_memory_log_level
     end
 
     initializer 'thredded.setup_assets' do

--- a/spec/dummy/config/initializers/thredded.rb
+++ b/spec/dummy/config/initializers/thredded.rb
@@ -8,4 +8,3 @@ Thredded.layout = 'application' unless ENV['THREDDED_DUMMY_LAYOUT_STANDALONE']
 Thredded.avatar_url = ->(user) { Gravatar.src(user.email, 128, 'retro') }
 Thredded.moderator_column = :admin
 Thredded.admin_column = :admin
-Thredded.queue_inline = true

--- a/spec/gemfiles/rails_4_1.gemfile
+++ b/spec/gemfiles/rails_4_1.gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 gemspec path: '../../'
 eval_gemfile './shared.gemfile'
 gem 'rails', '~> 4.1.6'
+gem 'activejob_backport'
 
 # mysql2 0.4 is not compatible with rails 4.1
 gem 'mysql2', '~> 0.3.20'

--- a/spec/jobs/thredded/activity_updater_job_spec.rb
+++ b/spec/jobs/thredded/activity_updater_job_spec.rb
@@ -14,9 +14,7 @@ module Thredded
       end
 
       Timecop.freeze(march_2) do
-        Thredded::ActivityUpdaterJob.queue.update_user_activity(
-          'messageboard_id' => @messageboard.id,
-          'user_id' => @user.id)
+        Thredded::ActivityUpdaterJob.perform_later(@user.id, @messageboard.id)
       end
 
       expect(@user_detail.reload.last_seen_at).to eq(march_2)

--- a/spec/lib/thredded_spec.rb
+++ b/spec/lib/thredded_spec.rb
@@ -1,33 +1,5 @@
 require 'spec_helper'
 
-describe Thredded, '.queue_backend' do
-  it 'defaults the queue backend to in memory' do
-    expect(Thredded.queue_backend).to eq :threaded_in_memory_queue
-  end
-
-  it 'allows the queue backend to change' do
-    Thredded.queue_backend = :resque
-
-    expect(Thredded.queue_backend).to eq :resque
-  end
-end
-
-describe Thredded, '.queue_memory_log_level' do
-  after do
-    Thredded.queue_memory_log_level = Logger::WARN
-  end
-
-  it 'defaults the threaded memory log level' do
-    expect(Thredded.queue_memory_log_level).to eq Logger::WARN
-  end
-
-  it 'allows the threaded memory log level to change' do
-    Thredded.queue_memory_log_level = Logger::INFO
-
-    expect(Thredded.queue_memory_log_level).to eq Logger::INFO
-  end
-end
-
 describe Thredded, '.user_path' do
   it 'returns "/" if lambda is not set' do
     Thredded.user_path = nil

--- a/spec/models/thredded/messageboard_spec.rb
+++ b/spec/models/thredded/messageboard_spec.rb
@@ -71,7 +71,10 @@ module Thredded
         messageboard   = create(:messageboard)
         active_user    = create(:user)
         _inactive_user = create(:user)
-        ActivityUpdaterJob.queue.update_user_activity('user_id' => active_user.id, 'messageboard_id' => messageboard.id)
+        Thredded::ActivityUpdaterJob.perform_later(
+          active_user.id,
+          messageboard.id
+        )
 
         expect(messageboard.recently_active_users).to eq [active_user]
       end

--- a/spec/models/thredded/post_spec.rb
+++ b/spec/models/thredded/post_spec.rb
@@ -30,7 +30,12 @@ module Thredded
     end
 
     it 'notifies anyone @ mentioned in the post' do
-      mail = double('Thredded::PostMailer.at_notification(...)', deliver: true)
+      if Rails.version < '4.2.0'
+        mail = double('Thredded::PostMailer.at_notification(...)', deliver: true)
+      else
+        mail = double('Thredded::PostMailer.at_notification(...)', deliver_later: true)
+      end
+
       expect(Thredded::PostMailer).to receive(:at_notification).with(1, ['joel@example.com']).and_return(mail)
 
       messageboard = create(:messageboard)
@@ -41,7 +46,13 @@ module Thredded
         messageboard: messageboard,
         notify_on_mention: true
       )
-      expect(mail).to receive(:deliver)
+
+      if Rails.version < '4.2.0'
+        expect(mail).to receive(:deliver)
+      else
+        expect(mail).to receive(:deliver_later)
+      end
+
       create(:post, id: 1, content: 'hi @joel', messageboard: messageboard)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
     TestAfterCommit.enabled = true
-    Q.queue_config.inline = true
+    ActiveJob::Base.queue_adapter = :inline
   end
 
   config.after(:suite) do
@@ -43,7 +43,6 @@ RSpec.configure do |config|
     DatabaseCleaner.start
     Time.zone = 'UTC'
     Chronic.time_class = Time.zone
-    Thredded.queue_backend = :threaded_in_memory_queue
   end
 
   config.after(:each) do
@@ -56,6 +55,4 @@ RSpec.configure do |config|
       counter = 0
     end
   end
-
-  ThreadedInMemoryQueue.logger.level = Logger::ERROR
 end

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://www.thredded.com'
   s.summary     = 'A messageboard engine'
   s.license     = 'MIT'
-  s.description = 'A messageboard engine for Rails 4.0 apps'
+  s.description = 'A messageboard engine for Rails 4.1+ apps'
 
   # backend
   s.add_dependency 'bbcoder', '~> 1.0'
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'htmlentities'
   s.add_dependency 'kaminari'
   s.add_dependency 'nokogiri'
-  s.add_dependency 'q'
   s.add_dependency 'rails', '>= 4.1.0'
   s.add_dependency 'rb-gravatar'
 


### PR DESCRIPTION
For several reasons it's probably a good idea to move from using the Q gem to
ActiveJob. This commit pulls out the dependencies for both Q and the threaded
in-memory queue that is used in conjunction with Q ... in favor of the built-in
ActiveJob *OR* the activejob backport.

Determining whether to add the backport is done with a little inspection of the
gemspec set. If the parent app is using a version of rails less than 4.2 then
it'll include the backport.

The backport only adds ActiveJob support, and does not monkeypatch
ActionMailer. ActionMailer got `deliver_now` and `deliver_later` in Rails 4.2
so this is somewhat of a notable omission. As a result we have to ask what
version of rails we're using in order to determine which version of the deliver
method we need to use -- `deliver` or `deliver_later`.

This PR addresses issue #160 