### PR TITLE
Global Search

### DIFF
--- a/app/assets/stylesheets/thredded/layout/_user-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_user-navigation.scss
@@ -91,7 +91,7 @@
     }
   }
 
-  input[type="submit"] {
+  [type="submit"] {
     display: none;
   }
 }

--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -36,7 +36,7 @@ module Thredded
 
     def search
       @query = params[:q].to_s
-      @topics = messageboard.topics
+      @topics = (messageboard_or_nil ? messageboard.topics : Topic)
                   .search_query(@query)
                   .order_recently_updated_first
                   .includes(:categories, :last_user, :user)

--- a/app/helpers/thredded/urls_helper.rb
+++ b/app/helpers/thredded/urls_helper.rb
@@ -76,5 +76,15 @@ module Thredded
     def edit_preferences_path(messageboard = nil, params = {})
       edit_preferences_url(messageboard, params.merge(only_path: true))
     end
+
+    # @param messageboard [Thredded::Messageboard, nil]
+    # @return [String] the path to the global or messageboard search.
+    def search_path(messageboard = nil)
+      if messageboard.try(:persisted?)
+        messageboard_search_path(messageboard)
+      else
+        messageboards_search_path
+      end
+    end
   end
 end

--- a/app/views/thredded/messageboards/search.html.erb
+++ b/app/views/thredded/messageboards/search.html.erb
@@ -1,0 +1,1 @@
+<%= render 'thredded/topics/search' %>

--- a/app/views/thredded/search/_form.html.erb
+++ b/app/views/thredded/search/_form.html.erb
@@ -1,7 +1,10 @@
-<% if messageboard.try(:persisted?) %>
-  <%= form_tag messageboard_search_path(messageboard), class: 'thredded--form', method: 'get' do %>
-    <%= label :q, :search, 'Search', for: 'q', class: 'show-for-small', data: {toggle: '#q'} %>
-    <%= text_field_tag(:q, params[:q], { placeholder: 'Search Topics and Posts', type: 'search', class: 'input-search' }) %>
-    <%= submit_tag('Search', name: '') %>
-  <% end %>
+<%= form_tag search_path(messageboard), class: 'thredded--form', method: 'get' do %>
+  <%= label_tag :q, t('thredded.search.form.label') %>
+  <%= text_field_tag :q, @query,
+                     type:        'search',
+                     required:    true,
+                     # If there are no results the user will likely want to change the query, so auto-focus.
+                     autofocus:   @query.presence && !@topics.presence,
+                     placeholder: t('thredded.search.form.placeholder') %>
+  <button type="submit"><%= t 'thredded.search.form.btn_submit' %></button>
 <% end %>

--- a/app/views/thredded/shared/_top_nav.html.erb
+++ b/app/views/thredded/shared/_top_nav.html.erb
@@ -1,9 +1,7 @@
 <nav class="thredded--user-navigation" role="navigation">
-  <% if messageboard_or_nil %>
-    <div class="thredded--user-navigation--search">
-      <%= render 'thredded/search/form' %>
-    </div>
-  <% end %>
+  <div class="thredded--user-navigation--search">
+    <%= render 'thredded/search/form', messageboard: messageboard_or_nil %>
+  </div>
 
   <% if signed_in? %>
     <ul class="thredded--user-navigation--actions">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,11 @@ en:
     private_topics:
       errors:
         user_ids_length: Please specify at least one other user.
+    search:
+      form:
+        btn_submit: :thredded.search.form.label
+        label: Search
+        placeholder: Search Topics and Posts
     topics:
       search:
         no_results_message: There are no results for your search - %{query}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Thredded::Engine.routes.draw do
   resources :autocomplete_users, only: [:index], path: 'autocomplete-users'
 
   constraints(->(req) { req.env['QUERY_STRING'].include? 'q=' }) do
+    get '/' => 'topics#search', as: :messageboards_search
     get '/:messageboard_id(.:format)' => 'topics#search', as: :messageboard_search
   end
 

--- a/spec/features/thredded/user_searches_for_topics_spec.rb
+++ b/spec/features/thredded/user_searches_for_topics_spec.rb
@@ -1,25 +1,34 @@
 require 'spec_helper'
 
 feature 'User searching topics' do
+  title = 'Rando thread'
+
   # On MySQL, a transaction has to complete before the full text search index is updated
   before :all do
     messageboard = create(:messageboard)
-    create(:topic, title: 'Rando thread', messageboard: messageboard)
+    create(:topic, title: title, messageboard: messageboard)
     create_list(:topic, 2, messageboard: messageboard)
-    @three_topics = PageObject::Topics.new(messageboard)
+    @topics = PageObject::Topics.new(messageboard)
   end
 
   after :all do
-    @three_topics.messageboard.destroy
+    @topics.messageboard.destroy
   end
 
-  scenario 'sees a list of found topics' do
-    topics = @three_topics
-    topics.visit_style_guide
-    topics.search_for('Rando thread')
+  search_and_expect_found = lambda do
+    @topics.search_for(title)
+    expect(page).to have_content(I18n.t('thredded.topics.search.results_message', query: "'#{title}'"))
+    expect(@topics.normal_topics.size).to eq(1)
+    expect(@topics).to have_topic_titled(title)
+  end
 
-    expect(page).to have_content("Search Results for 'Rando thread'")
-    expect(topics.normal_topics.size).to eq(1)
-    expect(topics).to have_topic_titled('Rando thread')
+  scenario 'in a messageboard' do
+    @topics.visit_style_guide
+    instance_exec(&search_and_expect_found)
+  end
+
+  scenario 'globally' do
+    visit thredded.root_path
+    instance_exec(&search_and_expect_found)
   end
 end

--- a/spec/support/features/page_object/topics.rb
+++ b/spec/support/features/page_object/topics.rb
@@ -148,8 +148,8 @@ module PageObject
     end
 
     def search_for(title)
-      fill_in 'Search', with: title
-      find('.thredded--user-navigation--search input[type="submit"]').click
+      fill_in 'q', with: title
+      find('.thredded--user-navigation--search [type="submit"]').click
     end
 
     private


### PR DESCRIPTION
Search across all messageboards.

For now, uses the same controller#action, but the routes are separate
so the global search can use a different action in the future, e.g. one
that groups the results by Messageboard names.

Resolves #211