### PR TITLE
[JRO] Style topics' categories

### DIFF
--- a/app/assets/stylesheets/thredded/components/_topics.scss
+++ b/app/assets/stylesheets/thredded/components/_topics.scss
@@ -9,19 +9,39 @@
 
 &--topics--title {
   @extend %thredded--heading;
-  display: inline-block;
+  display: inline;
   font-size: 1.125rem; // 18px
   line-height: 1.5;
-  margin-right: $thredded-small-spacing / 2;
-  margin-bottom: 0;
 
   a {
     @extend %thredded--link;
     color: $thredded-base-font-color;
+    display: inline;
 
     &:hover {
       color: $thredded-action-color;
     }
+  }
+}
+
+&--topics--categories {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  display: inline-block;
+  line-height: 1rem;
+
+  li {
+    font-size: .5rem;
+    display: inline-block;
+    color: $thredded-base-font-color;
+    background-color: lighten($thredded-base-font-color, 55%);
+    box-shadow: inset 0 -1px 0 lighten($thredded-base-font-color, 40%);
+    padding: 1px 6px;
+    border-radius: 2px;
+    text-transform: lowercase;
+    letter-spacing: 1px;
+    vertical-align: bottom;
   }
 }
 

--- a/app/assets/stylesheets/thredded/components/_topics.scss
+++ b/app/assets/stylesheets/thredded/components/_topics.scss
@@ -93,13 +93,14 @@
   color: white;
   display: inline-block;
   font-weight: 900;
+  font-size: 0.8rem;
   height: 2rem;
   left: -3rem;
-  line-height: 2;
+  line-height: 2rem;
   margin-right: $thredded-base-spacing;
   position: absolute;
   text-align: center;
-  top: -0.25rem;
+  top: 0;
   width: 2rem;
 }
 

--- a/app/views/thredded/topics/_topic.html.erb
+++ b/app/views/thredded/topics/_topic.html.erb
@@ -11,6 +11,12 @@
     %>
   </h1>
 
+  <% if topic.categories.any? %>
+    <ul class="thredded--topics--categories">
+      <%= render topic.categories %>
+    </ul>
+  <% end %>
+
   <cite class="thredded--topics--updated-by">
     <%= time_ago topic.updated_at %>
     <%= user_link topic.last_user %>
@@ -20,10 +26,4 @@
     <%= time_ago topic.created_at %>
     <%= user_link topic.user %>
   </cite>
-
-  <% if topic.categories.any? %>
-    <ul class="thredded--topics--categories">
-      <%= render topic.categories %>
-    </ul>
-  <% end %>
 <% end %>


### PR DESCRIPTION
Previously the categories looked like an unstyled unordered list, so this
commit makes things render inline, just after the topic title link.

Also include a slight adjustment to the topics count style

This addresses issue #191