### PR TITLE
Update Rubocop and fix warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,182 +3,189 @@
 # one by one as the offences are removed from the code base.
 
 AllCops:
+  TargetRubyVersion: 2.3
   Exclude:
     - 'db/**/*'
     - 'spec/dummy/db/**/*'
     - 'vendor/**/*'
 
-AbcSize:
+Lint/AssignmentInCondition:
+  Enabled: true
+
+Lint/BlockAlignment:
+  Enabled: true
+
+Lint/Debugger:
+  Enabled: true
+
+Lint/EndAlignment:
+  Enabled: true
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+
+Lint/StringConversionInInterpolation:
+  Enabled: true
+
+Lint/UselessAssignment:
+  Enabled: true
+
+Metrics/AbcSize:
   Enabled: false
 
-AccessorMethodName:
-  Enabled: true
-
-Alias:
-  Enabled: false
-
-AlignHash:
-  Enabled: true
-
-AlignParameters:
-  Enabled: false
-
-AssignmentInCondition:
-  Enabled: true
-
-BlockAlignment:
-  Enabled: true
-
-BlockNesting:
+Metrics/BlockNesting:
   Max: 4
 
-BracesAroundHashParameters:
-  Enabled: true
-
-ClassLength:
+Metrics/ClassLength:
   Max: 154
 
-CollectionMethods:
-  Enabled: true
-
-ColonMethodCall:
-  Enabled: true
-
-CyclomaticComplexity:
+Metrics/CyclomaticComplexity:
   Max: 19
 
-Debugger:
-  Enabled: true
-
-Documentation:
-  Enabled: false
-
-DotPosition:
-  Enabled: true
-
-EmptyLines:
-  Enabled: true
-
-EmptyLinesAroundClassBody:
-  Enabled: true
-
-EmptyLinesAroundModuleBody:
-  Enabled: true
-
-EndAlignment:
-  Enabled: true
-
-NegatedIf:
-  Enabled: true
-
-HashSyntax:
-  Enabled: true
-
-IfUnlessModifier:
-  Enabled: false
-
-IndentationWidth:
-  Enabled: true
-
-LineLength:
+Metrics/LineLength:
   Max: 209
 
-MethodLength:
+Metrics/MethodLength:
   Max: 120
 
-ModuleLength:
+Metrics/ModuleLength:
   Max: 175
 
-MultilineTernaryOperator:
-  Enabled: true
-
-MultilineOperationIndentation:
+Metrics/PerceivedComplexity:
   Enabled: false
 
-Next:
+Style/AccessorMethodName:
+  Enabled: true
+
+Style/Alias:
   Enabled: false
 
-NumericLiterals:
+Style/AlignHash:
   Enabled: true
 
-ParenthesesAroundCondition:
-  Enabled: true
-
-ParenthesesAsGroupedExpression:
-  Enabled: true
-
-PerceivedComplexity:
+Style/AlignParameters:
   Enabled: false
 
-PerlBackrefs:
+Style/BracesAroundHashParameters:
   Enabled: true
 
-PredicateName:
+Style/CollectionMethods:
+  Enabled: true
+
+Style/ColonMethodCall:
+  Enabled: true
+
+Style/Documentation:
+  Enabled: false
+
+Style/DotPosition:
+  Enabled: true
+
+Style/EmptyLines:
+  Enabled: true
+
+Style/EmptyLinesAroundClassBody:
+  Enabled: true
+
+Style/EmptyLinesAroundModuleBody:
+  Enabled: true
+
+Style/NegatedIf:
+  Enabled: true
+
+Style/HashSyntax:
+  Enabled: true
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/IndentationWidth:
+  Enabled: true
+
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Style/MultilineTernaryOperator:
+  Enabled: true
+
+Style/MultilineOperationIndentation:
+  Enabled: false
+
+Style/Next:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: true
+
+Style/ParenthesesAroundCondition:
+  Enabled: true
+
+Style/PerlBackrefs:
+  Enabled: true
+
+Style/PredicateName:
   Enabled: true
   Exclude:
     - !ruby/regexp /(\/)?spec\/.*/
 
-Proc:
+Style/Proc:
   Enabled: false
 
-RescueException:
+Style/RedundantSelf:
   Enabled: true
 
-RedundantSelf:
+Style/RegexpLiteral:
   Enabled: true
 
-RegexpLiteral:
-  Enabled: true
+Style/SignalException:
+  EnforcedStyle: semantic
 
-ShadowingOuterLocalVariable:
-  Enabled: true
-
-SignalException:
-  Enabled: true
-
-SingleLineBlockParams:
+Style/StabbyLambdaParentheses:
   Enabled: false
 
-SpaceAfterColon:
+Style/SingleLineBlockParams:
+  Enabled: false
+
+Style/SpaceAfterColon:
   Enabled: true
 
-SpaceAfterComma:
+Style/SpaceAfterComma:
   Enabled: true
 
-SpaceBeforeBlockBraces:
+Style/SpaceBeforeBlockBraces:
   Enabled: true
 
-SpaceInsideBlockBraces:
+Style/SpaceInsideBlockBraces:
   Enabled: true
 
-SpaceAroundEqualsInParameterDefault:
+Style/SpaceAroundEqualsInParameterDefault:
   Enabled: true
 
-SpaceInsideHashLiteralBraces:
+Style/SpaceInsideHashLiteralBraces:
   Enabled: true
 
-SpaceInsideParens:
+Style/SpaceInsideParens:
   Enabled: true
 
-StringConversionInInterpolation:
-  Enabled: true
-
-StringLiterals:
+Style/StringLiterals:
   Enabled: true
   Exclude:
     - !ruby/regexp /\/db\/migrate\/.*/
 
-TrailingBlankLines:
+Style/TrailingBlankLines:
   Enabled: true
 
-TrailingWhitespace:
+Style/TrailingWhitespace:
   Enabled: true
 
-TrailingComma:
+Style/TrailingCommaInLiteral:
   Enabled: false
 
-UselessAssignment:
-  Enabled: true
+Style/TrailingCommaInArguments:
+  Enabled: false
 
-WordArray:
+Style/WordArray:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-#!/usr/bin/env rake
+# frozen_string_literal: true
 begin
   require 'bundler/setup'
 rescue LoadError

--- a/app/commands/thredded/at_notification_extractor.rb
+++ b/app/commands/thredded/at_notification_extractor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class AtNotificationExtractor
     def initialize(content)

--- a/app/commands/thredded/members_marked_notified.rb
+++ b/app/commands/thredded/members_marked_notified.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class MembersMarkedNotified
     def initialize(post, members)

--- a/app/commands/thredded/messageboard_destroyer.rb
+++ b/app/commands/thredded/messageboard_destroyer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class MessageboardDestroyer
     def initialize(messageboard_name)

--- a/app/commands/thredded/notify_mentioned_users.rb
+++ b/app/commands/thredded/notify_mentioned_users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class NotifyMentionedUsers
     def initialize(post)

--- a/app/commands/thredded/notify_private_topic_users.rb
+++ b/app/commands/thredded/notify_private_topic_users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class NotifyPrivateTopicUsers
     def initialize(private_topic)

--- a/app/commands/thredded/user_reads_private_topic.rb
+++ b/app/commands/thredded/user_reads_private_topic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class UserReadsPrivateTopic
     def initialize(private_topic, user)

--- a/app/commands/thredded/user_resets_private_topic_to_unread.rb
+++ b/app/commands/thredded/user_resets_private_topic_to_unread.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class UserResetsPrivateTopicToUnread
     def initialize(private_topic, user)

--- a/app/controllers/thredded/application_controller.rb
+++ b/app/controllers/thredded/application_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class ApplicationController < ::ApplicationController
     layout Thredded.layout

--- a/app/controllers/thredded/autocomplete_users_controller.rb
+++ b/app/controllers/thredded/autocomplete_users_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class AutocompleteUsersController < Thredded::ApplicationController
     MIN_QUERY_LENGTH = 2

--- a/app/controllers/thredded/messageboards_controller.rb
+++ b/app/controllers/thredded/messageboards_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class MessageboardsController < Thredded::ApplicationController
     def index

--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PostsController < Thredded::ApplicationController
     include ActionView::RecordIdentifier
@@ -44,10 +45,9 @@ module Thredded
     end
 
     def post_params
-      p = params
-            .require(:post)
-            .permit(:content)
-            .merge(user: thredded_current_user, ip: request.remote_ip)
+      p = params.require(:post)
+        .permit(:content)
+        .merge(user: thredded_current_user, ip: request.remote_ip)
       p = p.merge(messageboard: messageboard) unless for_a_private_topic?
       p
     end

--- a/app/controllers/thredded/preferences_controller.rb
+++ b/app/controllers/thredded/preferences_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PreferencesController < Thredded::ApplicationController
     before_action :thredded_require_login!,

--- a/app/controllers/thredded/private_topics_controller.rb
+++ b/app/controllers/thredded/private_topics_controller.rb
@@ -1,18 +1,20 @@
+# frozen_string_literal: true
 module Thredded
   class PrivateTopicsController < Thredded::ApplicationController
     helper_method :private_topic
 
     def index
-      @new_private_topic        = PrivateTopicForm.new(user: thredded_current_user)
-      @private_topics           = PrivateTopic
-                                    .distinct
-                                    .for_user(thredded_current_user)
-                                    .order('updated_at DESC')
-                                    .includes(:last_user, :user)
-                                    .on_page(params[:page])
-                                    .load
+      @private_topics = PrivateTopic
+        .distinct
+        .for_user(thredded_current_user)
+        .order('updated_at DESC')
+        .includes(:last_user, :user)
+        .on_page(params[:page])
+        .load
       @decorated_private_topics = Thredded::UserPrivateTopicDecorator
-                                    .decorate_all(thredded_current_user, @private_topics)
+        .decorate_all(thredded_current_user, @private_topics)
+
+      @new_private_topic = PrivateTopicForm.new(user: thredded_current_user)
     end
 
     def show
@@ -20,9 +22,9 @@ module Thredded
       UserReadsPrivateTopic.new(private_topic, thredded_current_user).run
 
       @posts = private_topic
-                 .posts
-                 .includes(:user)
-                 .order_oldest_first
+        .posts
+        .includes(:user)
+        .order_oldest_first
 
       @post = private_topic.posts.build
     end

--- a/app/controllers/thredded/setups_controller.rb
+++ b/app/controllers/thredded/setups_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class SetupsController < Thredded::ApplicationController
     def new

--- a/app/controllers/thredded/theme_previews_controller.rb
+++ b/app/controllers/thredded/theme_previews_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class ThemePreviewsController < Thredded::ApplicationController
     def show

--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class TopicsController < Thredded::ApplicationController
     helper_method :current_page, :topic, :user_topic
@@ -7,10 +8,10 @@ module Thredded
       authorize_reading messageboard
 
       @topics = messageboard.topics
-                  .order_sticky_first.order_recently_updated_first
-                  .includes(:categories, :last_user, :user)
-                  .on_page(current_page)
-                  .load
+        .order_sticky_first.order_recently_updated_first
+        .includes(:categories, :last_user, :user)
+        .on_page(current_page)
+        .load
       @decorated_topics = Thredded::UserTopicDecorator
         .decorate_all(thredded_current_user, @topics)
       initialize_new_topic.tap do |new_topic|
@@ -34,10 +35,10 @@ module Thredded
     def search
       @query = params[:q].to_s
       @topics = (messageboard_or_nil ? messageboard.topics : Topic)
-                  .search_query(@query)
-                  .order_recently_updated_first
-                  .includes(:categories, :last_user, :user)
-                  .page(current_page)
+        .search_query(@query)
+        .order_recently_updated_first
+        .includes(:categories, :last_user, :user)
+        .page(current_page)
       @decorated_topics = Thredded::UserTopicDecorator
         .decorate_all(thredded_current_user, @topics)
     end

--- a/app/decorators/thredded/base_topic_decorator.rb
+++ b/app/decorators/thredded/base_topic_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class BaseTopicDecorator < SimpleDelegator
     include Rails.application.routes.url_helpers

--- a/app/decorators/thredded/base_user_topic_decorator.rb
+++ b/app/decorators/thredded/base_user_topic_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class BaseUserTopicDecorator < SimpleDelegator
     extend ActiveModel::Naming

--- a/app/decorators/thredded/messageboard_decorator.rb
+++ b/app/decorators/thredded/messageboard_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class MessageboardDecorator < SimpleDelegator
     def initialize(messageboard)

--- a/app/decorators/thredded/post_decorator.rb
+++ b/app/decorators/thredded/post_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PostDecorator < SimpleDelegator
     attr_reader :post

--- a/app/decorators/thredded/private_topic_decorator.rb
+++ b/app/decorators/thredded/private_topic_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PrivateTopicDecorator < SimpleDelegator
     def initialize(private_topic)

--- a/app/decorators/thredded/topic_decorator.rb
+++ b/app/decorators/thredded/topic_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class TopicDecorator < SimpleDelegator
     def initialize(private_topic)

--- a/app/decorators/thredded/topic_email_decorator.rb
+++ b/app/decorators/thredded/topic_email_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class TopicEmailDecorator
     # @param [Thredded::TopicCommon] topic

--- a/app/decorators/thredded/user_private_topic_decorator.rb
+++ b/app/decorators/thredded/user_private_topic_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class UserPrivateTopicDecorator < BaseUserTopicDecorator
     def self.topic_class

--- a/app/decorators/thredded/user_topic_decorator.rb
+++ b/app/decorators/thredded/user_topic_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class UserTopicDecorator < BaseUserTopicDecorator
     def self.topic_class

--- a/app/forms/thredded/private_topic_form.rb
+++ b/app/forms/thredded/private_topic_form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PrivateTopicForm
     include ActiveModel::Model

--- a/app/forms/thredded/topic_form.rb
+++ b/app/forms/thredded/topic_form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class TopicForm
     include ActiveModel::Model

--- a/app/forms/thredded/user_preferences_form.rb
+++ b/app/forms/thredded/user_preferences_form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class UserPreferencesForm
     include ActiveModel::Model

--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module ApplicationHelper
     include ::Thredded::UrlsHelper

--- a/app/helpers/thredded/urls_helper.rb
+++ b/app/helpers/thredded/urls_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module UrlsHelper
     # @param user [Thredded.user_class, Thredded::NullUser]

--- a/app/jobs/thredded/activity_updater_job.rb
+++ b/app/jobs/thredded/activity_updater_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class ActivityUpdaterJob < ::ActiveJob::Base
     queue_as :default

--- a/app/jobs/thredded/at_notifier_job.rb
+++ b/app/jobs/thredded/at_notifier_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class AtNotifierJob < ::ActiveJob::Base
     queue_as :default

--- a/app/jobs/thredded/notify_private_topic_users_job.rb
+++ b/app/jobs/thredded/notify_private_topic_users_job.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class NotifyPrivateTopicUsersJob < ::ActiveJob::Base
     queue_as :default

--- a/app/mailer_previews/thredded/base_mailer_preview.rb
+++ b/app/mailer_previews/thredded/base_mailer_preview.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   # A base class for Thredded mailer previews.
   # @abstract

--- a/app/mailer_previews/thredded/post_mailer_preview.rb
+++ b/app/mailer_previews/thredded/post_mailer_preview.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   # Previews for the PostMailer
   class PostMailerPreview < BaseMailerPreview

--- a/app/mailer_previews/thredded/private_post_mailer_preview.rb
+++ b/app/mailer_previews/thredded/private_post_mailer_preview.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   # Previews for the PrivatePostMailer
   class PrivatePostMailerPreview < BaseMailerPreview

--- a/app/mailer_previews/thredded/private_topic_mailer_preview.rb
+++ b/app/mailer_previews/thredded/private_topic_mailer_preview.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   # Previews for the PrivateTopicMailer
   class PrivateTopicMailerPreview < BaseMailerPreview

--- a/app/mailers/thredded/base_mailer.rb
+++ b/app/mailers/thredded/base_mailer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class BaseMailer < ActionMailer::Base
     helper ::Thredded::UrlsHelper

--- a/app/mailers/thredded/post_mailer.rb
+++ b/app/mailers/thredded/post_mailer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PostMailer < Thredded::BaseMailer
     def at_notification(post_id, emails)

--- a/app/mailers/thredded/private_post_mailer.rb
+++ b/app/mailers/thredded/private_post_mailer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PrivatePostMailer < Thredded::BaseMailer
     def at_notification(post_id, emails)

--- a/app/mailers/thredded/private_topic_mailer.rb
+++ b/app/mailers/thredded/private_topic_mailer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PrivateTopicMailer < Thredded::BaseMailer
     def message_notification(private_topic_id, emails)

--- a/app/models/concerns/thredded/friendly_id_reserved_words_and_pagination.rb
+++ b/app/models/concerns/thredded/friendly_id_reserved_words_and_pagination.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'set'
 module Thredded
   # Excludes pagination routes in addition to the given list of reserved words.

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module PostCommon
     extend ActiveSupport::Concern

--- a/app/models/concerns/thredded/topic_common.rb
+++ b/app/models/concerns/thredded/topic_common.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 module Thredded
   module TopicCommon
     extend ActiveSupport::Concern
     included do
-      paginates_per 50 if self.respond_to?(:paginates_per)
+      paginates_per 50 if respond_to?(:paginates_per)
 
       belongs_to :last_user,
                  class_name: Thredded.user_class,

--- a/app/models/thredded/ability.rb
+++ b/app/models/thredded/ability.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class Ability
     include ::CanCan::Ability

--- a/app/models/thredded/category.rb
+++ b/app/models/thredded/category.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class Category < ActiveRecord::Base
     extend FriendlyId

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class Messageboard < ActiveRecord::Base
     extend FriendlyId

--- a/app/models/thredded/messageboard_user.rb
+++ b/app/models/thredded/messageboard_user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   # The state of a user with regards to a messageboard, such as the last time the user was active (visited)
   # the messageboard.

--- a/app/models/thredded/null_preference.rb
+++ b/app/models/thredded/null_preference.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class NullPreference
     def notify_on_mention

--- a/app/models/thredded/null_topic_read.rb
+++ b/app/models/thredded/null_topic_read.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class NullTopicRead
     def page

--- a/app/models/thredded/null_user.rb
+++ b/app/models/thredded/null_user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class NullUser
     include ::Thredded::UserPermissions::Read::All

--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class Post < ActiveRecord::Base
     include PostCommon

--- a/app/models/thredded/post_notification.rb
+++ b/app/models/thredded/post_notification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   # Keeps track of post notifications that have been sent already.
   class PostNotification < ActiveRecord::Base

--- a/app/models/thredded/private_post.rb
+++ b/app/models/thredded/private_post.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PrivatePost < ActiveRecord::Base
     include PostCommon

--- a/app/models/thredded/private_topic.rb
+++ b/app/models/thredded/private_topic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PrivateTopic < ActiveRecord::Base
     include TopicCommon

--- a/app/models/thredded/private_user.rb
+++ b/app/models/thredded/private_user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PrivateUser < ActiveRecord::Base
     belongs_to :private_topic, inverse_of: :private_users

--- a/app/models/thredded/stats.rb
+++ b/app/models/thredded/stats.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class Stats
     include ActionView::Helpers::NumberHelper

--- a/app/models/thredded/topic.rb
+++ b/app/models/thredded/topic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class Topic < ActiveRecord::Base
     include TopicCommon

--- a/app/models/thredded/topic_category.rb
+++ b/app/models/thredded/topic_category.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class TopicCategory < ActiveRecord::Base
     belongs_to :category

--- a/app/models/thredded/user_detail.rb
+++ b/app/models/thredded/user_detail.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class UserDetail < ActiveRecord::Base
     belongs_to :user, class_name: Thredded.user_class, inverse_of: :thredded_user_detail

--- a/app/models/thredded/user_extender.rb
+++ b/app/models/thredded/user_extender.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module UserExtender
     extend ActiveSupport::Concern

--- a/app/models/thredded/user_messageboard_preference.rb
+++ b/app/models/thredded/user_messageboard_preference.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class UserMessageboardPreference < ActiveRecord::Base
     belongs_to :user_preference,

--- a/app/models/thredded/user_permissions/admin/if_admin_column_true.rb
+++ b/app/models/thredded/user_permissions/admin/if_admin_column_true.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module UserPermissions
     module Admin

--- a/app/models/thredded/user_permissions/admin/none.rb
+++ b/app/models/thredded/user_permissions/admin/none.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module UserPermissions
     module Admin

--- a/app/models/thredded/user_permissions/message/readers_of_writeable_boards.rb
+++ b/app/models/thredded/user_permissions/message/readers_of_writeable_boards.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module UserPermissions
     module Message

--- a/app/models/thredded/user_permissions/moderate/if_moderator_column_true.rb
+++ b/app/models/thredded/user_permissions/moderate/if_moderator_column_true.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module UserPermissions
     module Moderate

--- a/app/models/thredded/user_permissions/moderate/none.rb
+++ b/app/models/thredded/user_permissions/moderate/none.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module UserPermissions
     module Moderate

--- a/app/models/thredded/user_permissions/read/all.rb
+++ b/app/models/thredded/user_permissions/read/all.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module UserPermissions
     module Read

--- a/app/models/thredded/user_permissions/write/all.rb
+++ b/app/models/thredded/user_permissions/write/all.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module UserPermissions
     module Write

--- a/app/models/thredded/user_permissions/write/none.rb
+++ b/app/models/thredded/user_permissions/write/none.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module UserPermissions
     module Write

--- a/app/models/thredded/user_preference.rb
+++ b/app/models/thredded/user_preference.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class UserPreference < ActiveRecord::Base
     belongs_to :user, class_name: Thredded.user_class, inverse_of: :thredded_user_preference

--- a/app/models/thredded/user_topic_read.rb
+++ b/app/models/thredded/user_topic_read.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class UserTopicRead < ActiveRecord::Base
     belongs_to :topic

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Thredded::Engine.routes.draw do
   resource :theme_preview, only: [:show], path: 'theme-preview' if %w(development test).include? Rails.env
 

--- a/db/migrate/20160329231848_create_thredded.rb
+++ b/db/migrate/20160329231848_create_thredded.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CreateThredded < ActiveRecord::Migration
   def change
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'factory_girl_rails'
 
 # rubocop:disable HandleExceptions

--- a/db/upgrade_migrations/20160410111522_upgrade_v0_2_to_v0_3.rb
+++ b/db/upgrade_migrations/20160410111522_upgrade_v0_2_to_v0_3.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class UpgradeV02ToV03 < ActiveRecord::Migration
   def up
     remove_index :thredded_notification_preferences, name: :index_thredded_notification_preferences_on_messageboard_id

--- a/lib/generators/thredded/install/install_generator.rb
+++ b/lib/generators/thredded/install/install_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   module Generators
     class InstallGenerator < Rails::Generators::Base

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Thredded configuration
 
 # ==> User Configuration

--- a/lib/html/pipeline/at_mention_filter.rb
+++ b/lib/html/pipeline/at_mention_filter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'thredded/at_users'
 
 module HTML
@@ -5,7 +6,7 @@ module HTML
     class AtMentionFilter < Filter
       def initialize(text, context = nil, result = nil)
         super text, context, result
-        @text = text.to_s.gsub "\r", ''
+        @text = text.to_s.delete("\r")
         @post = context[:post]
         @view_context = context[:view_context]
       end

--- a/lib/html/pipeline/bbcode_filter.rb
+++ b/lib/html/pipeline/bbcode_filter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bbcoder'
 
 module HTML
@@ -10,7 +11,7 @@ module HTML
       def call
         html = BBCoder.new(@text).to_html
         html = remove_url_link_contents(html)
-        html.gsub('<br>', '')
+        html.delete('<br>')
         html.rstrip!
         html
       end

--- a/lib/tasks/thredded_tasks.rake
+++ b/lib/tasks/thredded_tasks.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 namespace :thredded do
   desc 'Destroy messageboard and all related data'
   task :destroy, [:slug] => :environment do |_, args|

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Backend
 require 'cancan'
 require 'active_record_union'

--- a/lib/thredded/at_users.rb
+++ b/lib/thredded/at_users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class AtUsers
     def self.render(content, post, view_context)

--- a/lib/thredded/engine.rb
+++ b/lib/thredded/engine.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class Engine < ::Rails::Engine
     isolate_namespace Thredded

--- a/lib/thredded/errors.rb
+++ b/lib/thredded/errors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class Error < StandardError
   end

--- a/lib/thredded/main_app_route_delegator.rb
+++ b/lib/thredded/main_app_route_delegator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   # If thredded is rendered within an application layout, this module allows
   # referring to the routes in the layout directly, without having to use `main_app.`.

--- a/lib/thredded/messageboard_user_permissions.rb
+++ b/lib/thredded/messageboard_user_permissions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class MessageboardUserPermissions
     attr_reader :messageboard, :user

--- a/lib/thredded/post_user_permissions.rb
+++ b/lib/thredded/post_user_permissions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PostUserPermissions
     # @param post [Thredded::Post]

--- a/lib/thredded/private_post_user_permissions.rb
+++ b/lib/thredded/private_post_user_permissions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PrivatePostUserPermissions
     # @param post [Thredded::PrivatePost]

--- a/lib/thredded/private_topic_user_permissions.rb
+++ b/lib/thredded/private_topic_user_permissions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class PrivateTopicUserPermissions
     def initialize(private_topic, user)

--- a/lib/thredded/search_parser.rb
+++ b/lib/thredded/search_parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class SearchParser
     def initialize(query)
@@ -21,7 +22,7 @@ module Thredded
 
         if keyword_scan.present?
           keyword_scan.each do |term|
-            keyword_term = term.gsub(' ', '').split(':')
+            keyword_term = term.delete(' ').split(':')
 
             if found_terms_hash[keyword].nil?
               found_terms_hash[keyword] = []

--- a/lib/thredded/topic_user_permissions.rb
+++ b/lib/thredded/topic_user_permissions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   class TopicUserPermissions
     def initialize(topic, user)

--- a/lib/thredded/topics_search.rb
+++ b/lib/thredded/topics_search.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'thredded/search_parser'
 module Thredded
   class TopicsSearch
@@ -39,7 +40,8 @@ module Thredded
     def categories
       @search_categories ||=
         if @terms['in'].present?
-          DbTextSearch::CaseInsensitive.new(Category, :name)
+          DbTextSearch::CaseInsensitive
+            .new(Category, :name)
             .in(@terms['in']).pluck(:id)
         else
           []
@@ -49,7 +51,8 @@ module Thredded
     def users
       @search_users ||=
         if @terms['by']
-          DbTextSearch::CaseInsensitive.new(Thredded.user_class, Thredded.user_name_column)
+          DbTextSearch::CaseInsensitive
+            .new(Thredded.user_class, Thredded.user_name_column)
             .in(@terms['by']).pluck(:id)
         else
           []

--- a/lib/thredded/version.rb
+++ b/lib/thredded/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Thredded
   VERSION = '0.2.2'
 end

--- a/script/rails
+++ b/script/rails
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path('../..', __FILE__)

--- a/spec/commands/thredded/messageboard_destroyer_spec.rb
+++ b/spec/commands/thredded/messageboard_destroyer_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/commands/thredded/notify_mentioned_users_spec.rb
+++ b/spec/commands/thredded/notify_mentioned_users_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded
@@ -116,7 +117,7 @@ module Thredded
 
   describe NotifyMentionedUsers, '#notifications_for_at_users' do
     before do
-      sam  = create(:user, name: 'sam')
+      sam = create(:user, name: 'sam')
       @joel = create(:user, name: 'joel', email: 'joel@example.com')
       @john = create(:user, name: 'john', email: 'john@example.com')
       @post = create_post_by(sam)

--- a/spec/commands/thredded/notify_private_topic_users_spec.rb
+++ b/spec/commands/thredded/notify_private_topic_users_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/commands/thredded/user_reads_private_topic_spec.rb
+++ b/spec/commands/thredded/user_reads_private_topic_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/commands/thredded/user_resets_private_topic_to_unread_spec.rb
+++ b/spec/commands/thredded/user_resets_private_topic_to_unread_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/controllers/thredded/topics_controller_spec.rb
+++ b/spec/controllers/thredded/topics_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/decorators/thredded/post_decorator_spec.rb
+++ b/spec/decorators/thredded/post_decorator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/decorators/thredded/private_topic_decorator_spec.rb
+++ b/spec/decorators/thredded/private_topic_decorator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/decorators/thredded/topic_decorator_spec.rb
+++ b/spec/decorators/thredded/topic_decorator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/decorators/thredded/topic_email_decorator_spec.rb
+++ b/spec/decorators/thredded/topic_email_decorator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/decorators/thredded/user_topic_decorator_spec.rb
+++ b/spec/decorators/thredded/user_topic_decorator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/dummy/Rakefile
+++ b/spec/dummy/Rakefile
@@ -1,4 +1,4 @@
-#!/usr/bin/env rake
+# frozen_string_literal: true
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationController < ActionController::Base
   protect_from_forgery
   helper_method :signed_in?, :current_user

--- a/spec/dummy/app/controllers/sessions_controller.rb
+++ b/spec/dummy/app/controllers/sessions_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SessionsController < ApplicationController
   def new
   end

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class UsersController < ApplicationController
   def show
     @slug = params[:id].to_s

--- a/spec/dummy/app/helpers/application_helper.rb
+++ b/spec/dummy/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 module ApplicationHelper
-  VALID_THEMES = %w(default dark)
+  VALID_THEMES = %w(default dark).freeze
 
   def themes
     VALID_THEMES

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class User < ActiveRecord::Base
   validates :name, presence: true
 

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,4 +1,5 @@
+# frozen_string_literal: true
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run Dummy::Application

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../boot', __FILE__)
 
 require 'active_record/railtie'

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 require 'bundler/setup'

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Dummy::Application.configure do
   config.eager_load = false
 

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Dummy::Application.configure do
   config.eager_load = true
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Dummy::Application.configure do
   config.assets.compress = false
   config.assets.debug = true

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 Rails.application.config.assets.precompile += %w( default.css dark.css )

--- a/spec/dummy/config/initializers/backtrace_silencers.rb
+++ b/spec/dummy/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/spec/dummy/config/initializers/inflections.rb
+++ b/spec/dummy/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format

--- a/spec/dummy/config/initializers/mime_types.rb
+++ b/spec/dummy/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/spec/dummy/config/initializers/rails_email_preview.rb
+++ b/spec/dummy/config/initializers/rails_email_preview.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.config.to_prepare do
   RailsEmailPreview.setup do |config|
     config.layout            = 'application'

--- a/spec/dummy/config/initializers/secret_token.rb
+++ b/spec/dummy/config/initializers/secret_token.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Your secret key for verifying the integrity of signed cookies.

--- a/spec/dummy/config/initializers/session_store.rb
+++ b/spec/dummy/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 Dummy::Application.config.session_store :cookie_store, key: '_dummy_session'

--- a/spec/dummy/config/initializers/thredded.rb
+++ b/spec/dummy/config/initializers/thredded.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Thredded.user_class = 'User'
 Thredded.user_name_column = :name
 Thredded.user_path = ->(user) { main_app.user_path(user.to_param) }

--- a/spec/dummy/config/initializers/wrap_parameters.rb
+++ b/spec/dummy/config/initializers/wrap_parameters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 #
 # This file contains settings for ActionController::ParamsWrapper which

--- a/spec/dummy/config/puma.rb
+++ b/spec/dummy/config/puma.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
 
 # The environment variable WEB_CONCURRENCY may be set to a default value based

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.routes.draw do
   root to: 'application#index'
 

--- a/spec/dummy/db/migrate/20130430210842_create_users.rb
+++ b/spec/dummy/db/migrate/20130430210842_create_users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CreateUsers < ActiveRecord::Migration
   def change
     create_table :users do |t|

--- a/spec/dummy/db/migrate/20160308104204_add_admin_to_users.rb
+++ b/spec/dummy/db/migrate/20160308104204_add_admin_to_users.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddAdminToUsers < ActiveRecord::Migration
   def change
     add_column :users, :admin, :boolean, default: false, null: false

--- a/spec/dummy/db/seeds.rb
+++ b/spec/dummy/db/seeds.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 Thredded::Engine.load_seed

--- a/spec/dummy/script/rails
+++ b/spec/dummy/script/rails
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
-require File.expand_path('../../config/boot',  __FILE__)
+APP_PATH = File.expand_path('../../config/application', __FILE__)
+require File.expand_path('../../config/boot', __FILE__)
 require 'rails/commands'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'faker'
 I18n.reload!
 include ActionDispatch::TestProcess

--- a/spec/features/thredded/user_creates_messageboard_spec.rb
+++ b/spec/features/thredded/user_creates_messageboard_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'Creating a messageboard' do

--- a/spec/features/thredded/user_creates_new_topic_spec.rb
+++ b/spec/features/thredded/user_creates_new_topic_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User creates new topic' do

--- a/spec/features/thredded/user_deletes_post_spec.rb
+++ b/spec/features/thredded/user_deletes_post_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User deleting posts' do

--- a/spec/features/thredded/user_deletes_topic_spec.rb
+++ b/spec/features/thredded/user_deletes_topic_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User deleting topics' do

--- a/spec/features/thredded/user_edits_post_spec.rb
+++ b/spec/features/thredded/user_edits_post_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User editing posts' do

--- a/spec/features/thredded/user_edits_topic_spec.rb
+++ b/spec/features/thredded/user_edits_topic_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User editing topics' do

--- a/spec/features/thredded/user_replies_to_post_spec.rb
+++ b/spec/features/thredded/user_replies_to_post_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User replying to topic' do

--- a/spec/features/thredded/user_searches_for_topics_spec.rb
+++ b/spec/features/thredded/user_searches_for_topics_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User searching topics' do

--- a/spec/features/thredded/user_sends_new_private_topic_spec.rb
+++ b/spec/features/thredded/user_sends_new_private_topic_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User sends a new private topic' do

--- a/spec/features/thredded/user_tracks_read_topics_and_posts_spec.rb
+++ b/spec/features/thredded/user_tracks_read_topics_and_posts_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User tracking what they have and have not already read' do

--- a/spec/features/thredded/user_updates_preferences_spec.rb
+++ b/spec/features/thredded/user_updates_preferences_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 require 'support/features/page_object/notification_preferences'
 

--- a/spec/features/thredded/user_views_private_topics_spec.rb
+++ b/spec/features/thredded/user_views_private_topics_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User viewing private topics' do

--- a/spec/features/thredded/user_views_topics_spec.rb
+++ b/spec/features/thredded/user_views_topics_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User viewing topics' do

--- a/spec/features/thredded/visitor_signs_in_spec.rb
+++ b/spec/features/thredded/visitor_signs_in_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'Signing in' do

--- a/spec/jobs/thredded/activity_updater_job_spec.rb
+++ b/spec/jobs/thredded/activity_updater_job_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/lib/thredded/post_user_permissions_spec.rb
+++ b/spec/lib/thredded/post_user_permissions_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 require 'thredded/post_user_permissions'
 

--- a/spec/lib/thredded/private_topic_user_permissions_spec.rb
+++ b/spec/lib/thredded/private_topic_user_permissions_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 require 'thredded/topic_user_permissions'
 require 'thredded/private_topic_user_permissions'

--- a/spec/lib/thredded/topic_user_permissions_spec.rb
+++ b/spec/lib/thredded/topic_user_permissions_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 require 'thredded/topic_user_permissions'
 

--- a/spec/lib/thredded_spec.rb
+++ b/spec/lib/thredded_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Thredded, '.user_path' do

--- a/spec/mailers/thredded/mailer_previews_spec.rb
+++ b/spec/mailers/thredded/mailer_previews_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/mailers/thredded/post_mailer_spec.rb
+++ b/spec/mailers/thredded/post_mailer_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/models/factories_spec.rb
+++ b/spec/models/factories_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 FactoryGirl.factories.map(&:name).each do |factory_name|

--- a/spec/models/thredded/category_spec.rb
+++ b/spec/models/thredded/category_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/models/thredded/messageboard_spec.rb
+++ b/spec/models/thredded/messageboard_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/models/thredded/post_notification_spec.rb
+++ b/spec/models/thredded/post_notification_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/models/thredded/post_spec.rb
+++ b/spec/models/thredded/post_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded
@@ -51,7 +52,7 @@ module Thredded
     end
 
     it "increments the topic's and user's post counts" do
-      joel  = create(:user)
+      joel = create(:user)
       joel_details = create(:user_detail, user: joel)
       topic = create(:topic)
       create_list(:post, 3, postable: topic, user: joel)
@@ -83,7 +84,7 @@ module Thredded
 
   describe Post, '#filtered_content' do
     let(:view_context) { ViewContextStub }
-    before(:each) { @post  = build(:post) }
+    before(:each) { @post = build(:post) }
     after { Thredded.user_path = nil }
 
     module ViewContextStub
@@ -99,7 +100,7 @@ module Thredded
     it 'renders more bbcode' do
       @post.content = 'this is [b]bold[/b]'
       expect(@post.filtered_content(view_context))
-          .to eq('<p>this is <strong>bold</strong></p>')
+        .to eq('<p>this is <strong>bold</strong></p>')
     end
 
     it 'handles bbcode quotes' do
@@ -203,7 +204,7 @@ module Thredded
     end
 
     def parsed_html(html)
-      Nokogiri::HTML::DocumentFragment.parse(html) { |config| config.noblanks }
+      Nokogiri::HTML::DocumentFragment.parse(html, &:noblanks)
         .to_html
         .gsub(/^\s*/, '')
         .gsub(/\s*$/, '')

--- a/spec/models/thredded/private_topic_spec.rb
+++ b/spec/models/thredded/private_topic_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/models/thredded/private_user_spec.rb
+++ b/spec/models/thredded/private_user_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/models/thredded/topic_spec.rb
+++ b/spec/models/thredded/topic_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded
@@ -125,7 +126,7 @@ module Thredded
     before(:each) do
       @user = create(:user)
       @messageboard = create(:messageboard)
-      @topic  = create(:topic, messageboard: @messageboard)
+      @topic = create(:topic, messageboard: @messageboard)
     end
 
     it 'is associated with a messageboard' do

--- a/spec/models/thredded/user_detail_spec.rb
+++ b/spec/models/thredded/user_detail_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/models/thredded/user_topic_read_spec.rb
+++ b/spec/models/thredded/user_topic_read_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module Thredded

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe User, '.to_s' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['RAILS_ENV'] = 'test'
 if ENV['TRAVIS'] && !(defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx')
   require 'codeclimate-test-reporter'
@@ -45,8 +46,7 @@ Dir[Rails.root.join('../../spec/support/**/*.rb')].each { |f| require f }
 counter = -1
 
 FileUtils.mkdir('log') unless File.directory?('log')
-ActiveRecord::SchemaMigration.logger = ActiveRecord::Base.logger =
-  Logger.new(File.open("log/test.#{db}.log", 'w'))
+ActiveRecord::SchemaMigration.logger = ActiveRecord::Base.logger = Logger.new(File.open("log/test.#{db}.log", 'w'))
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!

--- a/spec/support/features/page_object/authentication.rb
+++ b/spec/support/features/page_object/authentication.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module PageObject
   module Authentication
     def logged_in?

--- a/spec/support/features/page_object/base.rb
+++ b/spec/support/features/page_object/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module PageObject
   class Base
     include Capybara::DSL

--- a/spec/support/features/page_object/messageboards.rb
+++ b/spec/support/features/page_object/messageboards.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support/features/page_object/base'
 
 module PageObject

--- a/spec/support/features/page_object/navigation.rb
+++ b/spec/support/features/page_object/navigation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support/features/page_object/base'
 
 module PageObject

--- a/spec/support/features/page_object/new_messageboard.rb
+++ b/spec/support/features/page_object/new_messageboard.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module PageObject
   class NewMessageboard
     include Capybara::DSL

--- a/spec/support/features/page_object/notification_preferences.rb
+++ b/spec/support/features/page_object/notification_preferences.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support/features/page_object/base'
 
 module PageObject

--- a/spec/support/features/page_object/post.rb
+++ b/spec/support/features/page_object/post.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support/features/page_object/base'
 
 module PageObject

--- a/spec/support/features/page_object/posts.rb
+++ b/spec/support/features/page_object/posts.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support/features/page_object/base'
 
 module PageObject

--- a/spec/support/features/page_object/private_topics.rb
+++ b/spec/support/features/page_object/private_topics.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support/features/page_object/base'
 
 module PageObject

--- a/spec/support/features/page_object/topic.rb
+++ b/spec/support/features/page_object/topic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support/features/page_object/base'
 
 module PageObject

--- a/spec/support/features/page_object/topics.rb
+++ b/spec/support/features/page_object/topics.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support/features/page_object/base'
 
 module PageObject

--- a/spec/support/features/page_object/user.rb
+++ b/spec/support/features/page_object/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module PageObject
   class User
     include Capybara::DSL

--- a/spec/support/features/page_object/visitor.rb
+++ b/spec/support/features/page_object/visitor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative './authentication'
 
 module PageObject

--- a/spec/support/matchers/eager_load.rb
+++ b/spec/support/matchers/eager_load.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class EagerLoad
   def initialize(association)
     @association = association

--- a/spec/views/thredded/messageboards/index.html.erb_spec.rb
+++ b/spec/views/thredded/messageboards/index.html.erb_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'thredded/messageboards/index' do

--- a/spec/views/thredded/shared/time_ago_spec.rb
+++ b/spec/views/thredded/shared/time_ago_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'partial: thredded/shared/time_ago' do

--- a/spec/views/thredded/user/link_spec.rb
+++ b/spec/views/thredded/user/link_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe 'partial: thredded/users/link' do

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 require 'thredded/version'
@@ -53,7 +54,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'faker', '>= 1.6.2'
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'rubocop', '0.32.0'
+  s.add_development_dependency 'rubocop', '~> 0.39'
   s.add_development_dependency 'shoulda-matchers', '~> 2.7'
   s.add_development_dependency 'test-unit'
 


### PR DESCRIPTION
Thredded has been using an older version of Rubocop that fails to parse the files with required keyword arguments, and doesn't have a number of neat suggestions such as:

```diff
-        html.gsub('<br>', '')
+        html.delete('<br>')
```

This upgrades Rubocop to the latest version, updates .rubocop.yml to the new format, and tells it to target Ruby 2.3.