### PR TITLE
Fix pagination routes

### DIFF
--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -72,7 +72,7 @@ module Thredded
 
     def update
       topic.update_attributes!(topic_params.merge(last_user_id: thredded_current_user.id))
-      redirect_to messageboard_topic_posts_url(messageboard, topic), flash: { notice: 'Topic updated' }
+      redirect_to messageboard_topic_url(messageboard, topic), flash: { notice: 'Topic updated' }
     end
 
     def destroy

--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -37,5 +37,26 @@ module Thredded
         edit_messageboard_topic_post_path(messageboard, post.postable, post)
       end
     end
+
+    # @param topic [UserTopicDecorator, UserPrivateTopicDecorator]
+    # @return [String] path to the latest unread page of the given topic.
+    def topic_path(topic, params = {})
+      if topic.private?
+        # TODO: this should actually pass the latest read page.
+        private_topic_path(
+          topic.slug,
+          **params
+        )
+      else
+        # TODO: farthest_page always returns 1, investigate.
+        params[:page] ||= topic.farthest_page
+        params[:page] = nil if params[:page] == 1
+        messageboard_topic_path(
+          topic.messageboard.slug,
+          topic.slug,
+          **params
+        )
+      end
+    end
   end
 end

--- a/app/models/concerns/thredded/friendly_id_reserved_words_and_pagination.rb
+++ b/app/models/concerns/thredded/friendly_id_reserved_words_and_pagination.rb
@@ -1,0 +1,15 @@
+require 'set'
+module Thredded
+  # Excludes pagination routes in addition to the given list of reserved words.
+  class FriendlyIdReservedWordsAndPagination
+    PAGINATION_PATTERN = /\Apage-\d+\z/i
+
+    def initialize(words = [])
+      @words = Set.new(words)
+    end
+
+    def include?(slug)
+      @words.include?(slug) || slug =~ PAGINATION_PATTERN
+    end
+  end
+end

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -6,7 +6,8 @@ module Thredded
     friendly_id :slug_candidates,
                 use:            [:slugged, :reserved],
                 # Avoid route conflicts
-                reserved_words: %w(messageboards private-topics autocomplete-users theme-preview)
+                reserved_words: ::Thredded::FriendlyIdReservedWordsAndPagination.new(
+                  %w(messageboards private-topics autocomplete-users theme-preview))
 
     validates :filter, inclusion: { in: FILTERS }, presence: true
     validates :name, uniqueness: true, length: { maximum: 60 }, presence: true
@@ -15,7 +16,7 @@ module Thredded
     has_many :categories, dependent: :destroy
     has_many :notification_preferences, dependent: :destroy
     has_many :posts, dependent: :destroy
-    has_many :topics, dependent: :destroy
+    has_many :topics, dependent: :destroy, inverse_of: :messageboard
     has_many :user_details, through: :posts
 
     has_many :messageboard_users,

--- a/app/models/thredded/private_topic.rb
+++ b/app/models/thredded/private_topic.rb
@@ -2,7 +2,10 @@ module Thredded
   class PrivateTopic < ActiveRecord::Base
     include TopicCommon
     extend FriendlyId
-    friendly_id :title, use: :history
+    friendly_id :slug_candidates,
+                use:            [:history, :reserved],
+                # Avoid route conflicts
+                reserved_words: ::Thredded::FriendlyIdReservedWordsAndPagination.new(%w(new))
 
     has_many :posts,
              class_name:  'Thredded::PrivatePost',
@@ -55,6 +58,19 @@ module Thredded
 
     def users_to_sentence
       users.map { |user| user.to_s.capitalize }.to_sentence
+    end
+
+    def should_generate_new_friendly_id?
+      title_changed?
+    end
+
+    private
+
+    def slug_candidates
+      [
+        :title,
+        [:title, '-topic']
+      ]
     end
   end
 end

--- a/app/models/thredded/topic.rb
+++ b/app/models/thredded/topic.rb
@@ -7,11 +7,16 @@ module Thredded
     scope :for_messageboard, -> messageboard { where(messageboard_id: messageboard.id) }
 
     extend FriendlyId
-    friendly_id :title, use: [:history, :scoped], scope: :messageboard
+    friendly_id :slug_candidates,
+                use:            [:history, :reserved, :scoped],
+                scope:          :messageboard,
+                # Avoid route conflicts
+                reserved_words: ::Thredded::FriendlyIdReservedWordsAndPagination.new(%w(topics))
 
     belongs_to :messageboard,
                counter_cache: true,
-               touch: true
+               touch: true,
+               inverse_of: :topics
     validates_presence_of :messageboard_id
 
     belongs_to :user_detail,
@@ -99,6 +104,15 @@ module Thredded
 
     def should_generate_new_friendly_id?
       title_changed?
+    end
+
+    private
+
+    def slug_candidates
+      [
+        :title,
+        [:title, '-topic']
+      ]
     end
   end
 end

--- a/app/views/thredded/post_mailer/at_notification.html.erb
+++ b/app/views/thredded/post_mailer/at_notification.html.erb
@@ -4,8 +4,8 @@
 
 <p>
   This email was sent to you because <%= @post.user %> mentioned you in
-  "<%= link_to @post.postable.title, messageboard_topic_posts_url(@post.messageboard, @post.postable, anchor: "post_#{@post.id}") %>".
-  <%= link_to 'View the conversation here.', messageboard_topic_posts_url(@post.messageboard, @post.postable) %>
+  "<%= link_to @post.postable.title, messageboard_topic_url(@post.messageboard, @post.postable, anchor: "post_#{@post.id}") %>".
+  <%= link_to 'View the conversation here.', messageboard_topic_url(@post.messageboard, @post.postable) %>
 </p>
 
 <p>

--- a/app/views/thredded/post_mailer/at_notification.text.erb
+++ b/app/views/thredded/post_mailer/at_notification.text.erb
@@ -4,7 +4,7 @@
 
 This email was sent to you because <%= @post.user %> mentioned you in
 "<%= @post.postable.title %>". Go here to view the conversation:
-<%= messageboard_topic_posts_url @post.messageboard, @post.postable, anchor: "post_#{@post.id}" %>
+<%= messageboard_topic_url @post.messageboard, @post.postable, anchor: "post_#{@post.id}" %>
 
 To unsubscribe from these emails, update your preferences here:
   <%= edit_messageboard_preferences_url @post.messageboard %>

--- a/app/views/thredded/private_topics/_private_topic.html.erb
+++ b/app/views/thredded/private_topics/_private_topic.html.erb
@@ -2,7 +2,7 @@
   <div class="thredded--topics--posts-count"><%= private_topic.posts_count %></div>
 
   <h1 class="thredded--topics--title">
-    <%= link_to private_topic.title, private_topic.original %>
+    <%= link_to private_topic.title, topic_path(private_topic) %>
   </h1>
 
   <cite class="thredded--topics--updated-by">

--- a/app/views/thredded/theme_previews/show.html.erb
+++ b/app/views/thredded/theme_previews/show.html.erb
@@ -31,7 +31,7 @@
   <br>
 
 
-  <%= render 'section_title', label: 'topics#show', href: messageboard_topic_posts_path(@messageboard, @topic) %>
+  <%= render 'section_title', label: 'topics#show', href: messageboard_topic_path(@messageboard, @topic) %>
   <%= content_tag_for :section, @topic, class: "thredded--thredded--main-section #{@user_topic.css_class}" do %>
     <%= render 'thredded/topics_common/header', topic: @topic %>
     <%= render @posts %>

--- a/app/views/thredded/topics/_topic.html.erb
+++ b/app/views/thredded/topics/_topic.html.erb
@@ -2,13 +2,7 @@
   <div class="thredded--topics--posts-count"><%= topic.posts_count %></div>
 
   <h1 class="thredded--topics--title">
-    <%= link_to topic.title,
-      paged_messageboard_topic_posts_path(
-        messageboard.slug,
-        topic.slug,
-        topic.farthest_page
-      )
-    %>
+    <%= link_to topic.title, topic_path(topic) %>
   </h1>
 
   <% if topic.categories.any? %>

--- a/spec/support/features/page_object/posts.rb
+++ b/spec/support/features/page_object/posts.rb
@@ -11,7 +11,7 @@ module PageObject
     end
 
     def visit_posts
-      visit messageboard_topic_posts_path(messageboard, topic)
+      visit messageboard_topic_path(messageboard, topic)
     end
 
     def submit_reply(content = 'I replied')

--- a/spec/support/features/page_object/topics.rb
+++ b/spec/support/features/page_object/topics.rb
@@ -114,11 +114,11 @@ module PageObject
     end
 
     def make_locked
-      find('input[type="hidden"][name="topic[locked]"]').set('1')
+      check 'Locked'
     end
 
     def make_sticky
-      find('input[type="hidden"][name="topic[sticky]"]').set('1')
+      check 'Sticky'
     end
 
     def select_category(category)

--- a/spec/support/features/page_object/visitor.rb
+++ b/spec/support/features/page_object/visitor.rb
@@ -42,7 +42,7 @@ module PageObject
 
     def visits_the_latest_thread_on(messageboard)
       topic = messageboard.topics.order('id desc').first
-      visit messageboard_topic_posts_path(messageboard, topic)
+      visit messageboard_topic_path(messageboard, topic)
     end
 
     def on_latest_thread_on?(messageboard)


### PR DESCRIPTION
* All paginated routes now use the 'page-%d' format.
* 'page-%d' is now a reserved slug for topics and messageboards.
* Moves messageboard_topic_posts_path to messageboard_topic_path,
  same for private topics. This fixes the page numbers generated
  by kaminari (previously it generated ?page=n).

Also discovered bugs with last page link generation and left TODOs.