### PR TITLE
[JRO] Rake task to install emoji images

### DIFF
--- a/CHANGELOG.mkdn
+++ b/CHANGELOG.mkdn
@@ -1,5 +1,10 @@
 # MASTER
 
+# Fixed
+
+* Rake task added to copy emojis to correct location in parent application.
+
+
 # 0.2.1 - 2016-04-03
 
 ## Changed

--- a/README.mkdn
+++ b/README.mkdn
@@ -25,13 +25,13 @@ Planned features:
 [Discourse]: http://www.discourse.org/
 [Forem]: https://www.github.com/radar/forem
 
-Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL.
-Thredded has no infrastructure dependencies other than the database and, if configured in the parent application,
-the ActiveJob backend dependency such as Redis.
-Currently only MRI Ruby 2.2+ is supported. We would love to support JRuby and Rubinius as well.
+Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. Thredded has no infrastructure
+dependencies other than the database and, if configured in the parent application, the ActiveJob
+backend dependency such as Redis. Currently only MRI Ruby 2.2+ is supported. We would love to
+support JRuby and Rubinius as well.
 
-If you're looking for variations on a theme - see [Forem] and [Discourse].
-Forem is also an engine, while Discourse is a full app.
+If you're looking for variations on a theme - see [Forem] and [Discourse]. Forem is also an engine,
+while Discourse is a full app.
 
 ## Installation
 
@@ -47,8 +47,14 @@ Add the Thredded [initializer] to your parent app by running the install generat
 rails generate thredded:install
 ```
 
-Thredded needs to know the base application User model name and certain columns on it. Configure these in the
-initializer installed with the command above.
+Copy emoji images to your `public/emoji` directory.
+
+```console
+rake thredded:install:emoji
+```
+
+Thredded needs to know the base application User model name and certain columns on it. Configure
+these in the initializer installed with the command above.
 
 Then, copy the migrations over to your parent application and migrate:
 

--- a/lib/tasks/thredded_tasks.rake
+++ b/lib/tasks/thredded_tasks.rake
@@ -5,4 +5,14 @@ namespace :thredded do
   end
 
   task :nuke, [:slug] => :destroy
+
+  namespace :install do
+    desc "Copy emoji to the Rails `public/emoji` directory"
+    task :emoji do
+      require 'emoji'
+
+      target = "#{Rake.original_dir}/public"
+      `mkdir -p '#{target}' && cp -Rp '#{Emoji.images_path}/emoji' '#{target}'`
+    end
+  end
 end

--- a/lib/tasks/thredded_tasks.rake
+++ b/lib/tasks/thredded_tasks.rake
@@ -7,7 +7,7 @@ namespace :thredded do
   task :nuke, [:slug] => :destroy
 
   namespace :install do
-    desc "Copy emoji to the Rails `public/emoji` directory"
+    desc 'Copy emoji to the Rails `public/emoji` directory'
     task :emoji do
       require 'emoji'
 


### PR DESCRIPTION
`rake thredded:install:emoji` does the trick and copies images from
gemoji to the parent app's `./public/emoji` directory.

* Update README w/install instructions

Fixes issue #189 