### PR TITLE
[JRO] Round two times being compared down to ints

### DIFF
--- a/app/models/concerns/thredded/user_topic_read_state_common.rb
+++ b/app/models/concerns/thredded/user_topic_read_state_common.rb
@@ -9,7 +9,7 @@ module Thredded
 
     # @return [Boolean]
     def read?
-      postable.updated_at <= read_at
+      postable.updated_at.to_i <= read_at.to_i
     end
 
     module ClassMethods


### PR DESCRIPTION
After trying things out with a live forum, it became apparent that there
was something going on with users' read tracking. After some digging I
found that the comparison `postable.updated_at <= read_at` was comparing
the timestamps down to the millisecond. So we were seeing some funny
race conditions based on when the updated_at and read_at columns were
being committed to the db. Example:

Thredded::Topic#updated_at            -> `1461352354.630764`

is effectively the same time as

Thredded::UserTopicReadStates#read_at -> `1461352354.615124`

So that comparison in the code *should* be intrepreted as truthy.
Instead, it's false.

Casting these two objects to integers fixes this just fine.