### PR TITLE
Add rel="nofollow noopener" to external links

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,7 +53,7 @@ Metrics/MethodLength:
   - 'db/**/*'
 
 Metrics/ModuleLength:
-  Max: 175
+  Max: 200
 
 Metrics/PerceivedComplexity:
   Enabled: false

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -54,7 +54,16 @@ module Thredded
       {
         asset_root: Rails.application.config.action_controller.asset_host || '',
         post:       self,
+        whitelist:  sanitize_whitelist,
       }
+    end
+
+    def sanitize_whitelist
+      HTML::Pipeline::SanitizationFilter::WHITELIST.deep_merge(
+        attributes: {
+          'a' => %w(href rel),
+        }
+      )
     end
 
     def update_parent_last_user_and_timestamp

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -65,7 +65,10 @@ module Thredded
 
           a_tags = node.css('a')
           a_tags.each do |a_tag|
-            a_tag['rel'] = 'nofollow noopener' if a_tag['href'].starts_with? 'http'
+            if a_tag['href'].starts_with? 'http'
+              a_tag['target'] = '_blank'
+              a_tag['rel'] = 'nofollow noopener'
+            end
           end
         end,
       ]

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -59,10 +59,20 @@ module Thredded
     end
 
     def sanitize_whitelist
+      HTML::Pipeline::SanitizationFilter::WHITELIST[:transformers] += [
+        lambda do |env|
+          node = env[:node]
+
+          a_tags = node.css('a')
+          a_tags.each do |a_tag|
+            a_tag['rel'] = 'nofollow noopener' if a_tag['href'].starts_with? 'http'
+          end
+        end,
+      ]
       HTML::Pipeline::SanitizationFilter::WHITELIST.deep_merge(
         attributes: {
           'a' => %w(href rel),
-        }
+        },
       )
     end
 

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -31,7 +31,6 @@ module Thredded
     :email_incoming_host,
     :email_outgoing_prefix,
     :email_reply_to,
-    :host,
     :layout,
     :user_class,
     :user_name_column,

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -24,16 +24,18 @@ require 'sprockets/es6'
 require 'thredded/engine'
 
 module Thredded
-  mattr_accessor :user_class,
-    :user_name_column,
+  mattr_accessor \
+    :active_user_threshold,
     :avatar_url,
-    :email_incoming_host,
     :email_from,
+    :email_incoming_host,
     :email_outgoing_prefix,
     :email_reply_to,
-    :user_path,
+    :host,
     :layout,
-    :active_user_threshold
+    :user_class,
+    :user_name_column,
+    :user_path
 
   # @return [Symbol] The name of the moderator flag column on the users table for the default permissions model
   mattr_accessor :moderator_column
@@ -41,13 +43,13 @@ module Thredded
   # @return [Symbol] The name of the admin flag column on the users table for the default permissions model
   mattr_accessor :admin_column
 
-  self.user_name_column = :name
-  self.avatar_url = ->(user) { Gravatar.src(user.email, 128, 'mm') }
   self.active_user_threshold = 5.minutes
-  self.layout = 'thredded/application'
-  self.email_reply_to = -> postable { "#{postable.hash_id}@#{Thredded.email_incoming_host}" }
-  self.moderator_column = :admin
   self.admin_column = :admin
+  self.avatar_url = ->(user) { Gravatar.src(user.email, 128, 'mm') }
+  self.email_reply_to = -> postable { "#{postable.hash_id}@#{Thredded.email_incoming_host}" }
+  self.layout = 'thredded/application'
+  self.moderator_column = :admin
+  self.user_name_column = :name
 
   # @return [Class<Thredded::UserExtender>] the user class from the host application.
   def self.user_class

--- a/spec/models/thredded/post_spec.rb
+++ b/spec/models/thredded/post_spec.rb
@@ -89,10 +89,10 @@ module Thredded
         [link](http://example.com)
       BBCODE
       expected_html = <<-HTML.strip_heredoc
-        <p><a href="http://thredded.com" rel="nofollow noopener">thredded</a><br>
+        <p><a href="http://thredded.com" target="_blank" rel="nofollow noopener">thredded</a><br>
         <a href="/forum/a-topic">a topic</a><br>
-        <a href="http://example.com" rel="nofollow noopener">example.com</a><br>
-        <a href="http://example.com" rel="nofollow noopener">link</a></p>
+        <a href="http://example.com" target="_blank" rel="nofollow noopener">example.com</a><br>
+        <a href="http://example.com" target="_blank" rel="nofollow noopener">link</a></p>
       HTML
       resulting_parsed_html = parsed_html(@post.filtered_content(view_context))
       expected_parsed_html  = parsed_html(expected_html)
@@ -102,7 +102,7 @@ module Thredded
 
     it 'renders bbcode url tags' do
       @post.content = 'go to [url]http://google.com[/url]'
-      expected_html = '<p>go to <a href="http://google.com" rel="nofollow noopener">google.com</a></p>'
+      expected_html = '<p>go to <a href="http://google.com" target="_blank" rel="nofollow noopener">google.com</a></p>'
       expect(@post.filtered_content(view_context)).to eq(expected_html)
     end
 
@@ -183,7 +183,7 @@ module Thredded
       MARKDOWN
       expected_html = <<-HTML.strip_heredoc
         <h1>Header</h1>
-        <p><a href="http://www.google.com" rel="nofollow noopener">http://www.google.com</a></p>
+        <p><a href="http://www.google.com" target="_blank" rel="nofollow noopener">http://www.google.com</a></p>
       HTML
 
       resulting_parsed_html = parsed_html(@post.filtered_content(view_context))

--- a/spec/models/thredded/post_spec.rb
+++ b/spec/models/thredded/post_spec.rb
@@ -75,18 +75,13 @@ module Thredded
   describe Post, '#filtered_content' do
     let(:view_context) { ViewContextStub }
     before(:each) { @post = build(:post) }
-    after do
-      Thredded.user_path = nil
-      Thredded.host = nil
-    end
+    after { Thredded.user_path = nil }
 
     module ViewContextStub
       def main_app; end
     end
 
     it 'applies rel properties to links' do
-      Thredded.host = 'thredded.com'
-
       @post.content = <<-BBCODE.strip_heredoc
         [thredded](http://thredded.com)
         [a topic](/forum/a-topic)
@@ -94,7 +89,7 @@ module Thredded
         [link](http://example.com)
       BBCODE
       expected_html = <<-HTML.strip_heredoc
-        <p><a href="http://thredded.com">thredded</a><br>
+        <p><a href="http://thredded.com" rel="nofollow noopener">thredded</a><br>
         <a href="/forum/a-topic">a topic</a><br>
         <a href="http://example.com" rel="nofollow noopener">example.com</a><br>
         <a href="http://example.com" rel="nofollow noopener">link</a></p>
@@ -107,7 +102,7 @@ module Thredded
 
     it 'renders bbcode url tags' do
       @post.content = 'go to [url]http://google.com[/url]'
-      expected_html = '<p>go to <a href="http://google.com">google.com</a></p>'
+      expected_html = '<p>go to <a href="http://google.com" rel="nofollow noopener">google.com</a></p>'
       expect(@post.filtered_content(view_context)).to eq(expected_html)
     end
 
@@ -188,7 +183,7 @@ module Thredded
       MARKDOWN
       expected_html = <<-HTML.strip_heredoc
         <h1>Header</h1>
-        <p><a href="http://www.google.com">http://www.google.com</a></p>
+        <p><a href="http://www.google.com" rel="nofollow noopener">http://www.google.com</a></p>
       HTML
 
       resulting_parsed_html = parsed_html(@post.filtered_content(view_context))

--- a/spec/models/thredded/post_spec.rb
+++ b/spec/models/thredded/post_spec.rb
@@ -89,11 +89,13 @@ module Thredded
 
       @post.content = <<-BBCODE.strip_heredoc
         [thredded](http://thredded.com)
+        [a topic](/forum/a-topic)
         [url]http://example.com[/url]
         [link](http://example.com)
       BBCODE
       expected_html = <<-HTML.strip_heredoc
         <p><a href="http://thredded.com">thredded</a><br>
+        <a href="/forum/a-topic">a topic</a><br>
         <a href="http://example.com" rel="nofollow noopener">example.com</a><br>
         <a href="http://example.com" rel="nofollow noopener">link</a></p>
       HTML


### PR DESCRIPTION
If someone links, in a post, to an external link, we should add `rel="nofollow noopener"`. `nofollow` to avoid google-juice'ing the link, and noopener to open a new tab/window on click.