### PR TITLE
[JRO] Better style quotes + better word wrap

### DIFF
--- a/app/assets/stylesheets/thredded/base/_typography.scss
+++ b/app/assets/stylesheets/thredded/base/_typography.scss
@@ -39,3 +39,12 @@
   fill: currentColor;
 }
 
+%thredded--quote {
+  margin: 0 0 0.75rem;
+  border-left: solid 5px $thredded-quote-border-color;
+  padding: 1rem;
+
+  p:last-of-type {
+    margin-bottom: 0;
+  }
+}

--- a/app/assets/stylesheets/thredded/base/_typography.scss
+++ b/app/assets/stylesheets/thredded/base/_typography.scss
@@ -39,9 +39,9 @@
   fill: currentColor;
 }
 
-%thredded--quote {
+%thredded--blockquote {
   margin: 0 0 0.75rem;
-  border-left: solid 5px $thredded-quote-border-color;
+  border-left: solid 5px $thredded-blockquote-border-color;
   padding: 1rem;
 
   p:last-of-type {

--- a/app/assets/stylesheets/thredded/base/_variables.scss
+++ b/app/assets/stylesheets/thredded/base/_variables.scss
@@ -45,7 +45,7 @@ $thredded-alert-warning-color: #8a6d3b !default;
 // Borders
 $thredded-base-border-color: $thredded-light-gray !default;
 $thredded-base-border: 1px solid $thredded-base-border-color !default;
-$thredded-quote-border-color: $thredded-light-gray !default;
+$thredded-blockquote-border-color: $thredded-light-gray !default;
 
 // Form inputs
 $thredded-form-background: $thredded-background-color !default;

--- a/app/assets/stylesheets/thredded/base/_variables.scss
+++ b/app/assets/stylesheets/thredded/base/_variables.scss
@@ -45,6 +45,7 @@ $thredded-alert-warning-color: #8a6d3b !default;
 // Borders
 $thredded-base-border-color: $thredded-light-gray !default;
 $thredded-base-border: 1px solid $thredded-base-border-color !default;
+$thredded-quote-border-color: $thredded-light-gray !default;
 
 // Form inputs
 $thredded-form-background: $thredded-background-color !default;

--- a/app/assets/stylesheets/thredded/components/_post.scss
+++ b/app/assets/stylesheets/thredded/components/_post.scss
@@ -75,6 +75,6 @@
     @extend %thredded--table;
   }
   blockquote {
-    @extend %thredded--quote;
+    @extend %thredded--blockquote;
   }
 }

--- a/app/assets/stylesheets/thredded/components/_post.scss
+++ b/app/assets/stylesheets/thredded/components/_post.scss
@@ -57,7 +57,7 @@
 &--post--content {
   font-size: 1.063rem; // 17px
   line-height: 1.65;
-  word-break: break-all;
+  word-break: break-word;
   a {
     @extend %thredded--link;
   }
@@ -73,5 +73,8 @@
   }
   table {
     @extend %thredded--table;
+  }
+  blockquote {
+    @extend %thredded--quote;
   }
 }


### PR DESCRIPTION
Quotes need a little bit more differentiation from the rest of post
content copy and can use a little styling.

In addition - `word-wrap: break-all` is a bit over-eager when it comes to
wrapping so changing it to `break-word` smoothes that out a little bit.