### PR TITLE
Remove file_storage and asset_root configuration

### DIFF
--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -44,7 +44,7 @@ module Thredded
 
     def context_options
       {
-        asset_root: Thredded.asset_root,
+        asset_root: Rails.application.config.action_controller.asset_host || '',
         post:       self,
         whitelist:  sanitize_whitelist
       }

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -49,17 +49,3 @@ Thredded.admin_column = :admin
 # ==> View Configuration
 # Set the layout for rendering the thredded views.
 Thredded.layout = 'thredded/application'
-
-# ==> Asset / File Storage Configuration
-# Root location where you have placed emojis (used when rendering posts).
-# If you're hosting on a platform that allows you to keep your files local
-# to your app - this might not be necessary. If you're hosting somewhere
-# with an ephemeral filesystem, like heroku, you'll need to point this to
-# wherever you store files on the cloud.
-#
-# Thredded.asset_root = ''
-# Thredded.asset_root = 'https://my-app-bucket.s3.amazonaws.com/assets'
-#
-# Where carrierwave will be storing its files - on the cloud, or filesystem.
-# Configure :fog with your own carrierwave initializer.
-Thredded.file_storage = Rails.env.production? ? :fog : :file

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -35,8 +35,6 @@ module Thredded
     :email_outgoing_prefix,
     :email_reply_to,
     :user_path,
-    :file_storage,
-    :asset_root,
     :layout,
     :active_user_threshold
 
@@ -49,8 +47,6 @@ module Thredded
   self.user_name_column = :name
   self.avatar_url = ->(user) { Gravatar.src(user.email, 128, 'mm') }
   self.active_user_threshold = 5.minutes
-  self.file_storage = :file # or :fog
-  self.asset_root = '' # or fully qualified URI to assets
   self.layout = 'thredded/application'
   self.email_reply_to = -> postable { "#{postable.hash_id}@#{Thredded.email_incoming_host}" }
   self.moderator_column = :admin


### PR DESCRIPTION
* `file_storage` is no longer used.
* Instead of a custom `asset_root`, just use `Rails.application.config.action_controller.asset_host`