### PR TITLE
Private topic form user names #183

### DIFF
--- a/CHANGELOG.mkdn
+++ b/CHANGELOG.mkdn
@@ -1,5 +1,18 @@
 # MASTER
 
+## Added
+
+* Private topic user select now looks prettier and loads the user via AJAX, instead of generating a huge select with all
+  the users. [#199](https://github.com/thredded/thredded/pull/199).
+* The theme is now more customizable thanks to a number of fixes and new variables. [#197](https://github.com/thredded/thredded/pull/197)
+* The topic read state is now visually updated on click. [#198](https://github.com/thredded/thredded/pull/198)
+* Email preview classes are now provided. [#196](https://github.com/thredded/thredded/pull/196).
+
+## Changed
+
+* Renamed `$thredded-base-font-color` to `$thredded-text-color`.
+* Renamed `$thredded-base-background-color` to `$thredded-background-color`.
+
 # 0.2.2 - 2016-04-04
 
 ## Fixed

--- a/README.mkdn
+++ b/README.mkdn
@@ -80,6 +80,15 @@ Include thredded JavaScripts in your `application.js`:
 //= require thredded
 ```
 
+You also may want to add an index to the user name column in your users table.
+Thredded uses it to find @-mentions and perform name prefix autocompletion on the private topic form.
+Add the index in a migration like so:
+
+```ruby
+DbTextSearch::CaseInsensitive.add_index(
+    connection, Thredded.user_class.table_name, Thredded.user_name_column, unique: true)
+```
+
 [initializer]: https://github.com/thredded/thredded/blob/master/lib/generators/thredded/install/templates/initializer.rb
 
 ## Theming

--- a/app/assets/javascripts/thredded/components/users_select.es6
+++ b/app/assets/javascripts/thredded/components/users_select.es6
@@ -1,5 +1,56 @@
-jQuery(function($) {
-  $('[data-thredded-users-select]').select2({
-    dropdownCssClass: 'thredded--select2-drop'
+($ => {
+  const COMPONENT_SELECTOR = '[data-thredded-users-select]';
+
+
+  let formatUser = (user, container, query, escapeHtml) => {
+    if (user.loading) return user.text;
+    return "<div class='thredded--select2-user-result'>" +
+      `<img class='thredded--select2-user-result__avatar' src='${escapeHtml(user.avatar_url)}' >` +
+      `<span class='thredded--select2-user-result__name'>${escapeHtml(user.name)}</span>` +
+      '</div>';
+  };
+
+  let formatUserSelection = (user, container, escapeHtml) => {
+    return `<span class='thredded--select2-user-selection'>` +
+      `<img class='thredded--select2-user-selection__avatar' src='${escapeHtml(user.avatar_url)}' >` +
+      `<span class='thredded--select2-user-selection__name'>${escapeHtml(user.name)}</span>` +
+      '</span>';
+  };
+
+  let initSelection = ($el, callback) => {
+    let ids = ($el.val() || '').split(',');
+    if (ids.length && ids[0] != '') {
+      $.ajax(`${$el.data('autocompleteUrl')}?ids=${ids.join(',')}`, {dataType: 'json'}).done(data => callback(data.results));
+    } else {
+      callback([]);
+    }
+  };
+
+  let init = $el => {
+    $el.select2({
+      ajax: {
+        cache: true,
+        data: query => ({q: query}),
+        results: data => data,
+        dataType: 'json',
+        url: $el.data('autocompleteUrl')
+      },
+      containerCssClass: 'thredded--select2-container',
+      dropdownCssClass: 'thredded--select2-drop',
+      initSelection: initSelection,
+      minimumInputLength: 2,
+      multiple: true,
+      formatResult: formatUser,
+      formatSelection: formatUserSelection
+    });
+  };
+
+  $(function() {
+    var $nodes = $(COMPONENT_SELECTOR);
+    if ($nodes.length) {
+      $nodes.each(function() {
+        init($(this));
+      });
+    }
   });
-});
+})(jQuery);

--- a/app/assets/stylesheets/thredded/base/_forms.scss
+++ b/app/assets/stylesheets/thredded/base/_forms.scss
@@ -1,3 +1,24 @@
+%thredded--form--input {
+  background: $thredded-form-background;
+  border: $thredded-form-border;
+  box-shadow: $thredded-form-box-shadow;
+  color: $thredded-form-color;
+  font-family: $thredded-base-font-family;
+  font-size: $thredded-base-font-size;
+  padding: $thredded-small-spacing;
+  transition: border-color;
+
+  &:hover {
+    border-color: $thredded-form-border-hover-color;
+  }
+
+  &:focus {
+    border-color: $thredded-form-border-focus-color;
+    box-shadow: $thredded-form-box-shadow, 0 0 3px $thredded-action-color;
+    outline: none;
+  }
+}
+
 %thredded--form {
   fieldset {
     background-color: $thredded-light-gray;
@@ -30,26 +51,9 @@
   [type='color'], [type='date'], [type='datetime'], [type='datetime-local'], [type='email'], [type='month'],
   [type='number'], [type='password'], [type='search'], [type='tel'], [type='text'], [type='time'], [type='url'],
   [type='week'], input:not([type]), textarea, select[multiple=multiple] {
-    background-color: $thredded-background-color;
-    border: $thredded-form-border;
-    box-shadow: $thredded-form-box-shadow;
+    @extend %thredded--form--input;
     box-sizing: border-box;
-    color: $thredded-text-color;
-    font-family: $thredded-base-font-family;
-    font-size: $thredded-base-font-size;
-    padding: $thredded-small-spacing;
-    transition: border-color;
     width: 100%;
-
-    &:hover {
-      border-color: $thredded-form-border-hover-color;
-    }
-
-    &:focus {
-      border-color: $thredded-form-border-focus-color;
-      box-shadow: $thredded-form-box-shadow, 0 0 3px $thredded-action-color;
-      outline: none;
-    }
   }
 
   textarea {

--- a/app/assets/stylesheets/thredded/base/_variables.scss
+++ b/app/assets/stylesheets/thredded/base/_variables.scss
@@ -46,12 +46,14 @@ $thredded-alert-warning-color: #8a6d3b !default;
 $thredded-base-border-color: $thredded-light-gray !default;
 $thredded-base-border: 1px solid $thredded-base-border-color !default;
 
-// Forms
+// Form inputs
+$thredded-form-background: $thredded-background-color !default;
 $thredded-form-border-color: darken($thredded-base-border-color, 5%) !default;
 $thredded-form-border-hover-color: darken($thredded-form-border-color, 6.4%) !default;
 $thredded-form-border-focus-color: $thredded-action-color !default;
 $thredded-form-border: 1px solid $thredded-form-border-color !default;
 $thredded-form-box-shadow: inset 0 1px 3px rgba(#000, 0.06) !default;
+$thredded-form-color: $thredded-text-color !default;
 
 // Buttons
 $thredded-button-background: $thredded-action-color !default;

--- a/app/assets/stylesheets/thredded/components/_select2.scss
+++ b/app/assets/stylesheets/thredded/components/_select2.scss
@@ -1,42 +1,112 @@
-&--main-container .select2-container {
+&--select2-container {
   width: 100%;
 
   > .select2-choices {
-    background-image: none;
-    border: $thredded-form-border;
-    box-shadow: $thredded-form-box-shadow;
+    @extend %thredded--form--input;
+    $gutter-y: 0.4rem;
+    $choices-gutter-y: 0.2rem;
+    $gutter-x: 0.6rem;
+    padding-top: ($thredded-small-spacing - $gutter-y - $choices-gutter-y);
     min-height: unset;
-    padding: $thredded-small-spacing;
 
     > .select2-search-choice {
-      margin: 0 6px 0 0;
+      border: $thredded-base-border;
+      background-color: $thredded-light-gray;
+      margin: $gutter-y $gutter-x (-$choices-gutter-y) 0;
+      &.select2-search-choice-focus {
+        background: $thredded-button-background;
+        border: 1px solid $thredded-button-background;
+        box-shadow: 0 0 2px $thredded-button-background inset, 0 1px 0 rgba(0, 0, 0, 0.05);
+        color: $thredded-button-color;
+        transition: none;
+      }
     }
 
     > .select2-search-field {
+      background: transparent;
+      margin-top: ($gutter-y + $choices-gutter-y);
       > [type="text"] {
+        color: $thredded-form-color;
         font-family: $thredded-base-font-family;
         font-size: 1rem;
         margin: 0;
         padding: 0;
+        &.select2-active {
+          // Select2 does !important here
+          background-color: transparent !important;
+        }
       }
+    }
+  }
+
+  &.select2-container-active, &.select2-dropdown-open {
+    > .select2-choices {
+      @extend %thredded--form--input:focus;
     }
   }
 }
 
 &--select2-drop {
-  border-color: darken($thredded-base-border-color, 5%);
-  box-shadow: 0 1px 1px $thredded-base-border-color;
+  background: inherit;
+  border-color: $thredded-form-border-focus-color;
+  box-shadow: 0 1px 1px $thredded-form-border-focus-color;
   font-family: $thredded-base-font-family;
   font-size: $thredded-base-font-size;
   line-height: $thredded-base-line-height;
 
+  .select2-results {
+    background: $thredded-form-background;
+    padding: 4px;
+    border-top: $thredded-base-border;
+    margin: 0;
+  }
+
   .select2-result {
+    color: $thredded-text-color;
+
     &.select2-highlighted {
-      background: $thredded-action-color;
+      background: $thredded-button-background;
+      color: $thredded-button-color;
     }
 
     > .select2-result-label {
+      font-family: $thredded-base-font-family;
+      font-size: $thredded-base-font-size;
       padding: $thredded-small-spacing;
     }
+  }
+
+  .select2-no-results, .select2-searching {
+    background: transparent;
+    color: $thredded-form-color;
+  }
+}
+
+
+&--select2-user-result {
+  &__avatar {
+    width: 2rem;
+    min-height: 2rem;
+    height: auto;
+    display: inline-block;
+    vertical-align: middle;
+  }
+  &__name {
+    display: inline-block;
+    margin-left: 0.6rem
+  }
+}
+
+&--select2-user-selection {
+  &__avatar {
+    width: 1rem;
+    min-height: 1rem;
+    height: auto;
+    display: inline-block;
+    vertical-align: text-bottom;
+  }
+  &__name {
+    display: inline-block;
+    margin-left: 0.4rem
   }
 }

--- a/app/controllers/thredded/autocomplete_users_controller.rb
+++ b/app/controllers/thredded/autocomplete_users_controller.rb
@@ -1,0 +1,45 @@
+module Thredded
+  class AutocompleteUsersController < Thredded::ApplicationController
+    MIN_QUERY_LENGTH = 2
+    MAX_RESULTS      = 20
+
+    def index
+      authorize_creating PrivateTopicForm.new(user: thredded_current_user).private_topic
+      users = params.key?(:q) ? users_by_prefix : users_by_ids
+      render json: {
+        results: users.map do |user|
+          { id:         user.id,
+            name:       user.send(Thredded.user_name_column),
+            avatar_url: Thredded.avatar_url.call(user) }
+        end
+      }
+    end
+
+    private
+
+    def users_by_prefix
+      query = params[:q].to_s.strip
+      if query.length >= MIN_QUERY_LENGTH
+        DbTextSearch::CaseInsensitive.new(users_scope, Thredded.user_name_column).prefix(query)
+          .where.not(id: thredded_current_user.id)
+          .limit(MAX_RESULTS)
+      else
+        []
+      end
+    end
+
+    # This method is used by select2 do fetch users by ids, e.g. in case of a browser-prefilled field.
+    def users_by_ids
+      ids = params[:ids].to_s.split(',')
+      if ids.present?
+        users_scope.where(id: ids)
+      else
+        []
+      end
+    end
+
+    def users_scope
+      thredded_current_user.thredded_can_message_users
+    end
+  end
+end

--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -94,7 +94,7 @@ module Thredded
     def topics
       messageboard
         .topics
-        .includes(:user_topic_reads, :categories, :last_user, :user)
+        .includes(:categories, :last_user, :user)
         .order_by_stuck_and_updated_time
         .on_page(current_page)
         .load

--- a/app/forms/thredded/private_topic_form.rb
+++ b/app/forms/thredded/private_topic_form.rb
@@ -30,14 +30,6 @@ module Thredded
       Thredded::PrivateTopic.model_name
     end
 
-    def users
-      @user.thredded_can_message_users
-    end
-
-    def users_for_select
-      (users - [@user]).map { |user| [user.to_s, user.id] }
-    end
-
     def id
       private_topic.id
     end
@@ -64,19 +56,6 @@ module Thredded
       @post ||= private_topic.posts.build(
         content: content,
         user: non_null_user)
-    end
-
-    def users_selected_options
-      { selected: private_user_ids }
-    end
-
-    def users_select_html_options
-      {
-        multiple: true,
-        required: true,
-        'data-placeholder' => 'select users to participate in this topic',
-        'data-thredded-users-select' => true
-      }
     end
 
     private

--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -23,9 +23,9 @@ module Thredded
 
     # @return [ActiveRecord::Relation<Thredded.user_class>] users from the list of user names that can read this post.
     def readers_from_user_names(user_names)
-      DbTextSearch::CaseInsensitiveEq
+      DbTextSearch::CaseInsensitive
         .new(Thredded.user_class.thredded_messageboards_readers([messageboard]), Thredded.user_name_column)
-        .find(user_names)
+        .in(user_names)
     end
 
     private

--- a/app/models/thredded/private_post.rb
+++ b/app/models/thredded/private_post.rb
@@ -17,9 +17,9 @@ module Thredded
 
     # @return [ActiveRecord::Relation<Thredded.user_class>] users from the list of user names that can read this post.
     def readers_from_user_names(user_names)
-      DbTextSearch::CaseInsensitiveEq
+      DbTextSearch::CaseInsensitive
         .new(postable.users, Thredded.user_name_column)
-        .find(user_names)
+        .in(user_names)
     end
   end
 end

--- a/app/views/thredded/private_topics/_form.html.erb
+++ b/app/views/thredded/private_topics/_form.html.erb
@@ -5,15 +5,14 @@
   <ul class="thredded--form-list on-top">
     <li class="title">
       <%= form.label :title, 'Private Topic Title' %>
-      <%= form.text_field :title, { placeholder: placeholder, required: true, 'data-thredded-topic-form-title' => true } %>
+      <%= form.text_field :title, placeholder: placeholder, required: true, 'data-thredded-topic-form-title' => true %>
     </li>
-
     <li>
-      <%= form.label :user_id, 'Users in Private Topic' %>
-      <%= form.select :user_ids,
-                      form.object.users_for_select,
-                      form.object.users_selected_options,
-                      form.object.users_select_html_options %>
+      <%= form.label :user_ids, 'Users in Private Topic' %>
+      <%= form.text_field :user_ids,
+                          placeholder:                 'Select users to participate in this topic',
+                          'data-thredded-users-select' => true,
+                          'data-autocomplete-url'      => autocomplete_users_path %>
     </li>
 
     <%= render 'thredded/posts/content_field', form: form %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,20 +1,24 @@
 Thredded::Engine.routes.draw do
-  constraints(->(req) { req.env['QUERY_STRING'].include? 'q=' }) do
-    get '/:messageboard_id(.:format)' => 'topics#search', as: :messageboard_search
-  end
-
-  resource :theme_preview, only: [:show] if %w(development test).include? Rails.env
+  resource :theme_preview, only: [:show], path: 'theme-preview' if %w(development test).include? Rails.env
 
   resources :private_topics, path: 'private-topics' do
     resources :private_posts, path: '', except: [:index], controller: 'posts'
   end
 
+  resources :autocomplete_users, only: [:index], path: 'autocomplete-users'
+
+  constraints(->(req) { req.env['QUERY_STRING'].include? 'q=' }) do
+    get '/:messageboard_id(.:format)' => 'topics#search', as: :messageboard_search
+  end
+
   get '/messageboards/new' => 'messageboards#new', as: :new_messageboard
-  get '/:messageboard_id/preferences/edit' => 'preferences#edit'
-  get '/:messageboard_id/new(.:format)' => 'topics#new', as: :new_messageboard_topic
-  get '/:messageboard_id/:id/edit(.:format)' => 'topics#edit', as: :edit_messageboard_topic
-  get '/:messageboard_id/:id/page-:page(.:format)' => 'topics#show', as: :paged_messageboard_topic_posts, constraints: { page: /\d+/ }
-  get '/:messageboard_id/category/:category_id' => 'topics#category', as: :messageboard_topics_categories
+  scope path: '/:messageboard_id' do
+    get '/preferences/edit' => 'preferences#edit'
+    get '/new(.:format)' => 'topics#new', as: :new_messageboard_topic
+    get '/:id/edit(.:format)' => 'topics#edit', as: :edit_messageboard_topic
+    get '/:id/page-:page(.:format)' => 'topics#show', as: :paged_messageboard_topic_posts, constraints: { page: /\d+/ }
+    get '/category/:category_id' => 'topics#category', as: :messageboard_topics_categories
+  end
 
   resources :messageboards, only: [:index, :create], path: '' do
     resource :preferences, only: [:edit, :update]

--- a/db/migrate/20160329231848_create_thredded.rb
+++ b/db/migrate/20160329231848_create_thredded.rb
@@ -25,7 +25,7 @@ class CreateThredded < ActiveRecord::Migration
     end
     add_index :thredded_categories, [:messageboard_id, :slug], name: :index_thredded_categories_on_messageboard_id_and_slug, unique: true
     add_index :thredded_categories, [:messageboard_id], name: :index_thredded_categories_on_messageboard_id
-    DbTextSearch::CaseInsensitiveEq.add_index connection, :thredded_categories, :name, name: :thredded_categories_name_ci
+    DbTextSearch::CaseInsensitive.add_index connection, :thredded_categories, :name, name: :thredded_categories_name_ci
 
     create_table :thredded_messageboards do |t|
       t.string :name, limit: 255, null: false
@@ -72,7 +72,7 @@ class CreateThredded < ActiveRecord::Migration
     add_index :thredded_posts, [:postable_id], name: :index_thredded_posts_on_postable_id
     add_index :thredded_posts, [:postable_id], name: :index_thredded_posts_on_postable_id_and_postable_type
     add_index :thredded_posts, [:user_id], name: :index_thredded_posts_on_user_id
-    DbTextSearch::FullTextSearch.add_index connection, :thredded_posts, :content, name: :thredded_posts_content_fts
+    DbTextSearch::FullText.add_index connection, :thredded_posts, :content, name: :thredded_posts_content_fts
 
     create_table :thredded_private_posts do |t|
       t.integer :user_id, limit: 4
@@ -129,7 +129,7 @@ class CreateThredded < ActiveRecord::Migration
     add_index :thredded_topics, [:messageboard_id, :slug], name: :index_thredded_topics_on_messageboard_id_and_slug, unique: true
     add_index :thredded_topics, [:messageboard_id], name: :index_thredded_topics_on_messageboard_id
     add_index :thredded_topics, [:user_id], name: :index_thredded_topics_on_user_id
-    DbTextSearch::FullTextSearch.add_index connection, :thredded_topics, :title, name: :thredded_topics_title_fts
+    DbTextSearch::FullText.add_index connection, :thredded_topics, :title, name: :thredded_topics_title_fts
 
     create_table :thredded_user_details do |t|
       t.integer :user_id, null: false

--- a/lib/thredded/post_sql_builder.rb
+++ b/lib/thredded/post_sql_builder.rb
@@ -5,7 +5,7 @@ module Thredded
       return unless users.present? || text.present?
       posts_scope = Thredded::Post
       posts_scope = posts_scope.where(user_id: users) if users.present?
-      posts_scope = DbTextSearch::FullTextSearch.new(posts_scope, :content).find(text) if text.present?
+      posts_scope = DbTextSearch::FullText.new(posts_scope, :content).search(text) if text.present?
       @scope      = @scope.joins(:posts).merge(posts_scope)
     end
   end

--- a/lib/thredded/table_sql_builder.rb
+++ b/lib/thredded/table_sql_builder.rb
@@ -17,8 +17,8 @@ module Thredded
     def categories
       @search_categories ||=
         if @terms['in']
-          DbTextSearch::CaseInsensitiveEq.new(Category, :name)
-            .find(@terms['in']).pluck(:id)
+          DbTextSearch::CaseInsensitive.new(Category, :name)
+            .in(@terms['in']).pluck(:id)
         else
           []
         end
@@ -27,8 +27,8 @@ module Thredded
     def users
       @search_users ||=
         if @terms['by']
-          DbTextSearch::CaseInsensitiveEq.new(Thredded.user_class, Thredded.user_name_column)
-            .find(@terms['by']).pluck(:id)
+          DbTextSearch::CaseInsensitive.new(Thredded.user_class, Thredded.user_name_column)
+            .in(@terms['by']).pluck(:id)
         else
           []
         end

--- a/lib/thredded/topic_sql_builder.rb
+++ b/lib/thredded/topic_sql_builder.rb
@@ -5,7 +5,7 @@ module Thredded
     def apply_filters
       @scope = @scope.joins(:topic_categories).where(category_id: categories) if categories.present?
       @scope = @scope.where(user_id: users) if users.present?
-      @scope = DbTextSearch::FullTextSearch.new(@scope, :title).find(text) if text.present?
+      @scope = DbTextSearch::FullText.new(@scope, :title).search(text) if text.present?
     end
   end
 end

--- a/spec/support/features/page_object/private_topics.rb
+++ b/spec/support/features/page_object/private_topics.rb
@@ -27,10 +27,10 @@ module PageObject
     end
 
     def create_private_topic
-      create(:user, name: 'carl')
+      user = create(:user, name: 'carl')
       visit new_private_topic_path
       fill_in 'Title', with: private_title
-      select 'carl', from: 'private_topic_user_ids'
+      find(:css, '#private_topic_user_ids').set(user.id)
       fill_in 'Content', with: 'not for others'
 
       click_on 'Create New Private Topic'

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   # backend
   s.add_dependency 'bbcoder', '~> 1.0'
   s.add_dependency 'cancancan'
-  s.add_dependency 'db_text_search', '~> 0.1.1'
+  s.add_dependency 'db_text_search', '~> 0.2.0'
   s.add_dependency 'friendly_id'
   s.add_dependency 'html-pipeline'
   s.add_dependency 'htmlentities'


### PR DESCRIPTION
![new-private-topic](https://cloud.githubusercontent.com/assets/216339/14328805/374dc664-fc30-11e5-8e82-5894bf93aee6.png)

* Autocomplete user names remotely. #183 
* Fix autocomplete styles to use thredded form styles.
* Add `$thredded-form-color/background` variables.
* Avoid creating notification jobs when seeding, bump the number of
  records, and log progress.
* Fix `includes` in topics and private topics controller. There is still
  an issue of loading read state for each topic, but this can't be fixed
  easily due to the decorator architecture.
* Update DbTextSearch to 0.2.0 for indexed prefix matching in user search.
* Fix Messageboard slugs to allow creating messageboards with reserved
  names.
* Update changelog