### PR TITLE
[JRO] Fix markdown quoting

### DIFF
--- a/lib/html/pipeline/bbcode_filter.rb
+++ b/lib/html/pipeline/bbcode_filter.rb
@@ -11,6 +11,7 @@ module HTML
       def call
         html = BBCoder.new(@text).to_html
         html = remove_url_link_contents(html)
+        html = preserve_mkdn_comments(html)
         html.delete('<br>')
         html.rstrip!
         html
@@ -22,6 +23,10 @@ module HTML
           link.content = link.content.gsub(%r{https?://}, '')
         end
         doc.to_html
+      end
+
+      def preserve_mkdn_comments(html)
+        html.gsub(/^&gt; /, '> ')
       end
     end
   end

--- a/spec/models/thredded/post_contents.yml
+++ b/spec/models/thredded/post_contents.yml
@@ -82,6 +82,18 @@
       <p></p>
       </blockquote><br>
 
+  quotes in markdown:
+    - |
+      > This is a quote
+
+      I quoted
+    - |
+      <blockquote>
+      <p>This is a quote</p>
+      </blockquote>
+
+      <p>I quoted</p>
+
   code snippets in markdown:
     - |
       this is code


### PR DESCRIPTION
The BBCode filter will replace `> ` with `&gt; ` before it gets to the
markdown filter. This commit ensures that any line starting with `> `
retains that as that part of the string -- therefore allowing markdown
to do its quoting job.