### PR TITLE
Styles: more variables, and a dummy theme switcher

### DIFF
--- a/app/assets/stylesheets/thredded/_base.scss
+++ b/app/assets/stylesheets/thredded/_base.scss
@@ -3,9 +3,10 @@
 @import "base/variables";
 
 @import "base/alerts";
-@import "base/grid";
-@import "base/typography";
 @import "base/buttons";
 @import "base/forms";
+@import "base/grid";
 @import "base/lists";
+@import "base/nav";
 @import "base/tables";
+@import "base/typography";

--- a/app/assets/stylesheets/thredded/base/_forms.scss
+++ b/app/assets/stylesheets/thredded/base/_forms.scss
@@ -1,6 +1,6 @@
 %thredded--form {
   fieldset {
-    background-color: lighten($thredded-base-border-color, 10%);
+    background-color: $thredded-light-gray;
     border: $thredded-base-border;
     margin: 0 0 $thredded-small-spacing;
     padding: $thredded-base-spacing;
@@ -30,10 +30,11 @@
   [type='color'], [type='date'], [type='datetime'], [type='datetime-local'], [type='email'], [type='month'],
   [type='number'], [type='password'], [type='search'], [type='tel'], [type='text'], [type='time'], [type='url'],
   [type='week'], input:not([type]), textarea, select[multiple=multiple] {
-    background-color: $thredded-base-background-color;
+    background-color: $thredded-background-color;
     border: $thredded-form-border;
     box-shadow: $thredded-form-box-shadow;
     box-sizing: border-box;
+    color: $thredded-text-color;
     font-family: $thredded-base-font-family;
     font-size: $thredded-base-font-size;
     padding: $thredded-small-spacing;
@@ -41,11 +42,11 @@
     width: 100%;
 
     &:hover {
-      border-color: darken($thredded-base-border-color, 10%);
+      border-color: $thredded-form-border-hover-color;
     }
 
     &:focus {
-      border-color: $thredded-action-color;
+      border-color: $thredded-form-border-focus-color;
       box-shadow: $thredded-form-box-shadow, 0 0 3px $thredded-action-color;
       outline: none;
     }

--- a/app/assets/stylesheets/thredded/base/_nav.scss
+++ b/app/assets/stylesheets/thredded/base/_nav.scss
@@ -1,0 +1,21 @@
+%thredded--nav-link {
+  color: $thredded-nav-color;
+  text-decoration: none;
+  transition: $thredded-action-transition;
+
+  &:active,
+  &:focus,
+  &:hover {
+    color: $thredded-nav-hover-color;
+    text-decoration: none;
+  }
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
+}
+
+%thredded--nav-link-current {
+  color: $thredded-nav-current-color;
+}

--- a/app/assets/stylesheets/thredded/base/_typography.scss
+++ b/app/assets/stylesheets/thredded/base/_typography.scss
@@ -8,12 +8,12 @@
 %thredded--link {
   color: $thredded-action-color;
   text-decoration: none;
-  transition: color 0.1s linear;
+  transition: $thredded-action-transition;
 
   &:active,
   &:focus,
   &:hover {
-    color: darken($thredded-action-color, 15%);
+    color: $thredded-action-hover-color;
     text-decoration: none;
   }
 
@@ -24,10 +24,10 @@
 }
 
 %thredded--hr {
-  border-bottom: $thredded-base-border;
+  border-bottom: none;
   border-left: none;
   border-right: none;
-  border-top: none;
+  border-top: $thredded-base-border;
   margin: $thredded-base-spacing 0;
 }
 

--- a/app/assets/stylesheets/thredded/base/_variables.scss
+++ b/app/assets/stylesheets/thredded/base/_variables.scss
@@ -1,5 +1,5 @@
 // Grid
-$thredded-grid-container-max-width: 720px !default;
+$thredded-grid-container-max-width: 690px !default;
 $thredded-grid-breakpoint-max-widths: (mobile: 400px, tablet: 600px) !default;
 
 // Typography
@@ -20,10 +20,17 @@ $thredded-brand: #4a90e2 !default;
 $thredded-dark-gray: #333 !default;
 $thredded-light-gray: #eee !default;
 
-// Colors of text, background, and actions (links)
-$thredded-base-font-color: #575d6b !default;
-$thredded-base-background-color: #fff !default;
+// Colors of text, background, actions (links), and navigation
+$thredded-text-color: #575d6b !default;
+$thredded-secondary-text-color: lighten($thredded-text-color, 30%) !default;
+$thredded-background-color: #fff !default;
 $thredded-action-color: $thredded-brand !default;
+$thredded-action-hover-color: darken($thredded-action-color, 15%) !default;
+$thredded-action-transition: color 0.1s linear !default;
+$thredded-nav-color: $thredded-text-color !default;
+$thredded-nav-hover-color: $thredded-action-color !default;
+$thredded-nav-current-color: $thredded-action-color !default;
+$thredded-secondary-nav-color: $thredded-secondary-text-color !default;
 
 // Colors of alerts and flash messages
 $thredded-alert-danger-background: #fbe3e4 !default;
@@ -40,7 +47,10 @@ $thredded-base-border-color: $thredded-light-gray !default;
 $thredded-base-border: 1px solid $thredded-base-border-color !default;
 
 // Forms
-$thredded-form-border: 1px solid darken($thredded-base-border-color, 5%) !default;
+$thredded-form-border-color: darken($thredded-base-border-color, 5%) !default;
+$thredded-form-border-hover-color: darken($thredded-form-border-color, 6.4%) !default;
+$thredded-form-border-focus-color: $thredded-action-color !default;
+$thredded-form-border: 1px solid $thredded-form-border-color !default;
 $thredded-form-box-shadow: inset 0 1px 3px rgba(#000, 0.06) !default;
 
 // Buttons
@@ -58,4 +68,4 @@ $thredded-button-line-height: 1 !default;
 $thredded-badge-active-color: $thredded-button-color !default;
 $thredded-badge-active-background: $thredded-action-color !default;
 $thredded-badge-inactive-color: $thredded-button-color !default;
-$thredded-badge-inactive-background: rgba($thredded-base-font-color, 0.3) !default;
+$thredded-badge-inactive-background: rgba($thredded-text-color, 0.3) !default;

--- a/app/assets/stylesheets/thredded/components/_currently-online.scss
+++ b/app/assets/stylesheets/thredded/components/_currently-online.scss
@@ -22,7 +22,7 @@
   }
 
   &--avatar {
-    background-color: $thredded-base-font-color;
+    background-color: $thredded-text-color;
     border-radius: 50%;
     display: inline-block;
     height: 1.75rem;

--- a/app/assets/stylesheets/thredded/components/_form-list.scss
+++ b/app/assets/stylesheets/thredded/components/_form-list.scss
@@ -28,7 +28,7 @@
 
 &--form-list--hint {
   @extend %thredded--paragraph;
-  color: lighten($thredded-base-font-color, 20%);
+  color: $thredded-secondary-text-color;
   font-size: $thredded-font-size-small;
   font-weight: normal;
   position: relative;

--- a/app/assets/stylesheets/thredded/components/_messageboard.scss
+++ b/app/assets/stylesheets/thredded/components/_messageboard.scss
@@ -28,7 +28,7 @@
 
 &--messageboard--meta {
   @extend %thredded--heading;
-  color: lighten($thredded-base-font-color, 30%);
+  color: $thredded-secondary-text-color;
   display: inline-block;
   font-weight: normal;
   margin-bottom: 0;
@@ -39,12 +39,12 @@
   @extend %thredded--paragraph;
   clear: both;
   margin-bottom: $thredded-small-spacing / 2;
-  color: $thredded-base-font-color;
+  color: $thredded-text-color;
 }
 
 &--messageboard--byline {
   @extend %thredded--paragraph;
-  color: lighten($thredded-base-font-color, 30%);
+  color: $thredded-secondary-text-color;
   font-size: 0.875em;
   font-weight: normal;
   margin-bottom: 0;

--- a/app/assets/stylesheets/thredded/components/_pagination.scss
+++ b/app/assets/stylesheets/thredded/components/_pagination.scss
@@ -5,12 +5,12 @@
   text-align: center;
 
   > span {
-    color: lighten($thredded-base-font-color, 30%);
+    color: $thredded-secondary-text-color;
     display: inline-block;
     margin-right: $thredded-small-spacing;
 
     > a {
-      color: $thredded-base-font-color;
+      color: $thredded-text-color;
       display: inline-block;
 
       &:focus,

--- a/app/assets/stylesheets/thredded/components/_post.scss
+++ b/app/assets/stylesheets/thredded/components/_post.scss
@@ -31,14 +31,14 @@
 
   a {
     @extend %thredded--link;
-    color: $thredded-base-font-color;
+    color: $thredded-text-color;
   }
 }
 
 &--post--created-at {
   @extend %thredded--paragraph;
   font-size: $thredded-font-size-small;
-  color: lighten($thredded-base-font-color, 30%);
+  color: $thredded-secondary-text-color;
   display: inline-block;
 }
 

--- a/app/assets/stylesheets/thredded/components/_topic-header.scss
+++ b/app/assets/stylesheets/thredded/components/_topic-header.scss
@@ -12,7 +12,7 @@
 
 &--topic-header--started-by {
   font-size: $thredded-font-size-small;
-  color: lighten($thredded-base-font-color, 30%);
+  color: $thredded-secondary-text-color;
   font-style: normal;
   a {
     @extend %thredded--link;

--- a/app/assets/stylesheets/thredded/components/_topics.scss
+++ b/app/assets/stylesheets/thredded/components/_topics.scss
@@ -15,7 +15,7 @@
 
   a {
     @extend %thredded--link;
-    color: $thredded-base-font-color;
+    color: $thredded-text-color;
     display: inline;
 
     &:hover {
@@ -34,9 +34,9 @@
   li {
     font-size: .5rem;
     display: inline-block;
-    color: $thredded-base-font-color;
-    background-color: lighten($thredded-base-font-color, 55%);
-    box-shadow: inset 0 -1px 0 lighten($thredded-base-font-color, 40%);
+    color: $thredded-text-color;
+    background-color: lighten($thredded-text-color, 55%);
+    box-shadow: inset 0 -1px 0 lighten($thredded-text-color, 40%);
     padding: 1px 6px;
     border-radius: 2px;
     text-transform: lowercase;
@@ -47,13 +47,13 @@
 
 &--topics--started-by,
 &--topics--updated-by {
-  color: lighten($thredded-base-font-color, 30%);
+  color: $thredded-secondary-text-color;
   font-size: $thredded-font-size-small;
   font-style: normal;
 
   a {
     @extend %thredded--link;
-    color: lighten($thredded-base-font-color, 20%);
+    color: lighten($thredded-text-color, 20%);
 
     &:hover {
 

--- a/app/assets/stylesheets/thredded/layout/_main-container.scss
+++ b/app/assets/stylesheets/thredded/layout/_main-container.scss
@@ -1,7 +1,7 @@
 &--main-container {
   @include thredded--clearfix;
   -webkit-font-smoothing: antialiased;
-  color: $thredded-base-font-color;
+  color: $thredded-text-color;
   font-family: $thredded-base-font-family;
   font-size: $thredded-base-font-size;
   line-height: $thredded-base-line-height;

--- a/app/assets/stylesheets/thredded/layout/_main-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_main-navigation.scss
@@ -34,12 +34,7 @@
   }
 
   a {
-    @extend %thredded--link;
-    color: $thredded-base-font-color;
+    @extend %thredded--nav-link;
     font-weight: bold;
-
-    &:hover {
-      color: $thredded-action-color;
-    }
   }
 }

--- a/app/assets/stylesheets/thredded/layout/_topic-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_topic-navigation.scss
@@ -18,14 +18,9 @@
   }
 
   a {
-    @extend %thredded--link;
-    color: lighten($thredded-base-font-color, 10%);
+    @extend %thredded--nav-link;
     display: block;
     padding-bottom: $thredded-small-spacing;
-
-    &:hover {
-      color: $thredded-action-color;
-    }
   }
 }
 
@@ -37,8 +32,7 @@
   margin-bottom: -2px;
 
   a {
-    @extend %thredded--link;
-    color: $thredded-action-color;
+    @extend %thredded--nav-link-current;
   }
 }
 

--- a/app/assets/stylesheets/thredded/layout/_user-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_user-navigation.scss
@@ -12,8 +12,8 @@
   }
 
   a {
-    @extend %thredded--link;
-    color: lighten($thredded-base-font-color, 30%);
+    @extend %thredded--nav-link;
+    color: $thredded-secondary-nav-color;
   }
 }
 
@@ -51,6 +51,7 @@
     width: 100%;
 
     @include thredded-media-tablet-and-up {
+      background: transparent;
       border-color: transparent;
       float: right;
       min-width: 200px;
@@ -59,6 +60,7 @@
       width: auto;
 
       &:focus {
+        background: $thredded-background-color;
         box-shadow: none;
         min-width: 290px;
         text-align: left;
@@ -70,10 +72,18 @@
         border-color: transparent;
         box-shadow: none;
       }
+
+      &::placeholder {
+        color: $thredded-secondary-nav-color;
+      }
     }
 
-    &:hover::placeholder {
-      color: $thredded-action-color;
+    &:hover:not(:focus) {
+      cursor: pointer;
+      &::placeholder {
+        color: $thredded-nav-hover-color;
+        transition: color 0.1s linear;
+      }
     }
 
     &:focus {

--- a/spec/dummy/app/assets/javascripts/app/theme.es6
+++ b/spec/dummy/app/assets/javascripts/app/theme.es6
@@ -1,0 +1,8 @@
+jQuery($ => {
+  $('.app-nav-theme li').click((evt) => {
+    let expiresAt = new Date();
+    expiresAt.setMonth(expiresAt.getMonth() + 12);
+    document.cookie = 'thredded-theme=' + $(evt.target).data('theme') + ';expires=' + expiresAt + ';path=/';
+    document.location.reload();
+  });
+});

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -3,5 +3,6 @@
 //= require jquery.turbolinks
 //= require jquery_ujs
 //= require thredded
+//= require_tree ./app
 // Must be required last:
 //= require turbolinks

--- a/spec/dummy/app/assets/stylesheets/_dummy_app.scss
+++ b/spec/dummy/app/assets/stylesheets/_dummy_app.scss
@@ -1,11 +1,13 @@
-$thredded-grid-container-max-width: 880px;
 @import "thredded";
 
 $rep-brand-color: $thredded-brand;
 @import "rails_email_preview/application";
 
+$dummy-app-bg: $thredded-background-color !default;
+
 body {
   margin: 0;
+  background: $dummy-app-bg;
 }
 
 .thredded--main-container {
@@ -20,12 +22,11 @@ body {
 }
 
 .app-container {
-  background: white;
-  padding: 2em 4em;
-  border: 1px solid $thredded-light-gray;
-  margin: 2em auto;
+  border: $thredded-base-border;
   box-sizing: border-box;
-  max-width: $thredded-grid-container-max-width;
+  margin: 2em auto;
+  max-width: 884px;
+  padding: 2em 4em;
 
   @media (max-width: $thredded-grid-container-max-width) {
     padding: 2em;
@@ -36,6 +37,7 @@ body {
 
 .app-home, .app-container-header {
   font-family: $thredded-base-font-family;
+  color: $thredded-text-color;
   a {
     @extend %thredded--link;
   }
@@ -43,36 +45,55 @@ body {
 
 
 .app-container-header {
-  border-bottom: solid 1px #d8d8d8;
+  border-bottom: $thredded-base-border;
   padding-bottom: 1em;
   margin: 0em -2em 1em;
 
   @include thredded-media-mobile {
     margin: -1em -1.5em 0.6em;
   }
-
-  .app-nav-logo {
-    @extend %thredded--link;
-    color: $thredded-base-font-color;
-    text-decoration: none;
-    font-weight: bold;
-  }
 }
 
+.app-nav-logo {
+  @extend %thredded--link;
+  color: $thredded-text-color;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.app-nav-theme {
+  display: block;
+  margin-left: 0.5rem;
+  margin-top: 0.5rem;
+  ul {
+    @extend %thredded--list-unstyled;
+    display: inline-block;
+    li {
+      @extend %thredded--link;
+      cursor: pointer;
+      display: inline-block;
+      margin-left: 0.5rem;
+      &.app-current-theme {
+        color: $thredded-text-color;
+        font-weight: bold;
+      }
+    }
+  }
+  @include thredded-media-tablet-and-up {
+    display: inline-block;
+    margin-left: 2rem;
+    margin-top: 0;
+  }
+}
 
 .app-nav-auth {
   float: right;
 
-  a {
-    @extend %thredded--link;
-  }
-
   @include thredded-media-mobile {
-    color: white;
     font-size: 0;
 
     a {
-      font-size: 16px;
+      font-size: 1rem;
     }
   }
 }

--- a/spec/dummy/app/assets/stylesheets/dark.scss
+++ b/spec/dummy/app/assets/stylesheets/dark.scss
@@ -1,0 +1,25 @@
+// See https://www.google.com/design/spec/style/color.html#color-color-palette
+$material-50: #e8f5e9;
+$material-100: #c8e6c9;
+$material-200: #a5d6a7;
+$material-200: #a5d6a7;
+$material-300: #81c784;
+$material-400: #66bb6a;
+$material-500: #4caf50;
+$material-600: #43a047;
+$material-700: #388e3C;
+
+$thredded-brand: $material-700;
+$thredded-text-color: $material-50;
+$thredded-secondary-text-color: $material-100;
+$thredded-background-color: rgba(#fff, 0.03);
+$thredded-action-hover-color: $material-600;
+$thredded-secondary-nav-color: $thredded-text-color;
+
+$thredded-button-color: $thredded-text-color;
+$thredded-button-hover-background: $material-600;
+$thredded-badge-active-background: $thredded-brand;
+$thredded-light-gray: rgba(#424242, 0.8);
+
+$dummy-app-bg: #212121;
+@import "dummy_app";

--- a/spec/dummy/app/assets/stylesheets/default.scss
+++ b/spec/dummy/app/assets/stylesheets/default.scss
@@ -1,0 +1,1 @@
+@import "dummy_app";

--- a/spec/dummy/app/helpers/application_helper.rb
+++ b/spec/dummy/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+  VALID_THEMES = %w(default dark)
+
+  def themes
+    VALID_THEMES
+  end
+
+  def current_theme
+    cookie_theme = cookies['thredded-theme']
+    VALID_THEMES.include?(cookie_theme) ? cookie_theme : VALID_THEMES[0]
+  end
 end

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title>
       <%= content_for?(:thredded_page_title) ? "#{yield(:thredded_page_title)} | Dummy App" : 'Dummy App' %>
     </title>
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
+    <%= stylesheet_link_tag current_theme, media: 'all', 'data-turbolinks-track' => true %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
     <%== Gravatar.prefetch_dns if content_for?(:thredded) %>
@@ -23,6 +23,15 @@
           <% end %>
         </span>
         <a class="app-nav-logo" href="/">Thredded: Example App</a>
+        <span class="app-nav-theme">
+          Theme:
+          <ul>
+            <% themes.each do |theme| %>
+              <%= content_tag :li, theme.humanize, class: ('app-current-theme' if theme == current_theme),
+                              'data-theme' => theme -%>
+            <% end %>
+          </ul>
+        </span>
       </header>
 
       <% unless content_for?(:thredded)  # thredded already renders the flash messages  %>

--- a/spec/dummy/app/views/sessions/new.html.erb
+++ b/spec/dummy/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag('/sessions', class: 'thredded--main-container') do %>
+<%= form_tag('/sessions', class: 'thredded--main-container thredded--form') do %>
   <ul class="thredded--form-list">
     <li><%= text_field_tag 'name', 'Joe', placeholder: 'Name' %></li>
     <li><label><%= check_box_tag 'admin', '1', true %> Admin</label></li>

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( default.css dark.css )


### PR DESCRIPTION
My eyes are a bit tired of all the white, so I've added a dark theme to the dummy app. Having another theme helps us validate the variables of the default theme: that they are used everywhere they should be, and that we don't rely on functions like `lighten` too much. A dark theme is perfect for this as most issues are visible immediately.

The dark theme has a bit of the Matrix feel to it:
![thredded-theme-dark](https://cloud.githubusercontent.com/assets/216339/14296594/c20f57d6-fb72-11e5-9a9a-3f77cb0b9356.png)
