### PR TITLE
Permalink URLs for posts and private posts

### DIFF
--- a/app/controllers/thredded/post_permalinks_controller.rb
+++ b/app/controllers/thredded/post_permalinks_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Thredded
+  class PostPermalinksController < ApplicationController
+    def show
+      post = Post.find(params[:id])
+      authorize post, :read?
+      redirect_to post_url(post), status: :found
+    end
+  end
+end

--- a/app/controllers/thredded/private_post_permalinks_controller.rb
+++ b/app/controllers/thredded/private_post_permalinks_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module Thredded
+  class PrivatePostPermalinksController < ApplicationController
+    before_action :thredded_require_login!
+    def show
+      private_post = PrivatePost.find(params[:id])
+      authorize private_post, :read?
+      redirect_to post_url(private_post), status: :found
+    end
+  end
+end

--- a/app/helpers/thredded/urls_helper.rb
+++ b/app/helpers/thredded/urls_helper.rb
@@ -43,7 +43,7 @@ module Thredded
     # @return [String] URL of the topic page with the post anchor.
     def post_url(post, params = {})
       params = params.dup
-      params[:anchor] ||= dom_id(post)
+      params[:anchor] ||= ActionView::RecordIdentifier.dom_id(post)
       params[:page] ||= post.page
       topic_url(post.postable, params)
     end

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -6,7 +6,16 @@ module Thredded
                 use:            [:slugged, :reserved],
                 # Avoid route conflicts
                 reserved_words: ::Thredded::FriendlyIdReservedWordsAndPagination.new(
-                  %w(messageboards preferences private-topics autocomplete-users theme-preview admin)
+                  %w(
+                    admin
+                    autocomplete-users
+                    messageboards
+                    posts
+                    preferences
+                    private-posts
+                    private-topics
+                    theme-preview
+                  )
                 )
 
     validates :name, uniqueness: true, length: { maximum: 60 }, presence: true

--- a/app/policies/thredded/post_policy.rb
+++ b/app/policies/thredded/post_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_dependency 'thredded/topic_policy'
 module Thredded
   class PostPolicy
     # @param user [Thredded.user_class]
@@ -10,6 +11,10 @@ module Thredded
 
     def create?
       @user.thredded_admin? || !@post.postable.locked? && messageboard_policy.post?
+    end
+
+    def read?
+      TopicPolicy.new(@user, @post.postable).read?
     end
 
     def update?

--- a/app/policies/thredded/private_post_policy.rb
+++ b/app/policies/thredded/private_post_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_dependency 'thredded/private_topic_policy'
 module Thredded
   class PrivatePostPolicy
     # @param user [Thredded.user_class]
@@ -10,6 +11,10 @@ module Thredded
 
     def create?
       @user.thredded_admin? || @post.postable.users.include?(@user)
+    end
+
+    def read?
+      PrivateTopicPolicy.new(@user, @post.postable).read?
     end
 
     def update?

--- a/app/views/thredded/post_mailer/at_notification.html.erb
+++ b/app/views/thredded/post_mailer/at_notification.html.erb
@@ -4,7 +4,7 @@
 
 <p>
   This email was sent to you because <%= @post.user %> mentioned you in
-  "<%= link_to @post.postable.title, post_url(@post) %>".
+  "<%= link_to @post.postable.title, post_permalink_url(@post.id) %>".
   <%= link_to 'View the conversation here', topic_url(@post.postable) %>.
 </p>
 

--- a/app/views/thredded/post_mailer/at_notification.text.erb
+++ b/app/views/thredded/post_mailer/at_notification.text.erb
@@ -4,7 +4,7 @@
 
 This email was sent to you because <%= @post.user %> mentioned you in
 "<%= @post.postable.title %>". Go here to view the conversation:
-<%= post_url @post %>
+<%= post_permalink_url @post %>
 
 To unsubscribe from these emails, update your preferences here:
   <%= edit_messageboard_preferences_url @post.messageboard %>

--- a/app/views/thredded/private_post_mailer/at_notification.html.erb
+++ b/app/views/thredded/private_post_mailer/at_notification.html.erb
@@ -4,7 +4,7 @@
 
 <p>
   This email was sent to you because <%= @post.user %> mentioned you in
-  "<%= link_to @post.postable.title, post_url(@post) %>".
+  "<%= link_to @post.postable.title, private_post_permalink_url(@post.id) %>".
   <%= link_to 'View the conversation here', topic_url(@post.postable) %>.
 </p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@
 Thredded::Engine.routes.draw do
   resource :theme_preview, only: [:show], path: 'theme-preview' if %w(development test).include? Rails.env
 
-  page_constraint = { page: /[1-9]\d*/ }
+  positive_int = /[1-9]\d*/
+  page_constraint = { page: positive_int }
 
   scope path: 'private-topics' do
     resource :private_topic, only: [:new], path: ''
@@ -12,6 +13,11 @@ Thredded::Engine.routes.draw do
       end
       resources :private_posts, path: '', except: [:index, :show], controller: 'posts'
     end
+  end
+
+  scope only: [:show], constraints: { id: positive_int } do
+    resources :private_post_permalinks, path: 'private-posts'
+    resources :post_permalinks, path: 'posts'
   end
 
   resources :autocomplete_users, only: [:index], path: 'autocomplete-users'

--- a/spec/controllers/thredded/post_permalinks_controller_spec.rb
+++ b/spec/controllers/thredded/post_permalinks_controller_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+module Thredded
+  describe PostPermalinksController do
+    routes { Thredded::Engine.routes }
+
+    it 'redirects if the user can read the post' do
+      get :show, id: create(:post).id
+      expect(response).to be_redirect
+    end
+
+    it 'responds with forbidden if the user cannot read the post' do
+      allow_any_instance_of(PostPolicy).to receive_messages(read?: false)
+      get :show, id: create(:post).id
+      expect(response).to be_forbidden
+    end
+  end
+end

--- a/spec/controllers/thredded/private_post_permalinks_controller_spec.rb
+++ b/spec/controllers/thredded/private_post_permalinks_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+module Thredded
+  describe PrivatePostPermalinksController do
+    routes { Thredded::Engine.routes }
+
+    let(:user) { create(:user) }
+    before { allow(controller).to receive_messages(thredded_current_user: user) }
+
+    it 'redirects if the user can read the private post' do
+      get :show, id: create(:private_post, user: user).id
+      expect(response).to be_redirect
+    end
+
+    it 'responds with forbidden if the user cannot read the private post' do
+      get :show, id: create(:private_post).id
+      expect(response).to be_forbidden
+    end
+  end
+end

--- a/spec/controllers/thredded/topics_controller_spec.rb
+++ b/spec/controllers/thredded/topics_controller_spec.rb
@@ -3,9 +3,7 @@ require 'spec_helper'
 
 module Thredded
   describe TopicsController do
-    before(:each) do
-      @routes = Thredded::Engine.routes
-    end
+    routes { Thredded::Engine.routes }
 
     before do
       user          = create(:user)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -32,7 +32,7 @@ FactoryGirl.define do
 
   factory :post, class: Thredded::Post do
     user
-    association :postable, factory: :topic
+    postable { association :topic, user: user }
     messageboard
 
     content { Faker::Hacker.say_something_smart }
@@ -41,7 +41,7 @@ FactoryGirl.define do
 
   factory :private_post, class: Thredded::PrivatePost do
     user
-    association :postable, factory: :private_topic
+    postable { association :private_topic, user: user }
 
     content { Faker::Hacker.say_something_smart }
     ip '127.0.0.1'


### PR DESCRIPTION
Currently we send emails with the URL to the page of the topic where the
post is at. However, when posts are deleted the page may change.

This introduces permalinks for posts and private posts that always
redirect to the correct page.