### PR TITLE
Permissions: cleanup and first post deletion

### DIFF
--- a/CHANGELOG.mkdn
+++ b/CHANGELOG.mkdn
@@ -17,6 +17,7 @@ for more information.
 
 ## Added
 
+* Ability to delete posts. [#214](https://github.com/thredded/thredded/pull/214)
 * Global search across all messageboards. [#215](https://github.com/thredded/thredded/pull/215)
 * Global notification settings, message notification settings. [#210](https://github.com/thredded/thredded/pull/210)
 * Private topic user select now looks prettier and loads the user via AJAX, instead of generating a huge select with all

--- a/app/controllers/thredded/application_controller.rb
+++ b/app/controllers/thredded/application_controller.rb
@@ -40,10 +40,10 @@ module Thredded
 
     if Rails::VERSION::MAJOR < 5
       # redirect_back polyfill
-      def redirect_back(fallback_location:)
-        redirect_to :back
+      def redirect_back(fallback_location:, **args)
+        redirect_to :back, args
       rescue ActionController::RedirectBackError
-        redirect_to fallback_location
+        redirect_to fallback_location, args
       end
     end
 

--- a/app/decorators/thredded/private_topic_decorator.rb
+++ b/app/decorators/thredded/private_topic_decorator.rb
@@ -1,5 +1,3 @@
-require 'thredded/base_topic_decorator'
-
 module Thredded
   class PrivateTopicDecorator < SimpleDelegator
     def initialize(private_topic)

--- a/app/decorators/thredded/topic_decorator.rb
+++ b/app/decorators/thredded/topic_decorator.rb
@@ -1,5 +1,3 @@
-require 'thredded/base_topic_decorator'
-
 module Thredded
   class TopicDecorator < SimpleDelegator
     def initialize(private_topic)

--- a/app/decorators/thredded/user_private_topic_decorator.rb
+++ b/app/decorators/thredded/user_private_topic_decorator.rb
@@ -1,5 +1,3 @@
-require 'thredded/base_user_topic_decorator'
-
 module Thredded
   class UserPrivateTopicDecorator < BaseUserTopicDecorator
     def self.topic_class

--- a/app/decorators/thredded/user_topic_decorator.rb
+++ b/app/decorators/thredded/user_topic_decorator.rb
@@ -1,5 +1,3 @@
-require 'thredded/base_user_topic_decorator'
-
 module Thredded
   class UserTopicDecorator < BaseUserTopicDecorator
     def self.topic_class

--- a/app/models/thredded/null_user.rb
+++ b/app/models/thredded/null_user.rb
@@ -1,9 +1,3 @@
-require_relative './user_permissions/read/all'
-require_relative './user_permissions/write/none'
-require_relative './user_permissions/message/readers_of_writeable_boards'
-require_relative './user_permissions/moderate/none'
-require_relative './user_permissions/admin/none'
-
 module Thredded
   class NullUser
     include ::Thredded::UserPermissions::Read::All

--- a/app/models/thredded/private_topic.rb
+++ b/app/models/thredded/private_topic.rb
@@ -19,6 +19,9 @@ module Thredded
              foreign_key: :postable_id,
              inverse_of:  :postable,
              dependent:   :destroy
+    has_one :first_post, -> { order_oldest_first },
+            class_name:  'Thredded::PrivatePost',
+            foreign_key: :postable_id
     has_many :private_users, inverse_of: :private_topic
     has_many :users, through: :private_users
 

--- a/app/models/thredded/topic.rb
+++ b/app/models/thredded/topic.rb
@@ -1,5 +1,3 @@
-require 'thredded/topics_search'
-
 module Thredded
   class Topic < ActiveRecord::Base
     include TopicCommon
@@ -42,6 +40,10 @@ module Thredded
              foreign_key: :postable_id,
              inverse_of:  :postable,
              dependent:   :destroy
+    has_one :first_post, -> { order_oldest_first },
+            class_name:  'Thredded::Post',
+            foreign_key: :postable_id
+
     has_many :topic_categories, dependent: :destroy
     has_many :categories, through: :topic_categories
     has_many :user_topic_reads, dependent: :destroy

--- a/app/models/thredded/user_extender.rb
+++ b/app/models/thredded/user_extender.rb
@@ -1,9 +1,3 @@
-require_relative './user_permissions/read/all'
-require_relative './user_permissions/write/all'
-require_relative './user_permissions/message/readers_of_writeable_boards'
-require_relative './user_permissions/moderate/if_moderator_column_true'
-require_relative './user_permissions/admin/if_admin_column_true'
-
 module Thredded
   module UserExtender
     extend ActiveSupport::Concern

--- a/app/views/thredded/posts_common/_post.html.erb
+++ b/app/views/thredded/posts_common/_post.html.erb
@@ -15,14 +15,14 @@
   </div>
 
   <% if current_ability.can? :edit, post.original %>
-    <%= link_to 'Edit Post', edit_post_path(post.original), class: 'thredded--post--edit' %>
+    <%= link_to t('thredded.posts.edit'), edit_post_path(post.original), class: 'thredded--post--edit' %>
   <% end %>
 
   <% if current_ability.can? :destroy, post.original %>
-    <%= link_to 'Delete Post', delete_post_path(post.original),
-      method: :delete,
-      class: 'thredded--post--delete',
-      data: { confirm: I18n.t('thredded.posts.delete.confirm') }
+    <%= link_to t('thredded.posts.delete'), delete_post_path(post.original),
+                method: :delete,
+                class: 'thredded--post--delete',
+                data: { confirm: I18n.t('thredded.posts.delete_confirm') }
     %>
   <% end %>
 <% end %>

--- a/app/views/thredded/topics/_topic_form_admin_options.html.erb
+++ b/app/views/thredded/topics/_topic_form_admin_options.html.erb
@@ -1,5 +1,5 @@
 <% topic = form.object.respond_to?(:topic) ? form.object.topic : form.object %>
-<% if current_ability.can? :admin, topic %>
+<% if current_ability.can? :moderate, topic %>
   <li class="thredded--form-list--admin-options">
     <%= form.label :locked do %>
       <%= form.check_box :locked %> Locked

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,8 +12,10 @@ en:
       settings: Notification Settings
       topics: Topics
     posts:
-      delete:
-        confirm: Are you sure you want to delete this post?
+      delete: Delete Post
+      delete_confirm: Are you sure you want to delete this post?
+      deleted_notice: Your post has been deleted.
+      edit: Edit Post
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -21,12 +21,6 @@ require 'select2-rails'
 require 'sprockets/es6'
 
 require 'thredded/engine'
-require 'thredded/errors'
-require 'thredded/messageboard_user_permissions'
-require 'thredded/post_user_permissions'
-require 'thredded/private_topic_user_permissions'
-require 'thredded/topic_user_permissions'
-require 'thredded/main_app_route_delegator'
 
 module Thredded
   mattr_accessor :user_class,

--- a/lib/thredded/engine.rb
+++ b/lib/thredded/engine.rb
@@ -2,10 +2,9 @@ module Thredded
   class Engine < ::Rails::Engine
     isolate_namespace Thredded
 
-    config.autoload_paths << File.expand_path('../../../app/decorators', __FILE__)
-    config.autoload_paths << File.expand_path('../../../app/forms', __FILE__)
-    config.autoload_paths << File.expand_path('../../../app/commands', __FILE__)
-    config.autoload_paths << File.expand_path('../../../app/jobs', __FILE__)
+    %w(app/decorators app/forms app/commands app/jobs lib).each do |path|
+      config.autoload_paths << File.expand_path("../../#{path}", File.dirname(__FILE__))
+    end
 
     config.generators do |g|
       g.test_framework :rspec, fixture: true

--- a/lib/thredded/post_user_permissions.rb
+++ b/lib/thredded/post_user_permissions.rb
@@ -1,32 +1,28 @@
 module Thredded
   class PostUserPermissions
-    def initialize(post, user, _user_details)
-      @post                         = post
-      @topic                        = post.postable
-      @messageboard_user_permission = MessageboardUserPermissions.new(post.messageboard, user)
-      @user                         = user
+    # @param post [Thredded::Post]
+    # @param user [Thredded.user_class]
+    def initialize(post, user)
+      @post = post
+      @user = user
     end
 
     def editable?
-      created_post? || @messageboard_user_permission.moderatable?
-    end
-
-    def manageable?
-      created_post? || @messageboard_user_permission.moderatable?
+      own_post? || messageboard_user_permissions.moderatable?
     end
 
     def creatable?
-      thread_is_not_locked? && @messageboard_user_permission.postable?
+      !@post.postable.locked? && messageboard_user_permissions.postable?
     end
 
     private
 
-    def created_post?
-      @user.id == @post.user_id
+    def messageboard_user_permissions
+      @messageboard_user_permission ||= MessageboardUserPermissions.new(@post.messageboard, @user)
     end
 
-    def thread_is_not_locked?
-      @topic.private? || !@topic.locked?
+    def own_post?
+      @user.id == @post.user_id
     end
   end
 end

--- a/lib/thredded/private_post_user_permissions.rb
+++ b/lib/thredded/private_post_user_permissions.rb
@@ -1,0 +1,28 @@
+module Thredded
+  class PrivatePostUserPermissions
+    # @param post [Thredded::PrivatePost]
+    # @param user [Thredded.user_class]
+    def initialize(post, user)
+      @post = post
+      @user = user
+    end
+
+    def editable?
+      own_post?
+    end
+
+    def manageable?
+      own_post?
+    end
+
+    def creatable?
+      @post.postable.users.include?(@user)
+    end
+
+    private
+
+    def own_post?
+      @user.id == @post.user_id
+    end
+  end
+end

--- a/lib/thredded/private_topic_user_permissions.rb
+++ b/lib/thredded/private_topic_user_permissions.rb
@@ -1,20 +1,20 @@
 module Thredded
   class PrivateTopicUserPermissions
-    def initialize(private_topic, user, _user_details)
+    def initialize(private_topic, user)
       @private_topic = private_topic
       @user = user
     end
 
-    def readable?
-      @private_topic.users.include?(@user)
+    def creatable?
+      !@user.thredded_anonymous?
     end
 
-    def manageable?
+    def editable?
       user_started_topic?
     end
 
-    def creatable?
-      !@user.thredded_anonymous?
+    def readable?
+      @private_topic.users.include?(@user)
     end
 
     private

--- a/lib/thredded/topic_user_permissions.rb
+++ b/lib/thredded/topic_user_permissions.rb
@@ -1,22 +1,21 @@
 module Thredded
   class TopicUserPermissions
-    def initialize(topic, user, _user_details)
+    def initialize(topic, user)
       @topic = topic
-      @messageboard = topic.messageboard
-      @messageboard_user_permission = MessageboardUserPermissions.new(topic.messageboard, user)
       @user = user
+      @messageboard_user_permission = MessageboardUserPermissions.new(topic.messageboard, user)
+    end
+
+    def moderatable?
+      @messageboard_user_permission.moderatable?
     end
 
     def creatable?
       @messageboard_user_permission.postable?
     end
 
-    def adminable?
-      @messageboard_user_permission.moderatable?
-    end
-
     def editable?
-      started_by_user? || adminable?
+      started_by_user? || moderatable?
     end
 
     def readable?

--- a/spec/features/thredded/user_deletes_post_spec.rb
+++ b/spec/features/thredded/user_deletes_post_spec.rb
@@ -15,6 +15,14 @@ feature 'User deleting posts' do
     expect(last_post).not_to be_listed
   end
 
+  scenario 'cannot delete the first post of their own topic' do
+    user.log_in
+    topic = users_topic
+    topic.visit_topic
+    expect(topic.first_post).to be_listed
+    expect(topic.first_post).not_to be_deletable
+  end
+
   scenario "cannot delete someone else's post" do
     user.log_in
     topic = someone_elses_topic
@@ -38,6 +46,14 @@ feature 'User deleting posts' do
       last_post.delete
 
       expect(last_post).not_to be_listed
+    end
+
+    scenario 'cannot delete the first post of a topic' do
+      admin.log_in
+      topic = someone_elses_topic
+      topic.visit_topic
+      expect(topic.first_post).to be_listed
+      expect(topic.first_post).not_to be_deletable
     end
   end
 

--- a/spec/features/thredded/user_deletes_topic_spec.rb
+++ b/spec/features/thredded/user_deletes_topic_spec.rb
@@ -6,7 +6,7 @@ feature 'User deleting topics' do
     topic = users_topic
     topic.visit_topic
 
-    expect(topic).to_not be_deletable
+    expect(topic).not_to be_deletable
   end
 
   context 'as an admin' do
@@ -20,7 +20,7 @@ feature 'User deleting topics' do
       topic.delete
 
       expect(topic).to have_redirected_after_delete
-      expect(topic).to_not be_listed
+      expect(topic).not_to be_listed
     end
   end
 

--- a/spec/features/thredded/user_updates_preferences_spec.rb
+++ b/spec/features/thredded/user_updates_preferences_spec.rb
@@ -27,7 +27,7 @@ feature 'User updating preferences' do
     preferences.disable_private_topic_notifications
 
     expect(preferences).to be_updated
-    expect(preferences).to_not have_private_topic_notifications
+    expect(preferences).not_to have_private_topic_notifications
   end
 
   def default_user_preferences

--- a/spec/lib/thredded/post_user_permissions_spec.rb
+++ b/spec/lib/thredded/post_user_permissions_spec.rb
@@ -7,30 +7,9 @@ module Thredded
       it 'can be edited by the user who started it' do
         user = build_stubbed(:user)
         post = build_stubbed(:post, user: user)
-        user_details = UserDetail.new
-        permissions = PostUserPermissions.new(post, user, user_details)
+        permissions = PostUserPermissions.new(post, user)
 
         expect(permissions).to be_editable
-      end
-    end
-
-    describe '#manageable?' do
-      it 'can be managed by the user who started it' do
-        user = build_stubbed(:user)
-        post = build_stubbed(:post, user: user)
-        user_details = UserDetail.new
-        permissions = PostUserPermissions.new(post, user, user_details)
-
-        expect(permissions).to be_manageable
-      end
-
-      it 'can be managed by an admin' do
-        user = build_stubbed(:user, admin: true)
-        post = build_stubbed(:post, user: user)
-        user_details = build_stubbed(:user_detail)
-        permissions = PostUserPermissions.new(post, user, user_details)
-
-        expect(permissions).to be_manageable
       end
     end
 
@@ -54,8 +33,7 @@ module Thredded
         user = build_stubbed(:user)
         topic = build_stubbed(:topic, :locked)
         post = build_stubbed(:post, user: user, postable: topic)
-        user_details = UserDetail.new
-        permissions = PostUserPermissions.new(post, user, user_details)
+        permissions = PostUserPermissions.new(post, user)
 
         expect(permissions).not_to be_creatable
       end
@@ -63,8 +41,7 @@ module Thredded
       def post_permissions
         user = build_stubbed(:user)
         post = build_stubbed(:post, user: user)
-        user_details = UserDetail.new
-        PostUserPermissions.new(post, user, user_details)
+        PostUserPermissions.new(post, user)
       end
     end
   end

--- a/spec/lib/thredded/private_topic_user_permissions_spec.rb
+++ b/spec/lib/thredded/private_topic_user_permissions_spec.rb
@@ -4,18 +4,6 @@ require 'thredded/private_topic_user_permissions'
 
 module Thredded
   describe PrivateTopicUserPermissions do
-    let(:user_details) { Thredded::UserDetail.new }
-
-    describe '#manageable?' do
-      it 'is manageable by the user that created it' do
-        user = build_stubbed(:user)
-        private_topic = build_stubbed(:private_topic, user: user)
-        permissions = PrivateTopicUserPermissions.new(private_topic, user, user_details)
-
-        expect(permissions).to be_manageable
-      end
-    end
-
     describe '#readable?' do
       it 'allows only users in the conversation to read' do
         me = build_stubbed(:user)
@@ -23,9 +11,9 @@ module Thredded
         them = build_stubbed(:user)
         private_topic = build_stubbed(:private_topic, user: me, users: [me, him])
 
-        my_permissions = PrivateTopicUserPermissions.new(private_topic, me, user_details)
-        his_permissions = PrivateTopicUserPermissions.new(private_topic, him, user_details)
-        their_permissions = PrivateTopicUserPermissions.new(private_topic, them, user_details)
+        my_permissions = PrivateTopicUserPermissions.new(private_topic, me)
+        his_permissions = PrivateTopicUserPermissions.new(private_topic, him)
+        their_permissions = PrivateTopicUserPermissions.new(private_topic, them)
 
         expect(my_permissions).to be_readable
         expect(his_permissions).to be_readable
@@ -37,8 +25,8 @@ module Thredded
       it 'for non-anonymous users' do
         user = create(:user)
         private_topic = build_stubbed(:private_topic, user: user)
-        expect(PrivateTopicUserPermissions.new(private_topic, user, user_details)).to be_creatable
-        expect(PrivateTopicUserPermissions.new(private_topic, Thredded::NullUser.new, nil)).to_not be_creatable
+        expect(PrivateTopicUserPermissions.new(private_topic, user)).to be_creatable
+        expect(PrivateTopicUserPermissions.new(private_topic, Thredded::NullUser.new)).not_to be_creatable
       end
     end
   end

--- a/spec/lib/thredded/topic_user_permissions_spec.rb
+++ b/spec/lib/thredded/topic_user_permissions_spec.rb
@@ -9,7 +9,7 @@ module Thredded
 
       it 'allows members to create a topic' do
         user = create(:user)
-        permissions = Thredded::TopicUserPermissions.new(topic, user, user_details)
+        permissions = Thredded::TopicUserPermissions.new(topic, user)
 
         expect(permissions).to be_creatable
       end
@@ -19,7 +19,7 @@ module Thredded
         topic = create(:topic, messageboard: messageboard)
         user = create(:user)
         allow(user).to receive(:thredded_can_write_messageboards) { Messageboard.none }
-        permissions = TopicUserPermissions.new(topic, user, user_details)
+        permissions = TopicUserPermissions.new(topic, user)
 
         expect(permissions).not_to be_creatable
       end

--- a/spec/mailers/thredded/mailer_previews_spec.rb
+++ b/spec/mailers/thredded/mailer_previews_spec.rb
@@ -9,11 +9,11 @@ module Thredded
             let(:mail) { preview_class.new.send(method_name) }
 
             it 'renders' do
-              expect { mail.body }.to_not raise_exception
+              expect { mail.body }.not_to raise_exception
             end
 
             it 'does not create any records' do
-              expect { mail }.to_not change {
+              expect { mail }.not_to change {
                 [Messageboard.count, Topic.count, Post.count, PrivateTopic.count, PrivatePost.count,
                  Thredded.user_class.count, UserDetail.count, MessageboardUser.count]
               }

--- a/spec/support/features/page_object/topic.rb
+++ b/spec/support/features/page_object/topic.rb
@@ -2,31 +2,29 @@ require 'support/features/page_object/base'
 
 module PageObject
   class Topic < Base
-    attr_accessor \
-      :last_post,
-      :messageboard,
-      :topic
-
     def initialize(topic)
       @topic = topic
       @messageboard = topic.messageboard
     end
 
+    def first_post
+      @last_post ||= PageObject::Post.new(@topic.posts.first)
+    end
+
     def last_post
-      post = topic.posts.last
-      @last_post ||= PageObject::Post.new(post)
+      @last_post ||= PageObject::Post.new(@topic.posts.last)
     end
 
     def visit_topic
-      visit messageboard_topic_path(messageboard, topic)
+      visit messageboard_topic_path(@messageboard, @topic)
     end
 
     def visit_topic_edit
-      visit edit_messageboard_topic_path(messageboard, topic)
+      visit edit_messageboard_topic_path(@messageboard, @topic)
     end
 
     def editable?
-      has_css? "form#edit_topic_#{topic.id}"
+      has_css? "form#edit_topic_#{@topic.id}"
     end
 
     def deletable?
@@ -34,7 +32,7 @@ module PageObject
     end
 
     def listed?
-      all('a', text: topic.title).any?
+      all('a', text: @topic.title).any?
     end
 
     def change_title_to(title)

--- a/spec/views/thredded/messageboards/index.html.erb_spec.rb
+++ b/spec/views/thredded/messageboards/index.html.erb_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe 'thredded/messageboards/index' do
   it 'does not show the Create button when not permitted to create a messageboard' do
     render
 
-    expect(rendered).to_not have_link('Create a New Messageboard')
+    expect(rendered).not_to have_link('Create a New Messageboard')
   end
 end


### PR DESCRIPTION
* Clean up permission, fix the private post ones (can now edit and delete own private posts).
* Disallow deletion of the first post of a topic (even by admin).
* Show a notice after deleting a post.
* I18n for post edit/delete links and notices.
* Add **`lib`** to autoload paths and remove the requires. It is no longer necessary to restart the server when changing `lib` code. :wink: 

/cc @jayroh @TheDudeWithTheThing 