### PR TITLE
Config whitelist & filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Gemfile.lock
 *.gemfile.lock
 !heroku.gemfile.lock
 .bundle/
+.ruby-version
 bin/*
 !bin/rails
 log/*.log

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -30,7 +30,7 @@ module Thredded
       add_attributes: {
         'iframe' => {
           'seamless' => 'seamless',
-          'sandbox' => 'allow-forms allow-scripts allow-same-origin',
+          'sandbox' => 'allow-forms allow-scripts',
         }
       }
     ).freeze

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -60,26 +60,12 @@ module Thredded
 
     # @param view_context [Object] the context of the rendering view.
     def filtered_content(view_context)
-      pipeline = HTML::Pipeline.new(content_pipeline_filters, content_pipeline_options)
+      pipeline = HTML::Pipeline.new(Thredded.content_pipeline_filters, content_pipeline_options)
       result = pipeline.call(content, view_context: view_context)
       result[:output].to_s.html_safe
     end
 
     protected
-
-    # @return [Array<HTML::Pipeline::Filter]>]
-    def content_pipeline_filters
-      [
-        HTML::Pipeline::VimeoFilter,
-        HTML::Pipeline::YoutubeFilter,
-        HTML::Pipeline::BbcodeFilter,
-        HTML::Pipeline::MarkdownFilter,
-        HTML::Pipeline::SanitizationFilter,
-        HTML::Pipeline::AtMentionFilter,
-        HTML::Pipeline::EmojiFilter,
-        HTML::Pipeline::AutolinkFilter,
-      ]
-    end
 
     # @return [Hash] options for HTML::Pipeline.new
     def content_pipeline_options

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -30,7 +30,7 @@ module Thredded
       add_attributes: {
         'iframe' => {
           'seamless' => 'seamless',
-          'sandbox' => 'allow-forms allow-scripts',
+          'sandbox' => 'allow-forms allow-scripts allow-same-origin',
         }
       }
     ).freeze

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -17,9 +17,7 @@ module Thredded
       end
     ].freeze
 
-    WHITELIST_ELEMENTS = HTML::Pipeline::SanitizationFilter::WHITELIST[:elements] + %w(
-      iframe span
-    ).freeze
+    WHITELIST_ELEMENTS = HTML::Pipeline::SanitizationFilter::WHITELIST[:elements] + Thredded.whitelist_elements.freeze
 
     WHITELIST = HTML::Pipeline::SanitizationFilter::WHITELIST.deep_merge(
       elements: WHITELIST_ELEMENTS,

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -54,6 +54,10 @@ Thredded.admin_column = :admin
 # Set the layout for rendering the thredded views.
 Thredded.layout = 'thredded/application'
 
+# ==> Whitelist Configuration
+# By default the standard html-pipeline element whitelist will apply, plus the elements noted below
+Thredded.whitelist_elements = %w( iframe span )
+
 # ==> Error Handling
 # By default Thredded just renders a flash alert on errors such as Topic not found, or Login required.
 # Below is an example of overriding the default behavior on LoginRequired:

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -54,8 +54,21 @@ Thredded.admin_column = :admin
 # Set the layout for rendering the thredded views.
 Thredded.layout = 'thredded/application'
 
-# ==> Whitelist Configuration
-# By default the standard html-pipeline element whitelist will apply, plus the elements noted below
+# ==> Content Pipeline Filters Configuration
+# By default the content pipeline filters below will apply.
+Thredded.self.content_pipeline_filters = [
+  HTML::Pipeline::VimeoFilter,
+  HTML::Pipeline::YoutubeFilter,
+  HTML::Pipeline::BbcodeFilter,
+  HTML::Pipeline::MarkdownFilter,
+  HTML::Pipeline::SanitizationFilter,
+  HTML::Pipeline::AtMentionFilter,
+  HTML::Pipeline::EmojiFilter,
+  HTML::Pipeline::AutolinkFilter,
+]
+
+# ==> Sanitization Filter Whitelist Configuration
+# By default the standard html-pipeline sanitization filter element whitelist will apply, plus the elements below
 Thredded.whitelist_elements = %w( iframe span )
 
 # ==> Error Handling

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -56,7 +56,7 @@ Thredded.layout = 'thredded/application'
 
 # ==> Content Pipeline Filters Configuration
 # By default the content pipeline filters below will apply.
-Thredded.self.content_pipeline_filters = [
+Thredded.content_pipeline_filters = [
   HTML::Pipeline::VimeoFilter,
   HTML::Pipeline::YoutubeFilter,
   HTML::Pipeline::BbcodeFilter,

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -28,6 +28,7 @@ module Thredded
   mattr_accessor \
     :active_user_threshold,
     :avatar_url,
+    :content_pipeline_filters,
     :email_from,
     :email_incoming_host,
     :email_outgoing_prefix,
@@ -50,6 +51,16 @@ module Thredded
   self.active_user_threshold = 5.minutes
   self.admin_column = :admin
   self.avatar_url = ->(user) { Gravatar.src(user.email, 128, 'mm') }
+  self.content_pipeline_filters = [
+    HTML::Pipeline::VimeoFilter,
+    HTML::Pipeline::YoutubeFilter,
+    HTML::Pipeline::BbcodeFilter,
+    HTML::Pipeline::MarkdownFilter,
+    HTML::Pipeline::SanitizationFilter,
+    HTML::Pipeline::AtMentionFilter,
+    HTML::Pipeline::EmojiFilter,
+    HTML::Pipeline::AutolinkFilter,
+  ]
   self.email_reply_to = -> postable { "#{postable.hash_id}@#{Thredded.email_incoming_host}" }
   self.layout = 'thredded/application'
   self.moderator_column = :admin

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -35,7 +35,8 @@ module Thredded
     :layout,
     :user_class,
     :user_name_column,
-    :user_path
+    :user_path,
+    :whitelist_elements
 
   # @return [Symbol] The name of the method used by Thredded controllers and views to fetch the currently signed-in user
   mattr_accessor :current_user_method
@@ -53,6 +54,7 @@ module Thredded
   self.layout = 'thredded/application'
   self.moderator_column = :admin
   self.user_name_column = :name
+  self.whitelist_elements = %w( iframe span )
 
   # @return [Class<Thredded::UserExtender>] the user class from the host application.
   def self.user_class


### PR DESCRIPTION
In order to get Thredded working with the basecamp/trix editor, I had to make the following two changes:

1. Since I'm now storing html content, I needed to remove the BBContent pipeline filter -- it was clobbering the img tags inside links. So I moved the list of content_pipeline_filters to the initializer.

2. Since Trix stores uploaded images as img elements inside a figure tag nested within a link, I needed to broaden the whitelist elements to allow figure tags (and figcaption). So I moved the whitelist elements to the initializer as well.

Not sure if this is a direction you'd want to go, but thought I'd pass it on.

Thanks!