### PR TITLE
[JRO] Allow img tags in posts

### DIFF
--- a/lib/thredded/engine.rb
+++ b/lib/thredded/engine.rb
@@ -31,5 +31,13 @@ module Thredded
         thredded/breadcrumb-chevron.svg
       )
     end
+
+    initializer 'thredded.setup_bbcoder' do
+      BBCoder.configure do
+        tag :img, match: /^https?:\/\/.*(png|bmp|jpe?g|gif)$/, singular: false do
+          %(<img src="#{singular? ? meta : content}" />)
+        end
+      end
+    end
   end
 end

--- a/lib/thredded/engine.rb
+++ b/lib/thredded/engine.rb
@@ -34,7 +34,7 @@ module Thredded
 
     initializer 'thredded.setup_bbcoder' do
       BBCoder.configure do
-        tag :img, match: /^https?:\/\/.*(png|bmp|jpe?g|gif)$/, singular: false do
+        tag :img, match: %r{^https?://.*(png|bmp|jpe?g|gif)$}, singular: false do
           %(<img src="#{singular? ? meta : content}" />)
         end
       end

--- a/spec/models/thredded/post_spec.rb
+++ b/spec/models/thredded/post_spec.rb
@@ -93,6 +93,23 @@ module Thredded
         .to eq('<p>this is <strong>bold</strong></p>')
     end
 
+    it 'handles image tags' do
+      @post.content = <<-BBCODE.strip_heredoc
+        [img]http://example.com/i.jpg[/img]
+        ![img](http://example.com/i.jpg)
+        ![](http://example.com/i.jpg)
+      BBCODE
+      expected_html = <<-HTML.strip_heredoc
+        <p><img src="http://example.com/i.jpg"><br>
+        <img src="http://example.com/i.jpg" alt="img"><br>
+        <img src="http://example.com/i.jpg" alt=""></p>
+      HTML
+      resulting_parsed_html = parsed_html(@post.filtered_content(view_context))
+      expected_parsed_html  = parsed_html(expected_html)
+
+      expect(resulting_parsed_html).to eq(expected_parsed_html)
+    end
+
     it 'handles bbcode quotes' do
       @post.content = <<-BBCODE.strip_heredoc
         [quote]hi[/quote]


### PR DESCRIPTION
`img` tags were busted according to issue #230.

This commit adds regression test & fix bbcode/mkdn interop. Change the config for bbcode img tags so that `![img](http://...)` won't be interpreted as a bbcode image tag ... make it require a closing `[/img]` tag.