### PR TITLE
Add Email Previews

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -139,6 +139,14 @@ Whenever possible, use the styles and i18n to customize Thredded to your needs.
 Thredded views also provide two content_tags available to yield - `:thredded_page_title` and `:thredded_page_id`.
 The views within Thredded pass those up through to your layout if you would like to use them.
 
+### Emails
+
+Thredded sends several notification emails to the users. You can override in the same way as the views.
+If you use [Rails Email Preview], you can include Thredded emails into the list of previews by adding
+`Thredded::BaseMailerPreview.preview_classes` to the [Rails Email Preview] `preview_classes` config option.
+
+[Rails Email Preview]: https://github.com/glebm/rails_email_preview
+
 ## Permissions
 
 Thredded comes with a flexible permissions system that can be configured per messageboard/user.

--- a/app/mailer_previews/thredded/base_mailer_preview.rb
+++ b/app/mailer_previews/thredded/base_mailer_preview.rb
@@ -1,0 +1,102 @@
+module Thredded
+  # A base class for Thredded mailer previews.
+  # @abstract
+  class BaseMailerPreview
+    def self.preview_classes
+      Dir[File.join(File.dirname(__FILE__), '*_preview.rb')].map do |p|
+        "Thredded::#{File.basename(p, '.rb').camelize}"
+      end
+    end
+
+    protected
+
+    def mock_content(mention_users: [])
+      <<-MARKDOWN
+#{mention_users.map { |u| "@#{u}" } * ', '}, if we synthesize the driver, we can get to the HDD panel through the `1080p EXE` bus!
+I'll program the **redundant** SMTP array, that should monitor the SMS microchip!
+MARKDOWN
+    end
+
+    def mock_topic(attr = {})
+      Topic.new(
+        attr.reverse_merge(
+          title:        'A test topic',
+          slug:         'a-test-topic',
+          created_at:   3.days.ago,
+          id:           1 + rand(1334),
+          last_user:    mock_user,
+          locked:       [false, true].sample,
+          messageboard: mock_messageboard,
+          posts_count:  1 + rand(42),
+          sticky:       [false, true].sample,
+          updated_at:   Time.zone.now,
+          user:         mock_user,
+        ))
+    end
+
+    def mock_post(attr = {})
+      topic = attr[:postable] || mock_topic
+      Post.new(
+        attr.reverse_merge(
+          content:      'A test post',
+          created_at:   Time.zone.now,
+          id:           1 + rand(1334),
+          messageboard: topic.messageboard,
+          postable:     topic,
+          updated_at:   Time.zone.now,
+          user:         topic.last_user,
+        ))
+    end
+
+    def mock_private_topic(attr = {})
+      PrivateTopic.new(
+        attr.reverse_merge(
+          title:       'A test private topic',
+          slug:        'a-test-private-topic',
+          created_at:  3.days.ago,
+          id:          1 + rand(1334),
+          last_user:   mock_user,
+          posts_count: 1 + rand(42),
+          updated_at:  Time.zone.now,
+          user:        mock_user,
+        ))
+    end
+
+    def mock_private_post(attr = {})
+      private_topic = attr[:postable] || mock_private_topic
+      PrivatePost.new(
+        attr.reverse_merge(
+          content:    'A test private post',
+          created_at: Time.zone.now,
+          id:         1 + rand(1334),
+          postable:   private_topic,
+          updated_at: Time.zone.now,
+          user:       private_topic.last_user,
+        ))
+    end
+
+    def mock_messageboard(attr = {})
+      Messageboard.new(
+        attr.reverse_merge(
+          name:         'A test messageboard',
+          slug:         'a-test-messageboard',
+          description:  'Test messageboard description',
+          closed:       false,
+          created_at:   1.month.ago,
+          id:           1 + rand(1334),
+          posts_count:  rand(1337),
+          topics_count: rand(42),
+          updated_at:   Time.zone.now,
+        ))
+    end
+
+    def mock_user(attr = {})
+      name = %w(Alice Bob).sample
+      Thredded.user_class.new(
+        attr.reverse_merge(
+          Thredded.user_name_column => name,
+          email:                    "#{name.downcase}@test.com",
+        ))
+    end
+  end
+end

--- a/app/mailer_previews/thredded/post_mailer_preview.rb
+++ b/app/mailer_previews/thredded/post_mailer_preview.rb
@@ -1,0 +1,10 @@
+module Thredded
+  # Previews for the PostMailer
+  class PostMailerPreview < BaseMailerPreview
+    def at_notification
+      PostMailer.at_notification(
+        mock_post(content: mock_content(mention_users: %w(glebm joel))),
+        %w(glebm@test.com joel@test.com))
+    end
+  end
+end

--- a/app/mailer_previews/thredded/private_post_mailer_preview.rb
+++ b/app/mailer_previews/thredded/private_post_mailer_preview.rb
@@ -1,0 +1,10 @@
+module Thredded
+  # Previews for the PrivatePostMailer
+  class PrivatePostMailerPreview < BaseMailerPreview
+    def at_notification
+      PrivatePostMailer.at_notification(
+        mock_private_post(content: mock_content(mention_users: %w(glebm joel))),
+        %w(glebm@test.com joel@test.com))
+    end
+  end
+end

--- a/app/mailer_previews/thredded/private_topic_mailer_preview.rb
+++ b/app/mailer_previews/thredded/private_topic_mailer_preview.rb
@@ -1,0 +1,14 @@
+module Thredded
+  # Previews for the PrivateTopicMailer
+  class PrivateTopicMailerPreview < BaseMailerPreview
+    def message_notification
+      PrivateTopicMailer.message_notification(
+        mock_private_topic.tap do |private_topic|
+          private_topic.posts = [
+            mock_private_post(content: mock_content(mention_users: ['glebm']), postable: private_topic)
+          ]
+        end,
+        %w(glebm@test.com joel@test.com))
+    end
+  end
+end

--- a/app/mailers/thredded/base_mailer.rb
+++ b/app/mailers/thredded/base_mailer.rb
@@ -1,4 +1,14 @@
 module Thredded
   class BaseMailer < ActionMailer::Base
+    protected
+
+    # Find a record by ID, or return the passed record.
+    # @param [Class<ActiveRecord::Base>] klass
+    # @param [Fixnum, String, klass] id_or_record
+    # @return [klass]
+    def find_record(klass, id_or_record)
+      # Check by name because in development the Class might have been reloaded after id was initialized
+      id_or_record.class.name == klass.name ? id_or_record : klass.find(id_or_record)
+    end
   end
 end

--- a/app/mailers/thredded/post_mailer.rb
+++ b/app/mailers/thredded/post_mailer.rb
@@ -1,7 +1,7 @@
 module Thredded
   class PostMailer < Thredded::BaseMailer
     def at_notification(post_id, emails)
-      @post                = Post.find(post_id)
+      @post                = find_record Post, post_id
       email_details        = TopicEmailDecorator.new(@post.postable)
       headers['X-SMTPAPI'] = email_details.smtp_api_tag('at_notification')
 

--- a/app/mailers/thredded/private_post_mailer.rb
+++ b/app/mailers/thredded/private_post_mailer.rb
@@ -1,7 +1,7 @@
 module Thredded
   class PrivatePostMailer < Thredded::BaseMailer
     def at_notification(post_id, emails)
-      @post                = PrivatePost.find(post_id)
+      @post                = find_record PrivatePost, post_id
       email_details        = TopicEmailDecorator.new(@post.postable)
       headers['X-SMTPAPI'] = email_details.smtp_api_tag('at_notification')
 

--- a/app/mailers/thredded/private_topic_mailer.rb
+++ b/app/mailers/thredded/private_topic_mailer.rb
@@ -1,7 +1,7 @@
 module Thredded
   class PrivateTopicMailer < Thredded::BaseMailer
     def message_notification(private_topic_id, emails)
-      @topic               = PrivateTopic.find(private_topic_id)
+      @topic               = find_record PrivateTopic, private_topic_id
       email_details        = TopicEmailDecorator.new(@topic)
       headers['X-SMTPAPI'] = email_details.smtp_api_tag('private_topic_mailer')
 

--- a/spec/dummy/app/assets/stylesheets/application.scss
+++ b/spec/dummy/app/assets/stylesheets/application.scss
@@ -1,6 +1,9 @@
 $thredded-grid-container-max-width: 880px;
 @import "thredded";
 
+$rep-brand-color: $thredded-brand;
+@import "rails_email_preview/application";
+
 body {
   margin: 0;
 }

--- a/spec/dummy/app/views/application/index.html.erb
+++ b/spec/dummy/app/views/application/index.html.erb
@@ -12,6 +12,9 @@
       <li><%= link_to 'Theme Preview', thredded.theme_preview_path %> - a single page aggregating all of the views and
         styles.
       </li>
+      <li><%= link_to 'Email Templates', rails_email_preview.rep_root_url %> - previews of all emails sent by
+        Thredded.
+      </li>
       <li><%= link_to 'Sign in', new_session_path %> as anyone to post, create threads, etc. The only requirement in
         this demo app is a username.
       </li>

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -6,6 +6,7 @@ require 'action_mailer/railtie'
 require 'sprockets/railtie'
 require 'jquery-turbolinks'
 require 'turbolinks'
+require 'rails_email_preview'
 require 'thredded'
 
 module Dummy
@@ -34,6 +35,8 @@ module Dummy
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = 'utf-8'
+
+    config.i18n.available_locales = [:en, :es]
 
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]

--- a/spec/dummy/config/initializers/rails_email_preview.rb
+++ b/spec/dummy/config/initializers/rails_email_preview.rb
@@ -1,0 +1,8 @@
+Rails.application.config.to_prepare do
+  RailsEmailPreview.setup do |config|
+    config.layout            = 'application'
+    config.preview_classes   = Thredded::BaseMailerPreview.preview_classes
+    # Do not show Send Email button
+    config.enable_send_email = false
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,5 +7,6 @@ Rails.application.routes.draw do
   resources :sessions, only: [:new, :create, :destroy]
   resources :users, only: [:show], path: 'u'
 
+  mount RailsEmailPreview::Engine, at: '/emails'
   mount Thredded::Engine => '/thredded'
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,5 @@
 require 'faker'
+I18n.reload!
 include ActionDispatch::TestProcess
 
 FactoryGirl.define do

--- a/spec/mailers/thredded/mailer_previews_spec.rb
+++ b/spec/mailers/thredded/mailer_previews_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+module Thredded
+  describe 'Mailer previews' do
+    [PostMailerPreview, PrivateTopicMailerPreview, PrivatePostMailerPreview].each do |preview_class|
+      describe preview_class do
+        preview_class.public_instance_methods(false).each do |method_name|
+          describe "##{method_name}" do
+            let(:mail) { preview_class.new.send(method_name) }
+
+            it 'renders' do
+              expect { mail.body }.to_not raise_exception
+            end
+
+            it 'does not create any records' do
+              expect { mail }.to_not change {
+                [Messageboard.count, Topic.count, Post.count, PrivateTopic.count, PrivatePost.count,
+                 Thredded.user_class.count, UserDetail.count, MessageboardUser.count]
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -61,6 +61,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pg'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'puma'
+  s.add_development_dependency 'rails_email_preview', '>= 1.0.0'
 
   # dummy app frontend
   s.add_development_dependency 'jquery-turbolinks'


### PR DESCRIPTION
Adds email previews to the dummy app. Uses [a gem](https://github.com/glebm/rails_email_preview) I wrote, which is also a Rails engine.

It works by rendering emails with mock data provided by plain Ruby classes. If the users happens to use the same gem or a similar one, they can easily include Thredded emails to their list of previews.

Modifies the mailer code to optionally accept ActiveRecord instances as well, so that the preview classes can supply mock instances.

![thredded-emails-list](https://cloud.githubusercontent.com/assets/216339/14278388/590b033c-fb1f-11e5-9c6b-8a3c40ade5d0.png)
![thredded-email-html](https://cloud.githubusercontent.com/assets/216339/14278391/5af638a6-fb1f-11e5-90d6-1d8c28b4e4be.png)
![thredded-email-raw](https://cloud.githubusercontent.com/assets/216339/14278393/5d3607cc-fb1f-11e5-8563-a51376b79041.png)


