### PR TITLE
[JRO] Auto-correct rubocop errors

### DIFF
--- a/app/controllers/thredded/private_topics_controller.rb
+++ b/app/controllers/thredded/private_topics_controller.rb
@@ -13,7 +13,8 @@ module Thredded
           .for_user(thredded_current_user)
           .order_recently_updated_first
           .includes(:last_user, :user)
-          .page(params[:page]))
+          .page(params[:page])
+      )
 
       PrivateTopicForm.new(user: thredded_current_user).tap do |form|
         @new_private_topic = form if policy(form.private_topic).create?

--- a/app/controllers/thredded/theme_previews_controller.rb
+++ b/app/controllers/thredded/theme_previews_controller.rb
@@ -23,8 +23,9 @@ module Thredded
       @private_topic     = PrivateTopicView.from_user(private_topic, @user)
       @private_posts     = PostsPageView.new(@user, private_topic, private_topic.posts.page(1).limit(3))
       @private_post      = private_topic.posts.build(
-        id: 1337, postable: private_topic, content: 'A private hello world', user: @user)
-      @preferences       = UserPreferencesForm.new(user: @user, messageboard: @messageboard)
+        id: 1337, postable: private_topic, content: 'A private hello world', user: @user
+      )
+      @preferences = UserPreferencesForm.new(user: @user, messageboard: @messageboard)
     end
   end
 end

--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -15,7 +15,8 @@ module Thredded
         messageboard.topics
           .order_sticky_first.order_recently_updated_first
           .includes(:categories, :last_user, :user)
-          .page(current_page))
+          .page(current_page)
+      )
       TopicForm.new(messageboard: messageboard, user: thredded_current_user).tap do |form|
         @new_topic = form if policy(form.topic).create?
       end
@@ -42,7 +43,8 @@ module Thredded
           .search_query(@query)
           .order_recently_updated_first
           .includes(:categories, :last_user, :user)
-          .page(current_page))
+          .page(current_page)
+      )
     end
 
     def new
@@ -58,7 +60,8 @@ module Thredded
         @category.topics
           .unstuck
           .order_recently_updated_first
-          .page(current_page))
+          .page(current_page)
+      )
       render :index
     end
 

--- a/app/forms/thredded/private_topic_form.rb
+++ b/app/forms/thredded/private_topic_form.rb
@@ -49,13 +49,15 @@ module Thredded
         title: title,
         users: private_users,
         user: non_null_user,
-        last_user: non_null_user)
+        last_user: non_null_user
+      )
     end
 
     def post
       @post ||= private_topic.posts.build(
         content: content,
-        user: non_null_user)
+        user: non_null_user
+      )
     end
 
     private

--- a/app/helpers/thredded/urls_helper.rb
+++ b/app/helpers/thredded/urls_helper.rb
@@ -22,12 +22,14 @@ module Thredded
       if topic.private?
         private_topic_url(
           topic.slug,
-          params)
+          params
+        )
       else
         messageboard_topic_url(
           topic.messageboard.slug,
           topic.slug,
-          params)
+          params
+        )
       end
     end
 

--- a/app/mailer_previews/thredded/base_mailer_preview.rb
+++ b/app/mailer_previews/thredded/base_mailer_preview.rb
@@ -30,7 +30,8 @@ MARKDOWN
           sticky:       [false, true].sample,
           updated_at:   Time.zone.now,
           user:         mock_user,
-        ))
+        )
+      )
     end
 
     def mock_post(attr = {})
@@ -44,7 +45,8 @@ MARKDOWN
           postable:     topic,
           updated_at:   Time.zone.now,
           user:         topic.last_user,
-        ))
+        )
+      )
     end
 
     def mock_private_topic(attr = {})
@@ -58,7 +60,8 @@ MARKDOWN
           posts_count: 1 + rand(42),
           updated_at:  Time.zone.now,
           user:        mock_user,
-        ))
+        )
+      )
     end
 
     def mock_private_post(attr = {})
@@ -71,7 +74,8 @@ MARKDOWN
           postable:   private_topic,
           updated_at: Time.zone.now,
           user:       private_topic.last_user,
-        ))
+        )
+      )
     end
 
     def mock_messageboard(attr = {})
@@ -86,7 +90,8 @@ MARKDOWN
           posts_count:  rand(1337),
           topics_count: rand(42),
           updated_at:   Time.zone.now,
-        ))
+        )
+      )
     end
 
     def mock_user(attr = {})
@@ -95,7 +100,8 @@ MARKDOWN
         attr.reverse_merge(
           Thredded.user_name_column => name,
           email:                    "#{name.downcase}@test.com",
-        ))
+        )
+      )
     end
   end
 end

--- a/app/mailer_previews/thredded/post_mailer_preview.rb
+++ b/app/mailer_previews/thredded/post_mailer_preview.rb
@@ -5,7 +5,8 @@ module Thredded
     def at_notification
       PostMailer.at_notification(
         mock_post(content: mock_content(mention_users: %w(glebm joel))),
-        %w(glebm@test.com joel@test.com))
+        %w(glebm@test.com joel@test.com)
+      )
     end
   end
 end

--- a/app/mailer_previews/thredded/private_post_mailer_preview.rb
+++ b/app/mailer_previews/thredded/private_post_mailer_preview.rb
@@ -5,7 +5,8 @@ module Thredded
     def at_notification
       PrivatePostMailer.at_notification(
         mock_private_post(content: mock_content(mention_users: %w(glebm joel))),
-        %w(glebm@test.com joel@test.com))
+        %w(glebm@test.com joel@test.com)
+      )
     end
   end
 end

--- a/app/mailer_previews/thredded/private_topic_mailer_preview.rb
+++ b/app/mailer_previews/thredded/private_topic_mailer_preview.rb
@@ -9,7 +9,8 @@ module Thredded
             mock_private_post(content: mock_content(mention_users: ['glebm']), postable: private_topic)
           ]
         end,
-        %w(glebm@test.com joel@test.com))
+        %w(glebm@test.com joel@test.com)
+      )
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,13 +83,15 @@ module Thredded
         :topic, count,
         messageboard: messageboard,
         user:         users.sample,
-        last_user:    users.sample)
+        last_user:    users.sample
+      )
 
       @private_topics = FactoryGirl.create_list(
         :private_topic, count,
         user:      users.sample,
         last_user: users.sample,
-        users:     [user])
+        users:     [user]
+      )
     end
 
     def create_posts(count: (1..30))

--- a/spec/commands/thredded/notify_private_topic_users_spec.rb
+++ b/spec/commands/thredded/notify_private_topic_users_spec.rb
@@ -48,7 +48,8 @@ module Thredded
       private_topic = create(
         :private_topic,
         user: @john,
-        users: [@john, @joel, @sam])
+        users: [@john, @joel, @sam]
+      )
       post = create(:private_post, postable: private_topic)
       create(:post_notification, email: @joel.email, post: post)
 

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -20,7 +20,8 @@ Dummy::Application.configure do
     config.force_ssl                        = true
     if ENV['MEMCACHEDCLOUD_SERVERS']
       config.cache_store = :dalli_store, ENV['MEMCACHEDCLOUD_SERVERS'].split(','), {
-        username: ENV['MEMCACHEDCLOUD_USERNAME'], password: ENV['MEMCACHEDCLOUD_PASSWORD'] }
+        username: ENV['MEMCACHEDCLOUD_USERNAME'], password: ENV['MEMCACHEDCLOUD_PASSWORD']
+      }
     end
   else
     config.public_file_server.enabled = false

--- a/spec/features/thredded/user_views_private_topics_spec.rb
+++ b/spec/features/thredded/user_views_private_topics_spec.rb
@@ -70,7 +70,8 @@ feature 'User viewing private topics' do
       :private_topic,
       user: me,
       users: [me, them],
-      posts: build_list(:private_post, 1))
+      posts: build_list(:private_post, 1)
+    )
     PageObject::PrivateTopics.new(private_topic.title)
   end
 

--- a/spec/models/thredded/topic_spec.rb
+++ b/spec/models/thredded/topic_spec.rb
@@ -34,7 +34,8 @@ module Thredded
       @topic_with_title_and_category = create(:topic, title: test_title, categories: [@category], **defaults)
       @topic_with_title_and_user = create(:topic, title: test_title, user: @user, **defaults)
       @topic_with_title_and_category_and_user = create(
-        :topic, title: test_title, categories: [@category], user: @user, **defaults)
+        :topic, title: test_title, categories: [@category], user: @user, **defaults
+      )
     end
 
     after :all do
@@ -44,34 +45,40 @@ module Thredded
     it 'with text' do
       expect(Topic.search_query(test_title).to_a).to(
         match_array([@topic_with_title, @topic_with_title_and_category, @topic_with_title_and_user,
-                     @topic_with_title_and_category_and_user]))
+                     @topic_with_title_and_category_and_user])
+      )
     end
 
     it 'with "by:"' do
       expect(Topic.search_query("by:#{@user.name}").to_a).to(
         match_array([@topic_with_user, @topic_with_category_and_user, @topic_with_title_and_user,
-                     @topic_with_title_and_category_and_user]))
+                     @topic_with_title_and_category_and_user])
+      )
     end
 
     it 'with "in:"' do
       expect(Topic.search_query("in:#{@category.name}").to_a).to(
         match_array([@topic_with_category, @topic_with_category_and_user, @topic_with_title_and_category,
-                     @topic_with_title_and_category_and_user]))
+                     @topic_with_title_and_category_and_user])
+      )
     end
 
     it 'with "by:" and text' do
       expect(Topic.search_query("#{test_title} by:#{@user.name}").to_a).to(
-        match_array([@topic_with_title_and_user, @topic_with_title_and_category_and_user]))
+        match_array([@topic_with_title_and_user, @topic_with_title_and_category_and_user])
+      )
     end
 
     it 'with "in:" and text' do
       expect(Topic.search_query("#{test_title} in:#{@category.name}").to_a).to(
-        match_array([@topic_with_title_and_category, @topic_with_title_and_category_and_user]))
+        match_array([@topic_with_title_and_category, @topic_with_title_and_category_and_user])
+      )
     end
 
     it 'with "by:" and "in:" and text' do
       expect(Topic.search_query("#{test_title} by: #{@user.name} in:#{@category.name}").to_a).to(
-        match_array([@topic_with_title_and_category_and_user]))
+        match_array([@topic_with_title_and_category_and_user])
+      )
     end
   end
 

--- a/spec/views/thredded/messageboards/index.html.erb_spec.rb
+++ b/spec/views/thredded/messageboards/index.html.erb_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'thredded/messageboards/index' do
 
     # Stub the helper methods defined in the controller
     allow(view).to(
-      receive_messages(signed_in?: true, messageboard_or_nil: nil, active_users: [], unread_private_topics_count: 1))
+      receive_messages(signed_in?: true, messageboard_or_nil: nil, active_users: [], unread_private_topics_count: 1)
+    )
 
     # Stub the policy, so we can test the view given different permissions
     allow(view).to receive(:policy).and_return(double(Thredded::MessageboardPolicy))


### PR DESCRIPTION
Travis is using rubocop 0.40.0 and there's a new cop there that doesn't like where some of our end-parens are. Things here in this PR have been fixed with `rubocop -a`.