### PR TITLE
Change read state on topic link click

### DIFF
--- a/app/assets/javascripts/thredded/components/topics.es6
+++ b/app/assets/javascripts/thredded/components/topics.es6
@@ -1,0 +1,23 @@
+(function($) {
+  const COMPONENT_SELECTOR = '[data-thredded-topics]';
+
+  const TOPIC_SELECTOR = 'article';
+  const TOPIC_LINK_SELECTOR = 'h1 a';
+  const TOPIC_UNREAD_CLASS = 'thredded--topic--unread';
+  const TOPIC_READ_CLASS = 'thredded--topic--read';
+
+  class ThreddedTopics {
+    init($nodes) {
+      $nodes.on('click', TOPIC_LINK_SELECTOR, (evt) => {
+        $(evt.target).closest(TOPIC_SELECTOR).addClass(TOPIC_READ_CLASS).removeClass(TOPIC_UNREAD_CLASS);
+      });
+    }
+  }
+
+  $(function() {
+    var $nodes = $(COMPONENT_SELECTOR);
+    if ($nodes.length) {
+      new ThreddedTopics().init($nodes);
+    }
+  });
+})(jQuery);

--- a/app/assets/stylesheets/thredded/components/_topics.scss
+++ b/app/assets/stylesheets/thredded/components/_topics.scss
@@ -101,6 +101,7 @@
   text-align: center;
   top: 0;
   width: 2rem;
+  transition: background 0.1s linear, color 0.1s linear;
 }
 
 &--topic--unread > &--topics--posts-count {

--- a/app/views/thredded/private_topics/index.html.erb
+++ b/app/views/thredded/private_topics/index.html.erb
@@ -3,7 +3,8 @@
 <% content_for :thredded_breadcrumbs, render('thredded/private_topics/breadcrumbs') %>
 
 <%= thredded_page do %>
-  <%= content_tag :section, class: 'thredded--main-section thredded--private-topics' do %>
+  <%= content_tag :section, class: 'thredded--main-section thredded--private-topics',
+                  'data-thredded-topics' => true do %>
     <% if @private_topics.empty? -%>
       <%= render 'thredded/private_topics/no_private_topics' %>
     <% else -%>

--- a/app/views/thredded/topics/index.html.erb
+++ b/app/views/thredded/topics/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :thredded_breadcrumbs, render('thredded/shared/messageboard_topics_breadcrumbs') %>
 
 <%= thredded_page do %>
-  <%= content_tag :section, class: 'thredded--main-section thredded--topics' do %>
+  <%= content_tag :section, class: 'thredded--main-section thredded--topics', 'data-thredded-topics' => true do %>
     <%= render 'thredded/topics/form',
                messageboard: messageboard,
                topic:        @new_topic,


### PR DESCRIPTION
A minor improvement, but this way the read state is reflected after
going to the topic and then back (via the back button).