### PR TITLE
Change copy: Private Topics to Private Messages

### DIFF
--- a/app/views/thredded/posts/_content_field.html.erb
+++ b/app/views/thredded/posts/_content_field.html.erb
@@ -1,4 +1,4 @@
 <li>
-  <%= form.label :content %>
+  <%= form.label :content, content_label %>
   <%= form.text_area :content, { rows: 5, required: true }  %>
 </li>

--- a/app/views/thredded/posts/_form.html.erb
+++ b/app/views/thredded/posts/_form.html.erb
@@ -1,1 +1,5 @@
-<%= render 'thredded/posts_common/form', topic: topic, post: post, button_text: button_text %>
+<%= render 'thredded/posts_common/form',
+           topic: topic,
+           post: post,
+           content_label: t('thredded.posts.form.content_label'),
+           button_text: button_text %>

--- a/app/views/thredded/posts/edit.html.erb
+++ b/app/views/thredded/posts/edit.html.erb
@@ -12,6 +12,6 @@
                messageboard: messageboard,
                topic:        topic,
                post:         @post,
-               button_text:  'Update Post' %>
+               button_text:  t('thredded.posts.form.update_btn') %>
   </section>
 <% end %>

--- a/app/views/thredded/posts_common/_form.html.erb
+++ b/app/views/thredded/posts_common/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for (post.private_topic_post? ? [topic, post] : [messageboard, topic, post]), as: :post,
              html: { class: 'thredded--form thredded--post-form', 'data-thredded-post-form' => true } do |form| %>
   <ul class="thredded--form-list">
-    <%= render 'thredded/posts/content_field', form: form %>
+    <%= render 'thredded/posts/content_field', form: form, content_label: content_label %>
 
     <li>
       <%= form.submit button_text, class: 'thredded--form--submit' %>

--- a/app/views/thredded/preferences/_form.html.erb
+++ b/app/views/thredded/preferences/_form.html.erb
@@ -10,21 +10,20 @@
   <h3><%= t 'thredded.preferences.form.global_preferences_label' %></h3>
   <ul class="thredded--form-list">
     <li>
-      <%= f.label :notify_on_mention do %>
-        <%= f.check_box :notify_on_mention %>
-        <%= t 'thredded.preferences.form.notify_on_mention.label' %>
-        <p class="thredded--form-list--hint">
-          <%= t 'thredded.preferences.form.notify_on_mention.hint' %>
-        </p>
-      <% end %>
-    </li>
-
-    <li>
       <%= f.label :notify_on_message do %>
         <%= f.check_box :notify_on_message %>
         <%= t 'thredded.preferences.form.notify_on_message.label' %>
         <p class="thredded--form-list--hint">
           <%= t 'thredded.preferences.form.notify_on_message.hint' %>
+        </p>
+      <% end %>
+    </li>
+    <li>
+      <%= f.label :notify_on_mention do %>
+        <%= f.check_box :notify_on_mention %>
+        <%= t 'thredded.preferences.form.notify_on_mention.label' %>
+        <p class="thredded--form-list--hint">
+          <%= t 'thredded.preferences.form.notify_on_mention.hint' %>
         </p>
       <% end %>
     </li>

--- a/app/views/thredded/private_posts/_form.html.erb
+++ b/app/views/thredded/private_posts/_form.html.erb
@@ -1,1 +1,5 @@
-<%= render 'thredded/posts_common/form', topic: topic, post: post, button_text: button_text %>
+<%= render 'thredded/posts_common/form',
+           topic: topic,
+           post: post,
+           button_text: t('thredded.private_posts.form.create_btn'),
+           content_label: t('thredded.private_posts.form.content_label') %>

--- a/app/views/thredded/private_topics/_form.html.erb
+++ b/app/views/thredded/private_topics/_form.html.erb
@@ -15,11 +15,13 @@
                           'data-autocomplete-url'      => autocomplete_users_path %>
     </li>
 
-    <%= render 'thredded/posts/content_field', form: form %>
+    <%= render 'thredded/posts/content_field',
+               form:          form,
+               content_label: t('thredded.private_topics.form.content_label') %>
 
     <li>
       <button type="submit" class="thredded--form--submit">
-        <%= t('thredded.private_topics.form.submit_btn') %>
+        <%= t('thredded.private_topics.form.create_btn') %>
       </button>
     </li>
   </ul>

--- a/app/views/thredded/private_topics/show.html.erb
+++ b/app/views/thredded/private_topics/show.html.erb
@@ -8,7 +8,6 @@
     <%= render @posts %>
     <%= render 'thredded/private_posts/form',
                topic:        private_topic,
-               post:         @post,
-               button_text:  'Submit Reply' %>
+               post:         @post %>
   <% end %>
 <% end %>

--- a/app/views/thredded/theme_previews/show.html.erb
+++ b/app/views/thredded/theme_previews/show.html.erb
@@ -39,7 +39,7 @@
                messageboard: @messageboard,
                topic:        @topic,
                post:         @new_post,
-               button_text:  'Submit Reply'
+               button_text:  t('thredded.posts.form.create_btn')
     %>
   <% end %>
 
@@ -57,7 +57,7 @@
                messageboard: @messageboard,
                topic:        @topic,
                post:         @post,
-               button_text:  'Update Post'
+               button_text:  t('thredded.posts.form.update_btn')
     %>
   <% end %>
 
@@ -90,7 +90,7 @@
     <%= render 'thredded/private_posts/form',
                topic:       @private_topic,
                post:        @private_post,
-               button_text: 'Submit Reply'
+               button_text: t('thredded.private_posts.form.create_btn')
     %>
   </section>
 

--- a/app/views/thredded/topics/_form.html.erb
+++ b/app/views/thredded/topics/_form.html.erb
@@ -15,7 +15,9 @@
       </li>
     <% end %>
 
-    <%= render 'thredded/posts/content_field', form: form %>
+    <%= render 'thredded/posts/content_field',
+               form:          form,
+               content_label: t('thredded.topics.form.content_label') %>
     <%= render 'thredded/topics/topic_form_admin_options', form: form %>
 
     <li><%= form.submit 'Create New Topic', class: 'thredded--form--submit' %></li>

--- a/app/views/thredded/topics/show.html.erb
+++ b/app/views/thredded/topics/show.html.erb
@@ -10,9 +10,9 @@
       <div class="thredded--post-form--wrapper">
         <h3 class="thredded--post-form--title">Add a post</h3>
         <%= render 'thredded/posts/form',
-                   topic:        topic,
-                   post:         @new_post,
-                   button_text:  'Submit Reply' %>
+                   topic:       topic,
+                   post:        @new_post,
+                   button_text: t('thredded.posts.form.create_btn') %>
       </div>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
       topics_and_posts_counts: "%{topics_count} topics / %{posts_count} posts"
     nav:
       all_messageboards: All Messageboards
-      private_topics: Private Topics
+      private_topics: Private Messages
       settings: Notification Settings
       topics: Topics
     posts:
@@ -18,6 +18,10 @@ en:
       delete_confirm: Are you sure you want to delete this post?
       deleted_notice: Your post has been deleted.
       edit: Edit Post
+      form:
+        content_label: Content
+        create_btn: Submit Reply
+        update_btn: Update Post
     preferences:
       edit:
         page_title: :thredded.nav.settings
@@ -35,31 +39,37 @@ en:
             that post.
           label: "@ Notifications"
         notify_on_message:
-          hint: When you are added to a private topic's discussion you will receive an email with the contents of
-            that post.
-          label: Private Topic Notifications
+          hint: When you are added to a private conversation you will receive an email with its content.
+          label: Private Message Notifications
         submit_btn: Update Settings
         title: Settings
       updated_notice: Your settings have been updated.
+    private_posts:
+      form:
+        content_label: Message
+        create_btn: Send Message
     private_topics:
       errors:
         user_ids_length: Please specify at least one other user.
       form:
-        submit_btn: Create New Private Topic
-        title_label: Private Topic Title
-        title_placeholder_new: New Private Topic Title
-        title_placeholder_start: Start a New Private Topic
-        users_label: Users in Private Topic
-        users_placeholder: Select users to participate in this topic
+        content_label: :thredded.private_posts.form.content_label
+        create_btn: :thredded.private_posts.form.create_btn
+        title_label: Title
+        title_placeholder_new: Write the subject of this conversatino
+        title_placeholder_start: Start a new conversation
+        users_label: Participants
+        users_placeholder: Select users to participate in this conversation
       no_private_topics:
-        create_btn: Create your first private topic
-        title: You have no private topics.
+        create_btn: Start your first private conversation
+        title: You have no private messages.
     search:
       form:
         btn_submit: :thredded.search.form.label
         label: Search
         placeholder: Search Topics and Posts
     topics:
+      form:
+        content_label: :thredded.posts.form.content_label
       search:
         no_results_message: There are no results for your search - %{query}
         page_title: Topics Search Results

--- a/spec/support/features/page_object/private_topics.rb
+++ b/spec/support/features/page_object/private_topics.rb
@@ -32,9 +32,9 @@ module PageObject
       visit new_private_topic_path
       fill_in 'Title', with: private_title
       find(:css, '#private_topic_user_ids').set(user.id)
-      fill_in 'Content', with: 'not for others'
+      fill_in I18n.t('thredded.private_topics.form.content_label'), with: 'not for others'
 
-      click_on 'Create New Private Topic'
+      click_on I18n.t('thredded.private_topics.form.create_btn')
     end
 
     def update_all_private_topics

--- a/spec/support/features/page_object/topics.rb
+++ b/spec/support/features/page_object/topics.rb
@@ -162,7 +162,7 @@ module PageObject
 
     def content(text)
       self.topic_content = text
-      fill_in 'Content', with: text
+      fill_in I18n.t('thredded.topics.form.content_label'), with: text
     end
   end
 end


### PR DESCRIPTION
"Private Topics" are now "Private Messages".
A thread of "Private Messages" is referred to as just "Conversation", because the "Private" bit is always prominent in the navigation / title.

A take on #213.