### PR TITLE
Enhance Moderation UI

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -148,6 +148,22 @@ Include thredded JavaScripts in your `application.js`:
 Thredded views also provide two `content_tag`s available to yield - `:thredded_page_title` and `:thredded_page_id`.
 The views within Thredded pass those up through to your layout if you would like to use them.
 
+### User profile page
+
+Thredded does not provide a user's profile page, but it provides a helper for rendering the user's recent posts
+in your app's user profile page.
+
+To use it:
+1. Include `Thredded::ApplicationHelper` in the app's helpers module.
+2. Render the partial like this:
+
+```erb
+<%= render 'thredded/users/_posts',
+           posts: Thredded.posts_page_view(
+               scope: user.thredded_posts.order_newest_first.limit(5),
+               current_user: current_user) %>
+```
+
 ### Customizing views
 
 You can also override any views and assets by placing them in the same path in your application as they are in the gem.

--- a/app/assets/stylesheets/thredded/_thredded.scss
+++ b/app/assets/stylesheets/thredded/_thredded.scss
@@ -10,6 +10,7 @@
   @import "layout/user-navigation";
   @import "layout/navigation";
   @import "layout/moderation";
+  @import "layout/user";
 
   @import "components/base";
   @import "components/alerts";

--- a/app/assets/stylesheets/thredded/base/_grid.scss
+++ b/app/assets/stylesheets/thredded/base/_grid.scss
@@ -22,6 +22,12 @@
   }
 }
 
+@mixin thredded-media-avatar-breakout {
+  @media (min-width: $thredded-grid-container-max-width + 4rem) {
+    @content;
+  }
+}
+
 @mixin thredded--clearfix {
   &::after {
     clear: both;

--- a/app/assets/stylesheets/thredded/base/_nav.scss
+++ b/app/assets/stylesheets/thredded/base/_nav.scss
@@ -19,3 +19,54 @@
 %thredded--nav-link-current {
   color: $thredded-nav-current-color;
 }
+
+
+%thredded--nav-tabs {
+  @extend %thredded--list-unstyled;
+  @include thredded--clearfix;
+  border-bottom: $thredded-base-border;
+  font-size: $thredded-font-size-small;
+  margin-left: 0;
+  margin-bottom: 1rem;
+  text-align: left;
+  list-style-type: none;
+
+  @include thredded-media-tablet-and-up {
+    margin-bottom: 0;
+  }
+}
+
+%thredded--nav-tabs--item {
+  display: inline-block;
+  margin-right: 1rem;
+
+  a {
+    @extend %thredded--nav-link;
+    display: inline-block;
+    color: $thredded-secondary-nav-color;
+    padding: $thredded-small-spacing 0;
+  }
+
+  &:last-child {
+    margin-right: 0;
+  }
+}
+
+%thredded--nav-tabs--item-current {
+  border-bottom: 1px solid $thredded-action-color;
+  margin-bottom: -1px;
+
+  a {
+    @extend %thredded--nav-link-current;
+  }
+}
+
+%thredded--nav-tabs--item--badge {
+  background: $thredded-badge-active-background;
+  border-radius: 10px;
+  color: $thredded-badge-active-color;
+  font-size: 0.75rem; // 12px
+  line-height: 1;
+  margin-left: 0.4rem;
+  padding: 2px 6px;
+}

--- a/app/assets/stylesheets/thredded/base/_variables.scss
+++ b/app/assets/stylesheets/thredded/base/_variables.scss
@@ -14,6 +14,7 @@ $thredded-heading-line-height: 1.2 !default;
 $thredded-large-spacing: $thredded-base-line-height * 2rem !default;
 $thredded-base-spacing: $thredded-base-line-height * 1rem !default;
 $thredded-small-spacing: $thredded-base-spacing / 2 !default;
+$thredded-inline-spacing: 0.4375em !default;
 
 // Named colors
 $thredded-brand: #4a90e2 !default;

--- a/app/assets/stylesheets/thredded/components/_base.scss
+++ b/app/assets/stylesheets/thredded/components/_base.scss
@@ -15,3 +15,7 @@
 &--blockquote {
   @extend %thredded--blockquote;
 }
+
+&--table {
+  @extend %thredded--table;
+}

--- a/app/assets/stylesheets/thredded/components/_post.scss
+++ b/app/assets/stylesheets/thredded/components/_post.scss
@@ -10,13 +10,13 @@
   border-radius: 50%;
   display: inline-block;
   height: 1.75rem; // 28px
-  margin-right: $thredded-small-spacing;
+  margin-right: $thredded-inline-spacing;
   position: relative;
   top: 6px;
   vertical-align: baseline;
   width: 1.75rem; // 28px
 
-  @media (min-width: $thredded-grid-container-max-width + 4rem) {
+  @include thredded-media-avatar-breakout {
     height: 2.25rem; // 36px
     left: -3rem;
     position: absolute;
@@ -25,16 +25,29 @@
   }
 }
 
-&--post--user {
+&--post--topic {
   @extend %thredded--heading;
-  display: inline-block;
+  font-size: $thredded-base-font-size * 1.25; // 24px
+  line-height: 1.2;
+  margin-bottom: $thredded-small-spacing / 2;
+}
+
+&--post--user,
+&--post--topic,
+&--post--user-and-topic {
+  @extend %thredded--heading;
+  display: inline;
   font-size: 1.125rem; // 18px
   line-height: 1.2;
-  margin-right: $thredded-small-spacing;
-  margin-bottom: 1.25rem; // 20px
+  margin-right: $thredded-inline-spacing;
 
   a {
     @extend %thredded--link;
+  }
+}
+
+&--post--user {
+  a {
     color: $thredded-text-color;
   }
 }

--- a/app/assets/stylesheets/thredded/components/_topics.scss
+++ b/app/assets/stylesheets/thredded/components/_topics.scss
@@ -88,6 +88,12 @@
   }
 }
 
+&--topics--moderation-state {
+  padding: 0.3em 0.5em;
+  font-size: $thredded-font-size-small;
+  font-style: normal;
+}
+
 &--topics--posts-count {
   border-radius: 50%;
   display: inline-block;

--- a/app/assets/stylesheets/thredded/layout/_moderation.scss
+++ b/app/assets/stylesheets/thredded/layout/_moderation.scss
@@ -1,12 +1,22 @@
-&--post-moderation-actions {
-  @extend %thredded--buttons-list;
+&--moderation-navigation {
+  position: relative;
+  &--items {
+    @extend %thredded--nav-tabs;
+  }
+  &--item {
+    @extend %thredded--nav-tabs--item;
+  }
 }
 
-&--moderation--history-link {
-  float: right;
-  margin: 0.4rem 0.6rem $thredded-small-spacing 0;
-  position: relative;
-  z-index: 1;
+.thredded--pending-moderation &--moderation-navigation--pending,
+.thredded--moderation-history &--moderation-navigation--history,
+.thredded--moderation-users &--moderation-navigation--users,
+.thredded--moderation-user &--moderation-navigation--users{
+  @extend %thredded--nav-tabs--item-current;
+}
+
+&--post-moderation-actions {
+  @extend %thredded--buttons-list;
 }
 
 &--moderated-notice {
@@ -15,10 +25,19 @@
   background: $thredded-light-gray;
 }
 
+&--post-moderation, &--post-moderation-record {
+  .thredded--post--user a {
+    color: $thredded-action-color;
+  }
+}
+
 &--post-moderation-record {
   .thredded--post {
     margin-bottom: 0;
-    margin-left: 4rem;
+    margin-left: 1rem;
+    @include thredded-media-avatar-breakout {
+      margin-left: 4rem;
+    }
   }
   &--moderation-state-notice {
     margin-bottom: 1rem;
@@ -42,4 +61,41 @@
 
 &--post-moderation-record + &--post-moderation-record {
   margin-top: $thredded-large-spacing;
+}
+
+&--moderation--users-table {
+  width: 100%;
+  a {
+    display: block;
+  }
+}
+
+&--moderation--avatar {
+  border-radius: 50%;
+  display: inline-block;
+  height: 1.75em; // 28px
+  width: 1.75em; // 28px
+  margin-right: $thredded-inline-spacing;
+  vertical-align: baseline;
+  position: relative;
+  top: 0.5em;
+}
+
+&--moderation--user--title {
+  margin: 0;
+}
+
+&--moderation--user--info {
+  margin-left: 2rem;
+}
+
+&--user--moderation-actions {
+  text-align: left;
+  margin-left: 4rem;
+  .button_to {
+    display: inline-block;
+  }
+  .button_to + .button_to {
+    margin-left: $thredded-small-spacing;
+  }
 }

--- a/app/assets/stylesheets/thredded/layout/_moderation.scss
+++ b/app/assets/stylesheets/thredded/layout/_moderation.scss
@@ -70,17 +70,6 @@
   }
 }
 
-&--moderation--avatar {
-  border-radius: 50%;
-  display: inline-block;
-  height: 1.75em; // 28px
-  width: 1.75em; // 28px
-  margin-right: $thredded-inline-spacing;
-  vertical-align: baseline;
-  position: relative;
-  top: 0.5em;
-}
-
 &--moderation--user--title {
   margin: 0;
 }

--- a/app/assets/stylesheets/thredded/layout/_navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_navigation.scss
@@ -24,7 +24,7 @@
       padding-right: $icon-nav-item-width * 3;
     }
   }
-  &--navigation--search {
+  &--navigation--search-topics {
     display: none;
     .thredded--messageboards-index &,
     .thredded--topics-index &,

--- a/app/assets/stylesheets/thredded/layout/_user-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_user-navigation.scss
@@ -1,40 +1,9 @@
 &--user-navigation {
-  @extend %thredded--list-unstyled;
-  @include thredded--clearfix;
-  border-bottom: $thredded-base-border;
-  margin-bottom: 1rem;
-  text-align: left;
-
-  @include thredded-media-tablet-and-up {
-    font-size: $thredded-font-size-small;
-    margin-bottom: 0;
-  }
-
-  a {
-    @extend %thredded--nav-link;
-    color: $thredded-secondary-nav-color;
-  }
-
-  > ul {
-    @extend %thredded--list-unstyled;
-  }
+  @extend %thredded--nav-tabs;
 }
 
 &--user-navigation--item {
-  display: inline-block;
-  margin-right: 1rem;
-
-  a {
-    padding: $thredded-small-spacing 0;
-  }
-
-  &:last-child {
-    margin-right: 0;
-  }
-
-  @include thredded-media-tablet-and-up {
-    padding: $thredded-small-spacing 0;
-  }
+  @extend %thredded--nav-tabs--item;
 }
 
 .thredded--preferences &--user-navigation--settings,
@@ -42,22 +11,13 @@
 .thredded--private-topics-index &--user-navigation--private-topics,
 .thredded--private-topic-show &--user-navigation--private-topics,
 .thredded--pending-moderation &--user-navigation--moderation,
-.thredded--moderation-history &--user-navigation--moderation {
-  border-bottom: 1px solid $thredded-action-color;
-  margin-bottom: -1px;
-
-  a {
-    @extend %thredded--nav-link-current;
-  }
+.thredded--moderation-history &--user-navigation--moderation,
+.thredded--moderation-users &--user-navigation--moderation,
+.thredded--moderation-user &--user-navigation--moderation {
+  @extend %thredded--nav-tabs--item-current;
 }
 
 &--user-navigation--private-topics--unread,
 &--user-navigation--moderation--pending-count {
-  background: $thredded-badge-active-background;
-  border-radius: 10px;
-  color: $thredded-badge-active-color;
-  font-size: 0.75rem; // 12px
-  line-height: 1;
-  margin-left: 0.4rem;
-  padding: 2px 6px;
+  @extend %thredded--nav-tabs--item--badge;
 }

--- a/app/assets/stylesheets/thredded/layout/_user.scss
+++ b/app/assets/stylesheets/thredded/layout/_user.scss
@@ -1,0 +1,10 @@
+&--user--avatar {
+  border-radius: 50%;
+  display: inline-block;
+  height: 1.75em;
+  width: 1.75em;
+  margin-right: $thredded-inline-spacing;
+  vertical-align: baseline;
+  position: relative;
+  top: 0.5em;
+}

--- a/app/commands/thredded/moderate_post.rb
+++ b/app/commands/thredded/moderate_post.rb
@@ -15,7 +15,7 @@ module Thredded
           previous_moderation_state: post.moderation_state,
           moderation_state: moderation_state,
         )
-        if post.user_detail.pending_moderation?
+        if post.user_id && post.user_detail.pending_moderation?
           post.user_detail.update!(moderation_state: moderation_state)
         end
         if post.postable.first_post == post

--- a/app/controllers/thredded/messageboards_controller.rb
+++ b/app/controllers/thredded/messageboards_controller.rb
@@ -8,7 +8,7 @@ module Thredded
 
     def index
       @groups = policy_scope(Messageboard.all)
-        .preload(:group).group_by(&:group)
+        .preload(:group, last_topic: [:last_user]).group_by(&:group)
         .map { |(group, messageboards)| MessageboardGroupView.new(group, messageboards) }
     end
 

--- a/app/controllers/thredded/moderation_controller.rb
+++ b/app/controllers/thredded/moderation_controller.rb
@@ -13,17 +13,17 @@ module Thredded
           .pending_moderation
           .order_oldest_first
           .preload(:user, :postable)
-          .page(params[:page] || 1)
+          .page(current_page)
       )
       if flash[:last_moderated_record_id]
-        @last_moderated_record = accessible_moderation_records.find(flash[:last_moderated_record_id].to_i)
+        @last_moderated_record = accessible_post_moderation_records.find(flash[:last_moderated_record_id].to_i)
       end
     end
 
     def history
-      @post_moderation_records = accessible_moderation_records
+      @post_moderation_records = accessible_post_moderation_records
         .order(created_at: :desc)
-        .page(params[:page] || 1)
+        .page(current_page)
     end
 
     def moderate_post
@@ -36,13 +36,42 @@ module Thredded
       redirect_back fallback_location: pending_moderation_path
     end
 
+    def users
+      @users = Thredded.user_class
+        .left_join_thredded_user_details
+        .merge(Thredded::UserDetail.order(moderation_state_changed_at: :desc))
+      @query = params[:q].to_s
+      if @query.present?
+        @users = DbTextSearch::CaseInsensitive.new(@users, Thredded.user_name_column).prefix(@query)
+      end
+      @users = @users.page(current_page)
+    end
+
+    def user
+      @user = Thredded.user_class.find(params[:id])
+      # Do not apply policy_scope here, as we want to show blocked posts as well.
+      posts_scope = @user.thredded_posts
+        .where(messageboard_id: policy_scope(Messageboard.all).pluck(:id))
+        .order_newest_first
+        .includes(:postable)
+        .page(current_page)
+      @posts = PostsPageView.new(current_user, posts_scope)
+    end
+
+    def moderate_user
+      return head(:bad_request) unless Thredded::UserDetail.moderation_states.include?(params[:moderation_state])
+      user = Thredded.user_class.find(params[:id])
+      user.thredded_user_detail.update!(moderation_state: params[:moderation_state])
+      redirect_back fallback_location: user_moderation_path(user.id)
+    end
+
     private
 
     def moderatable_posts
       Thredded::Post.where(messageboard_id: @moderatable_messageboards)
     end
 
-    def accessible_moderation_records
+    def accessible_post_moderation_records
       Thredded::PostModerationRecord
         .where(messageboard_id: @moderatable_messageboards)
     end
@@ -52,6 +81,10 @@ module Thredded
       if @moderatable_messageboards.empty?
         fail Pundit::NotAuthorizedError, 'You are not authorized to perform this action.'
       end
+    end
+
+    def current_page
+      (params[:page] || 1).to_i
     end
   end
 end

--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -18,12 +18,14 @@ module Thredded
     end
 
     # @param datetime [DateTime]
+    # @param default [String] a string to return if time is nil.
     # @return [String] html_safe datetime presentation
-    def time_ago(datetime)
+    def time_ago(datetime, default: '-')
       timeago_tag datetime,
                   lang: I18n.locale.to_s.downcase,
                   format: -> (t, _opts) { t.year == Time.current.year ? :short : :long },
-                  nojs: true
+                  nojs: true,
+                  default: default
     end
 
     def paginate(collection, args = {})

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -14,6 +14,7 @@ module Thredded
       validates :content, presence: true
 
       scope :order_oldest_first, -> { order(id: :asc) }
+      scope :order_newest_first, -> { order(id: :desc) }
 
       after_commit :update_parent_last_user_and_timestamp, on: [:create, :destroy]
     end

--- a/app/models/concerns/thredded/topic_common.rb
+++ b/app/models/concerns/thredded/topic_common.rb
@@ -13,7 +13,6 @@ module Thredded
       scope :on_page, -> (page_num) { page(page_num).per(30) }
 
       validates :hash_id, presence: true, uniqueness: true
-      validates :last_user_id, presence: true
       validates :posts_count, numericality: true
 
       before_validation do

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -26,9 +26,7 @@ module Thredded
     has_many :posts, dependent: :destroy
     has_many :topics, dependent: :destroy, inverse_of: :messageboard
 
-    # TODO: change this to a belongs_to association to be able to preload efficiently
-    has_one :latest_topic, -> { order_recently_updated_first },
-            class_name: 'Thredded::Topic'
+    belongs_to :last_topic, class_name: 'Thredded::Topic'
 
     has_many :user_details, through: :posts
     has_many :messageboard_users,
@@ -56,8 +54,8 @@ module Thredded
     scope :top_level_messageboards, -> { where(group: nil) }
     scope :by_messageboard_group, ->(group) { where(group: group.id) }
 
-    def latest_user
-      latest_topic.last_user
+    def last_user
+      last_topic.try(:last_user)
     end
 
     def slug_candidates

--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -21,6 +21,8 @@ module Thredded
     has_many :moderation_records,
              class_name: 'Thredded::PostModerationRecord',
              dependent: :nullify
+    has_one :last_moderation_record, -> { order_newest_first },
+            class_name: 'Thredded::PostModerationRecord'
 
     validates :messageboard_id, presence: true
 

--- a/app/models/thredded/post_moderation_record.rb
+++ b/app/models/thredded/post_moderation_record.rb
@@ -37,7 +37,7 @@ module Thredded
         post:                      post,
         post_content:              post.content,
         post_user:                 post.user,
-        post_user_name:            post.user.send(Thredded.user_name_column),
+        post_user_name:            post.user.try(:send, Thredded.user_name_column),
         messageboard_id:           post.messageboard_id,
       )
     end

--- a/app/models/thredded/post_moderation_record.rb
+++ b/app/models/thredded/post_moderation_record.rb
@@ -8,6 +8,8 @@ module Thredded
     end
     validates :previous_moderation_state, presence: true
 
+    scope :order_newest_first, -> { order(created_at: :desc, id: :desc) }
+
     belongs_to :messageboard, inverse_of: :post_moderation_records
     validates :messageboard_id, presence: true
     belongs_to :post, inverse_of: :moderation_records

--- a/app/models/thredded/topic.rb
+++ b/app/models/thredded/topic.rb
@@ -109,6 +109,11 @@ module Thredded
       title_changed?
     end
 
+    # @return [Thredded::PostModerationRecord, nil]
+    def last_moderation_record
+      first_post.try(:last_moderation_record)
+    end
+
     private
 
     def slug_candidates

--- a/app/models/thredded/user_extender.rb
+++ b/app/models/thredded/user_extender.rb
@@ -41,6 +41,13 @@ module Thredded
         opt.has_many :thredded_post_moderation_records, foreign_key: 'post_user_id', inverse_of: :post_user
         opt.has_many :thredded_post_moderated_records, foreign_key: 'moderator_id', inverse_of: :moderator
       end
+
+      scope :left_join_thredded_user_details, (lambda do
+        users = arel_table
+        user_details = Thredded::UserDetail.arel_table
+        joins(users.join(user_details, Arel::Nodes::OuterJoin)
+                .on(users[:id].eq(user_details[:user_id])).join_sources)
+      end)
     end
 
     def thredded_user_preference

--- a/app/policies/thredded/post_policy.rb
+++ b/app/policies/thredded/post_policy.rb
@@ -41,6 +41,8 @@ module Thredded
       @post.postable.first_post != @post && update?
     end
 
+    delegate :moderate?, to: :messageboard_policy
+
     private
 
     def messageboard_policy

--- a/app/policies/thredded/topic_policy.rb
+++ b/app/policies/thredded/topic_policy.rb
@@ -21,17 +21,17 @@ module Thredded
     # @param user [Thredded.user_class]
     # @param topic [Thredded::Topic]
     def initialize(user, topic)
-      @user = user
-      @topic = topic
-      @messageboard_user_permission = MessageboardPolicy.new(user, topic.messageboard)
+      @user                = user
+      @topic               = topic
+      @messageboard_policy = MessageboardPolicy.new(user, topic.messageboard)
     end
 
     def create?
-      @messageboard_user_permission.post?
+      @messageboard_policy.post?
     end
 
     def read?
-      @messageboard_user_permission.read? && @topic.moderation_state_visible_to_user?(@user)
+      @messageboard_policy.read? && @topic.moderation_state_visible_to_user?(@user)
     end
 
     def update?
@@ -43,7 +43,7 @@ module Thredded
     end
 
     def moderate?
-      @messageboard_user_permission.moderate?
+      @messageboard_policy.moderate?
     end
   end
 end

--- a/app/view_models/thredded/post_view.rb
+++ b/app/view_models/thredded/post_view.rb
@@ -36,6 +36,10 @@ module Thredded
       Thredded::UrlsHelper.delete_post_path(@post)
     end
 
+    def permalink_path
+      Thredded::UrlsHelper.post_permalink_path(@post.id)
+    end
+
     def cache_key
       [
         I18n.locale,

--- a/app/view_models/thredded/posts_page_view.rb
+++ b/app/view_models/thredded/posts_page_view.rb
@@ -6,6 +6,7 @@ module Thredded
   # A view model for a page of PostViews.
   class PostsPageView
     delegate :to_ary,
+             :present?,
              to: :@post_views
     delegate :total_pages,
              :current_page,

--- a/app/view_models/thredded/topic_view.rb
+++ b/app/view_models/thredded/topic_view.rb
@@ -2,7 +2,7 @@
 module Thredded
   # A view model for Topic.
   class TopicView < BaseTopicView
-    delegate :categories, :id,
+    delegate :categories, :id, :blocked?, :last_moderation_record,
              to: :@topic
 
     # @param topic [TopicCommon]
@@ -28,6 +28,10 @@ module Thredded
         (:sticky if @topic.sticky?),
         (@follow ? :following : :notfollowing)
       ].compact
+    end
+
+    def can_moderate?
+      @policy.moderate?
     end
 
     def edit_path

--- a/app/views/thredded/messageboards/_messageboard.html.erb
+++ b/app/views/thredded/messageboards/_messageboard.html.erb
@@ -11,11 +11,11 @@
 
     <p class="thredded--messageboard--description"><%= messageboard.description %></p>
 
-    <% if messageboard.latest_topic %>
+    <% if messageboard.last_topic %>
       <p class="thredded--messageboard--byline">
         <%= t 'thredded.messageboard.last_updated_by_html',
-              time_ago: time_ago(messageboard.latest_topic.updated_at),
-              user:     messageboard.latest_user %>
+              time_ago: time_ago(messageboard.last_topic.updated_at),
+              user:     messageboard.last_user %>
       </p>
     <% end %>
   <% end %>

--- a/app/views/thredded/moderation/_nav.html.erb
+++ b/app/views/thredded/moderation/_nav.html.erb
@@ -1,0 +1,16 @@
+<% content_for :thredded_main_navigation do %>
+  <nav class="thredded--moderation-navigation">
+    <ul class="thredded--moderation-navigation--items">
+      <li class="thredded--moderation-navigation--item thredded--moderation-navigation--pending">
+        <%= link_to t('thredded.nav.moderation_pending'), pending_moderation_path %>
+      </li>
+      <li class="thredded--moderation-navigation--item thredded--moderation-navigation--history">
+        <%= link_to t('thredded.nav.moderation_history'), moderation_history_path %>
+      </li>
+      <li class="thredded--moderation-navigation--item thredded--moderation-navigation--users">
+        <%= link_to t('thredded.nav.moderation_users'), users_moderation_path %>
+      </li>
+    </ul>
+    <%= render 'users_search_form' %>
+  </nav>
+<% end %>

--- a/app/views/thredded/moderation/_post.html.erb
+++ b/app/views/thredded/moderation/_post.html.erb
@@ -1,6 +1,13 @@
 <%# @param post [Thredded::PostView] %>
-<%= content_tag :article, id: dom_id(post), class: 'thredded--post' do %>
-  <%= render 'thredded/posts_common/header', post: post %>
+<%= content_tag :article, id: dom_id(post), class: 'thredded--post thredded--post-moderation' do %>
+  <%= render 'thredded/posts_common/header_with_user_and_topic',
+             post:           post,
+             post_user_link: if post.user
+                               link_to(post.user, user_moderation_path(post.user.id))
+                             else
+                               content_tag :em, t('thredded.null_user_name')
+                             end
+  %>
   <%= render 'thredded/posts_common/content', post: post %>
   <%= render 'thredded/posts_common/actions', post: post %>
   <%= render 'post_moderation_actions', post: post %>

--- a/app/views/thredded/moderation/_post_moderation_record.html.erb
+++ b/app/views/thredded/moderation/_post_moderation_record.html.erb
@@ -1,20 +1,24 @@
 <%
-  post = post_moderation_record.post
+  record = post_moderation_record
+  post = record.post
+  if post
+    post_view = Thredded::PostView.new(post, policy(post))
+  end
   moderation_state_notice_args = {
-      moderator: user_link(post_moderation_record.moderator),
-      time_ago:  time_ago(post_moderation_record.created_at)
+      moderator: user_link(record.moderator),
+      time_ago:  time_ago(record.created_at)
   }
 %>
-<article class="thredded--post-moderation-record thredded--post-moderation-record-<%= post_moderation_record.moderation_state %>">
+<article class="thredded--post-moderation-record thredded--post-moderation-record-<%= record.moderation_state %>">
   <header class="thredded--post-moderation-record--header">
     <p class="thredded--post-moderation-record--moderation-state-notice">
-      <% if post_moderation_record.approved? %>
+      <% if record.approved? %>
         <%= t('thredded.moderation.post_approved_html', moderation_state_notice_args) %>
-      <% elsif post_moderation_record.blocked? %>
+      <% elsif record.blocked? %>
         <%= t('thredded.moderation.post_blocked_html', moderation_state_notice_args) %>
       <% end %>
     </p>
-    <% if post && post.content != post_moderation_record.post_content %>
+    <% if post && post.content != record.post_content %>
       <p class="thredded--post-moderation-record--content-changed-notice">
         <%= t('thredded.moderation.posts_content_changed_since_moderation_html', post_url: post_permalink_path(post)) %>
       </p>
@@ -22,21 +26,20 @@
     <%= t 'thredded.moderation.post_deleted_notice' unless post %>
   </header>
   <article class="thredded--post">
-    <header>
-      <% if post_moderation_record.post_user %>
-        <%= image_tag Thredded.avatar_url.call(post_moderation_record.post_user), class: 'thredded--post--avatar' %>
-        <h2 class="thredded--post--user"><%= user_link post_moderation_record.post_user %></h2>
+    <% post_user_link = capture do %>
+      <% if post.user %>
+        <%= link_to post.user, user_moderation_path(post.user.id) %>
       <% else %>
-        <h2 class="thredded--post--user">
-          <%= post_moderation_record.post_user_name %>, <em><%= t 'thredded.null_user_name' %></em>
-        </h2>
+        <%= safe_join [record.post_user_name, content_tag(:em, t('thredded.null_user_name'))].compact, ', ' %>
       <% end %>
-      <% if post %>
-        <p class="thredded--post--created-at"><%= time_ago post.created_at %></p>
-      <% end %>
-    </header>
+    <% end %>
+    <% if post %>
+      <%= render 'thredded/posts_common/header_with_user_and_topic', post: post_view, post_user_link: post_user_link %>
+    <% else %>
+      <header><h2 class="thredded--post--user"><%= post_user_link %></h2></header>
+    <% end %>
     <div class="thredded--post--content">
-      <%= Thredded::ContentFormatter.new(self).format_content(post_moderation_record.post_content) %>
+      <%= Thredded::ContentFormatter.new(self).format_content(record.post_content) %>
     </div>
   </article>
   <%= render 'post_moderation_actions', post: post if post %>

--- a/app/views/thredded/moderation/_user_moderation_state.html.erb
+++ b/app/views/thredded/moderation/_user_moderation_state.html.erb
@@ -1,0 +1,3 @@
+<% user_detail = user.thredded_user_detail %>
+<%= user_detail.moderation_state.to_s.humanize %>
+<%= time_ago user_detail.moderation_state_changed_at, default: '' %>

--- a/app/views/thredded/moderation/_user_post.html.erb
+++ b/app/views/thredded/moderation/_user_post.html.erb
@@ -1,0 +1,7 @@
+<%# @param post [Thredded::PostView] %>
+<%= content_tag :article, id: dom_id(post), class: 'thredded--post thredded--post-moderation' do %>
+  <%= render 'thredded/posts_common/header_with_topic', post: post %>
+  <%= render 'thredded/posts_common/content', post: post %>
+  <%= render 'thredded/posts_common/actions', post: post %>
+  <%= render 'post_moderation_actions', post: post %>
+<% end %>

--- a/app/views/thredded/moderation/_users_search_form.html.erb
+++ b/app/views/thredded/moderation/_users_search_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_tag users_moderation_path, class: 'thredded--form thredded--navigation--search', method: 'get' do %>
+  <%= label_tag :q, t('thredded.moderation.search_users.form_label') %>
+  <%= text_field_tag :q, @query,
+                     type:        'search',
+                     required:    true,
+                     # If there are no results the user will likely want to change the query, so auto-focus.
+                     autofocus:   @query.presence && !@users.presence,
+                     placeholder: t('thredded.moderation.search_users.form_placeholder') %>
+  <button type="submit"><%= t 'thredded.search.form.btn_submit' %></button>
+<% end %>

--- a/app/views/thredded/moderation/history.html.erb
+++ b/app/views/thredded/moderation/history.html.erb
@@ -1,13 +1,7 @@
 <% content_for :thredded_page_title,
                safe_join([t('thredded.nav.moderation'), t('thredded.nav.moderation_history')], ': ') %>
-<% content_for :thredded_page_id, 'thredded--pending-moderation' %>
-<% content_for :thredded_breadcrumbs do %>
-  <ul class="thredded--navigation-breadcrumbs">
-    <li><%= link_to t('thredded.nav.all_messageboards'), messageboards_path %></li>
-    <li><%= link_to t('thredded.nav.moderation'), pending_moderation_path %></li>
-    <li><%= link_to t('thredded.nav.moderation_history'), moderation_history_path %></li>
-  </ul>
-<% end %>
+<% content_for :thredded_page_id, 'thredded--moderation-history' %>
+<%= render 'nav' %>
 
 <%= thredded_page do %>
   <%= content_tag :section, class: 'thredded--main-section' do %>

--- a/app/views/thredded/moderation/pending.html.erb
+++ b/app/views/thredded/moderation/pending.html.erb
@@ -1,16 +1,9 @@
 <% content_for :thredded_page_title, t('thredded.nav.moderation') %>
 <% content_for :thredded_page_id, 'thredded--pending-moderation' %>
-<% content_for :thredded_breadcrumbs do %>
-  <ul class="thredded--navigation-breadcrumbs">
-    <li><%= link_to t('thredded.nav.all_messageboards'), messageboards_path %></li>
-    <li><%= link_to t('thredded.nav.moderation'), pending_moderation_path %></li>
-  </ul>
-<% end %>
+<%= render 'nav' %>
 
 <%= thredded_page do %>
   <%= content_tag :section, class: 'thredded--main-section' do %>
-    <%= link_to t('thredded.nav.moderation_history'), moderation_history_path,
-                class: 'thredded--link thredded--moderation--history-link' %>
     <% if @last_moderated_record %>
       <div class="thredded--moderated-notice">
         <%= render 'post_moderation_record', post_moderation_record: @last_moderated_record %>
@@ -21,8 +14,8 @@
       <%= paginate @posts %>
     <% else %>
       <div class="thredded--empty">
-        <h3 class="thredded--empty--title"><%= t 'thredded.moderation.pending_empty.title' %></h3>
-        <p><%= t 'thredded.moderation.pending_empty.content' %></p>
+        <h3 class="thredded--empty--title"><%= t 'thredded.moderation.pending.empty.title' %></h3>
+        <p><%= t 'thredded.moderation.pending.empty.content' %></p>
       </div>
     <% end %>
   <% end %>

--- a/app/views/thredded/moderation/user.html.erb
+++ b/app/views/thredded/moderation/user.html.erb
@@ -1,0 +1,42 @@
+<%
+  user = @user
+  user_detail = user.thredded_user_detail
+%>
+<% content_for :thredded_page_title, t('thredded.nav.moderation') %>
+<% content_for :thredded_page_id, 'thredded--moderation-user' %>
+<%= render 'nav' %>
+<%= thredded_page do %>
+  <h1 class="thredded--moderation--user--title">
+    <%= image_tag Thredded.avatar_url.call(user), class: 'thredded--moderation--avatar' %><%= user %>
+  </h1>
+  <ul class="thredded--moderation--user--info">
+    <li><%= t 'thredded.users.user_since_html', time_ago: time_ago(user.created_at) %></li>
+    <% if user_detail.last_seen_at %>
+      <li><%= t 'thredded.users.last_active_html', time_ago: time_ago(user_detail.last_seen_at) %></li>
+    <% end %>
+    <% if user_detail.topics_count > 0 %>
+      <li><%= t 'thredded.users.started_topics_count', count: user_detail.topics_count %></li>
+    <% end %>
+    <% if user_detail.posts_count > 0 %>
+      <li><%= t 'thredded.users.posts_count', count: user_detail.posts_count %></li>
+    <% end %>
+    <li><%= render 'user_moderation_state', user: @user %></li>
+  </ul>
+  <div class="thredded--user--moderation-actions">
+    <% unless user_detail.approved? %>
+      <%= button_to t('thredded.moderation.approve_btn'), moderate_user_path,
+                    class:  'thredded--button',
+                    params: { id: user.to_model.id, moderation_state: 'approved' } %>
+    <% end %>
+    <% unless user_detail.blocked? %>
+      <%= button_to t('thredded.moderation.block_btn'), moderate_user_path,
+                    class:  'thredded--button',
+                    params: { id: user.to_model.id, moderation_state: 'blocked' } %>
+    <% end %>
+  </div>
+  <% if @posts.present? %>
+    <h2><%= t 'thredded.users.recent_activity' %></h2>
+    <%= render partial: 'user_post', collection: @posts, as: :post %>
+    <%= paginate @posts %>
+  <% end %>
+<% end %>

--- a/app/views/thredded/moderation/user.html.erb
+++ b/app/views/thredded/moderation/user.html.erb
@@ -7,7 +7,7 @@
 <%= render 'nav' %>
 <%= thredded_page do %>
   <h1 class="thredded--moderation--user--title">
-    <%= image_tag Thredded.avatar_url.call(user), class: 'thredded--moderation--avatar' %><%= user %>
+    <%= image_tag Thredded.avatar_url.call(user), class: 'thredded--user--avatar' %><%= user %>
   </h1>
   <ul class="thredded--moderation--user--info">
     <li><%= t 'thredded.users.user_since_html', time_ago: time_ago(user.created_at) %></li>

--- a/app/views/thredded/moderation/users.html.erb
+++ b/app/views/thredded/moderation/users.html.erb
@@ -1,0 +1,38 @@
+<% content_for :thredded_page_title, t('thredded.nav.moderation') %>
+<% content_for :thredded_page_id, 'thredded--moderation-users' %>
+<%= render 'nav' %>
+
+<%= thredded_page do %>
+  <% if @users.present? %>
+    <% if @query.present? %>
+      <p class="thredded--alert thredded--alert-success">
+        <%= t 'thredded.moderation.search_users.results_message', query: "'#{@query}'" %>
+      </p>
+    <% end %>
+    <table class="thredded--moderation--users-table thredded--table">
+      <thead>
+      <tr>
+        <th>User</th>
+        <th>Moderation state</th>
+      </tr>
+      </thead>
+      <tbody>
+      <% @users.each do |user| %>
+        <tr>
+          <td>
+            <%= link_to user, user_moderation_path(user.id), class: 'thredded--link' %>
+          </td>
+          <td>
+            <%= render 'user_moderation_state', user: user %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+    <%= paginate @users %>
+  <% else %>
+    <p class="thredded--alert thredded--alert-danger">
+      <%= t 'thredded.moderation.search_users.no_results_message', query: "'#{@query}'" %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/thredded/posts/_post.html.erb
+++ b/app/views/thredded/posts/_post.html.erb
@@ -5,6 +5,10 @@
     <%= render 'thredded/posts_common/actions', post: post %>
     <% if post.pending_moderation? && !Thredded.content_visible_while_pending_moderation %>
       <p class="thredded--alert thredded--alert-warning"><%= t 'thredded.posts.pending_moderation_notice' %></p>
+    <% elsif post.blocked? && post.can_moderate? %>
+      <p class="thredded--alert thredded--alert-danger">
+        <%= render 'thredded/shared/content_moderation_blocked_state', moderation_record: post.last_moderation_record %>
+      </p>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/thredded/posts_common/_header.html.erb
+++ b/app/views/thredded/posts_common/_header.html.erb
@@ -1,3 +1,4 @@
+<%# @param post [Thredded::PostView] %>
 <header>
   <%= image_tag post.avatar_url, class: 'thredded--post--avatar' if post.user %>
   <h2 class="thredded--post--user"><%= user_link post.user %></h2>

--- a/app/views/thredded/posts_common/_header_with_topic.html.erb
+++ b/app/views/thredded/posts_common/_header_with_topic.html.erb
@@ -1,0 +1,15 @@
+<%# @param post [Thredded::PostView] %>
+<% topic = post.to_model.postable %>
+<header>
+  <h2 class="thredded--post--topic">
+    <%=
+      topic_link = link_to(topic.title, post.permalink_path)
+      if topic.first_post == post.to_model
+        t 'thredded.users.started_topic_html', topic_link: topic_link
+      else
+        t 'thredded.users.posted_in_topic_html', topic_link: topic_link
+      end
+    %>
+  </h2>
+  <p class="thredded--post--created-at"><%= time_ago post.created_at %></p>
+</header>

--- a/app/views/thredded/posts_common/_header_with_user_and_topic.html.erb
+++ b/app/views/thredded/posts_common/_header_with_user_and_topic.html.erb
@@ -1,0 +1,18 @@
+<%# @param post [Thredded::PostView] %>
+<%# @param post_user_link [String] optional %>
+<% topic = post.to_model.postable %>
+<% post_user_link ||= user_link(post.user) %>
+<header>
+  <%= image_tag post.avatar_url, class: 'thredded--post--avatar' if post.user %>
+  <h2 class="thredded--post--user-and-topic">
+    <%=
+      topic_link = link_to(topic.title, post.permalink_path)
+      if topic.first_post == post.to_model
+        t 'thredded.users.user_started_topic_html', user_link: post_user_link, topic_link: topic_link
+      else
+        t 'thredded.users.user_posted_in_topic_html', user_link: post_user_link, topic_link: topic_link
+      end
+    %>
+  </h2>
+  <p class="thredded--post--created-at"><%= time_ago post.created_at %></p>
+</header>

--- a/app/views/thredded/search/_form.html.erb
+++ b/app/views/thredded/search/_form.html.erb
@@ -1,4 +1,6 @@
-<%= form_tag search_path(messageboard), class: 'thredded--form thredded--navigation--search', method: 'get' do %>
+<%= form_tag search_path(messageboard),
+             method: 'get',
+             class: 'thredded--form thredded--navigation--search thredded--navigation--search-topics' do %>
   <%= label_tag :q, t('thredded.search.form.label') %>
   <%= text_field_tag :q, @query,
                      type:        'search',

--- a/app/views/thredded/shared/_content_moderation_blocked_state.html.erb
+++ b/app/views/thredded/shared/_content_moderation_blocked_state.html.erb
@@ -1,0 +1,8 @@
+<% # @param moderation_record [Thredded::PostModerationRecord, nil] %>
+<% if moderation_record %>
+  <%= t 'thredded.content_moderation_states.content_blocked_notice_with_record_html',
+        moderator: user_link(moderation_record.moderator),
+        time_ago: time_ago(moderation_record.created_at) %>
+<% else %>
+  <%= t 'thredded.content_moderation_states.content_blocked_notice' %>
+<% end %>

--- a/app/views/thredded/shared/_nav.html.erb
+++ b/app/views/thredded/shared/_nav.html.erb
@@ -14,8 +14,12 @@
       <%= render 'thredded/shared/nav/standalone' %>
     <% end %>
   </ul>
-  <div class="thredded--main-navigation">
-    <%= yield :thredded_breadcrumbs %>
-    <%= render 'thredded/search/form', messageboard: messageboard_or_nil %>
-  </div>
+  <% if content_for? :thredded_main_navigation %>
+    <%= yield :thredded_main_navigation %>
+  <% else %>
+    <div class="thredded--main-navigation">
+      <%= yield :thredded_breadcrumbs %>
+      <%= render 'thredded/search/form', messageboard: messageboard_or_nil %>
+    </div>
+  <% end %>
 </nav>

--- a/app/views/thredded/topics/_topic.html.erb
+++ b/app/views/thredded/topics/_topic.html.erb
@@ -22,4 +22,10 @@
     <%= time_ago topic.created_at %>
     <%= user_link topic.user %>
   </cite>
+
+  <% if topic.blocked? && topic.can_moderate? %>
+    <span class="thredded--topics--moderation-state thredded--alert thredded--alert-danger">
+      <%= render 'thredded/shared/content_moderation_blocked_state', moderation_record: topic.last_moderation_record %>
+    </span>
+  <% end %>
 <% end %>

--- a/app/views/thredded/users/_post.html.erb
+++ b/app/views/thredded/users/_post.html.erb
@@ -1,0 +1,6 @@
+<%# @param post [Thredded::PostView] %>
+<%= content_tag :article, id: dom_id(post), class: 'thredded--post' do %>
+  <%= render 'thredded/posts_common/header_with_topic', post: post %>
+  <%= render 'thredded/posts_common/content', post: post %>
+  <%= render 'thredded/posts_common/actions', post: post %>
+<% end %>

--- a/app/views/thredded/users/_posts.html.erb
+++ b/app/views/thredded/users/_posts.html.erb
@@ -1,0 +1,7 @@
+<%#
+  This partial can be called from the parent app to render the user's posts.
+  The parent view context that renders this partial must include Thredded::ApplicationHelper.
+  TODO: Use a Cell instead. https://github.com/apotonick/cells
+%>
+<%# @param posts [Thredded::PostsPageView] %>
+<%= render partial: 'thredded/users/post', collection: posts %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,9 @@ en:
       private_topic_not_found: This private topic does not exist.
     form:
       update: Update
+    content_moderation_states:
+      content_blocked_notice: Blocked by a moderator
+      content_blocked_notice_with_record_html: Blocked by %{moderator} %{time_ago}
     messageboard:
       create: Create a New Messageboard
       form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,15 +23,21 @@ en:
     moderation:
       approve_btn: Approve
       block_btn: Block
-      pending_empty:
-        content: All posts have been moderated.
-        title: Good job!
+      pending:
+        empty:
+          content: All posts have been moderated.
+          title: Good job!
       post_approved_html: Post approved by %{moderator} %{time_ago}.
       post_blocked_html: Post blocked by %{moderator} %{time_ago}.
       post_deleted_notice: This post has been deleted.
       posts_content_changed_since_moderation_html: >-
         The <a href="%{post_url}">post's</a> content change since it was moderated. Below is the content at the
         time it was moderated.
+      search_users:
+        form_label: Search users
+        form_placeholder: :thredded.moderation.search_users.form_label
+        results_message: Users with names starting with %{query}
+        no_results_message: No users with name starting with %{query}
     nav:
       all_messageboards: All Messageboards
       edit_messageboard: Edit Messageboard
@@ -40,6 +46,8 @@ en:
       edit_topic: Edit
       moderation: Moderation
       moderation_history: History
+      moderation_pending: Pending
+      moderation_users: Users
       private_topics: Private Messages
       settings: Notification Settings
     null_user_name: Deleted user
@@ -126,3 +134,18 @@ en:
       started_by_html: Started %{time_ago} by %{user}
       unfollowed_notice: You are no longer following this topic
       updated_notice: Topic updated
+    users:
+      last_active_html: "Last active %{time_ago}"
+      posted_in_topic_html: "Posted in %{topic_link}"
+      recent_activity: Recent activity
+      started_topic_html: "Started %{topic_link}"
+      user_posted_in_topic_html: "%{user_link} posted in %{topic_link}"
+      user_since_html: "User since %{time_ago}"
+      user_started_topic_html: "%{user_link} started %{topic_link}"
+      started_topics_count:
+        one: "Started one topic"
+        other: "Started %{count} topics"
+      posts_count:
+        one: "Posted once"
+        other: "Posted %{count} times"
+

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,6 +1,9 @@
 ---
 pt-BR:
   thredded:
+    content_moderation_states:
+      content_blocked_notice: Bloqueado por um moderador
+      content_blocked_notice_with_record_html: Bloqueados por %{moderator} %{time_ago}
     errors:
       login_required: Por favor, autentique-se primeiro.
       not_authorized: Você não está autorizado a acessar esta página.

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -23,15 +23,21 @@ pt-BR:
     moderation:
       approve_btn: Aprovar
       block_btn: Quadra
-      pending_empty:
-        content: Todas as mensagens têm sido moderadas.
-        title: Bom trabalho!
+      pending:
+        empty:
+          content: Todas as mensagens têm sido moderadas.
+          title: Bom trabalho!
       post_approved_html: Pós aprovado por %{moderator} %{time_ago}.
       post_blocked_html: Pós bloqueado por %{moderator} %{time_ago}.
       post_deleted_notice: Este post foi apagado.
       posts_content_changed_since_moderation_html: >-
         O <a href="%{post_url}">de pós</a> alteração de conteúdo, uma vez que foi moderado. Abaixo está o conteúdo
         no momento em que foi moderado.
+      search_users:
+        form_label: Buscar usuários
+        form_placeholder: :thredded.moderation.search_users.form_label
+        no_results_message: Nenhum usuário com o nome começando com %{query}
+        results_message: Os usuários com nomes começando com %{query}
     nav:
       all_messageboards: Todos os Fóruns de Mensagens
       edit_messageboard: Editar Fórum de Mensagem
@@ -40,6 +46,8 @@ pt-BR:
       edit_topic: Editar
       moderation: Moderação
       moderation_history: História
+      moderation_pending: Pendente
+      moderation_users: Usuários
       private_topics: Mensagens Privadas
       settings: Configurações de Notificação
     null_user_name: Usuário deletado
@@ -127,3 +135,17 @@ pt-BR:
       started_by_html: Iniciado %{time_ago} por %{user}
       unfollowed_notice: Você não está mais acompanhando este tópico
       updated_notice: Tópico atualizado
+    users:
+      last_active_html: Última %{time_ago} ativa
+      posted_in_topic_html: Postou em %{topic_link}
+      posts_count:
+        one: Postado uma vez
+        other: vezes %{count} Publicado
+      recent_activity: Atividade recente
+      started_topic_html: Começou %{topic_link}
+      started_topics_count:
+        one: Começou um tópico
+        other: tópicos iniciados %{count}
+      user_posted_in_topic_html: "%{user_link} postou em %{topic_link}"
+      user_since_html: Utilizador desde %{time_ago}
+      user_started_topic_html: "%{user_link} começou %{topic_link}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,9 +30,14 @@ Thredded::Engine.routes.draw do
   scope path: 'admin' do
     resources :messageboard_groups, only: [:new, :create]
     scope controller: :moderation, path: 'moderation' do
-      get '(/page-:page)', action: :pending, as: :pending_moderation, constraints: page_constraint
+      scope constraints: page_constraint do
+        get '(/page-:page)', action: :pending, as: :pending_moderation
+        get '/history(/page-:page)', action: :history, as: :moderation_history
+        get '/users(/page-:page)', action: :users, as: :users_moderation
+        get '/users/:id(/page-:page)', action: :user, as: :user_moderation
+      end
       post '', action: :moderate_post, as: :moderate_post
-      get '/history(/page-:page)', action: :history, as: :moderation_history, constraints: page_constraint
+      post '/user/:id', action: :moderate_user, as: :moderate_user
     end
   end
 

--- a/db/migrate/20160329231848_create_thredded.rb
+++ b/db/migrate/20160329231848_create_thredded.rb
@@ -21,7 +21,7 @@ class CreateThredded < ActiveRecord::Migration
     end
 
     create_table :thredded_categories do |t|
-      t.integer :messageboard_id, null: false
+      t.references :messageboard, null: false
       t.string :name, limit: 191, null: false
       t.string :description, limit: 255
       t.timestamps null: false
@@ -38,6 +38,7 @@ class CreateThredded < ActiveRecord::Migration
       t.integer :topics_count, default: 0
       t.integer :posts_count, default: 0
       t.boolean :closed, default: false, null: false
+      t.references :last_topic
       t.references :messageboard_group
       t.timestamps null: false
       t.index [:messageboard_group_id], name: :index_thredded_messageboards_on_messageboard_group_id
@@ -47,7 +48,7 @@ class CreateThredded < ActiveRecord::Migration
 
     create_table :thredded_post_notifications do |t|
       t.string :email, limit: 191, null: false
-      t.integer :post_id, null: false
+      t.references :post, null: false
       t.timestamps null: false
       t.string :post_type, limit: 191
       t.index [:post_id, :post_type], name: :index_thredded_post_notifications_on_post
@@ -58,8 +59,8 @@ class CreateThredded < ActiveRecord::Migration
       t.text :content, limit: 65_535
       t.string :ip, limit: 255
       t.string :source, limit: 255, default: 'web'
-      t.integer :postable_id, limit: 4
-      t.integer :messageboard_id, null: false
+      t.references :postable, null: false
+      t.references :messageboard, null: false
       t.integer :moderation_state, null: false
       t.timestamps null: false
       t.index [:moderation_state, :updated_at],
@@ -73,16 +74,16 @@ class CreateThredded < ActiveRecord::Migration
     DbTextSearch::FullText.add_index connection, :thredded_posts, :content, name: :thredded_posts_content_fts
 
     create_table :thredded_private_posts do |t|
-      t.integer :user_id, limit: 4
+      t.references :user
       t.text :content, limit: 65_535
+      t.references :postable, null: false
       t.string :ip, limit: 255
-      t.integer :postable_id, null: false
       t.timestamps null: false
     end
 
     create_table :thredded_private_topics do |t|
-      t.integer :user_id, null: false
-      t.integer :last_user_id, null: false
+      t.references :user
+      t.references :last_user
       t.string :title, limit: 255, null: false
       t.string :slug, limit: 191, null: false
       t.integer :posts_count, default: 0
@@ -93,26 +94,26 @@ class CreateThredded < ActiveRecord::Migration
     end
 
     create_table :thredded_private_users do |t|
-      t.integer :private_topic_id, limit: 4
-      t.integer :user_id, limit: 4
+      t.references :private_topic, limit: 4
+      t.references :user, limit: 4
       t.timestamps null: false
       t.index [:private_topic_id], name: :index_thredded_private_users_on_private_topic_id
       t.index [:user_id], name: :index_thredded_private_users_on_user_id
     end
 
     create_table :thredded_topic_categories do |t|
-      t.integer :topic_id, null: false
-      t.integer :category_id, null: false
+      t.references :topic, null: false
+      t.references :category, null: false
       t.index [:category_id], name: :index_thredded_topic_categories_on_category_id
       t.index [:topic_id], name: :index_thredded_topic_categories_on_topic_id
     end
 
     create_table :thredded_topics do |t|
-      t.integer :user_id, null: false
-      t.integer :last_user_id, null: false
+      t.references :user
+      t.references :last_user
       t.string :title, limit: 255, null: false
       t.string :slug, limit: 191, null: false
-      t.integer :messageboard_id, null: false
+      t.references :messageboard, null: false
       t.integer :posts_count, default: 0, null: false
       t.boolean :sticky, default: false, null: false
       t.boolean :locked, default: false, null: false
@@ -131,7 +132,7 @@ class CreateThredded < ActiveRecord::Migration
     DbTextSearch::FullText.add_index connection, :thredded_topics, :title, name: :thredded_topics_title_fts
 
     create_table :thredded_user_details do |t|
-      t.integer :user_id, null: false
+      t.references :user, null: false
       t.datetime :latest_activity_at
       t.integer :posts_count, default: 0
       t.integer :topics_count, default: 0
@@ -157,7 +158,7 @@ class CreateThredded < ActiveRecord::Migration
     end
 
     create_table :thredded_user_preferences do |t|
-      t.integer :user_id, null: false
+      t.references :user, null: false
       t.boolean :notify_on_mention, default: true, null: false
       t.boolean :notify_on_message, default: true, null: false
       t.timestamps null: false
@@ -165,8 +166,8 @@ class CreateThredded < ActiveRecord::Migration
     end
 
     create_table :thredded_user_messageboard_preferences do |t|
-      t.integer :user_id, null: false
-      t.integer :messageboard_id, null: false
+      t.references :user, null: false
+      t.references :messageboard, null: false
       t.boolean :notify_on_mention, default: true, null: false
       t.timestamps null: false
       t.index [:user_id, :messageboard_id],
@@ -177,7 +178,7 @@ class CreateThredded < ActiveRecord::Migration
     %i(topic private_topic).each do |topics_table|
       table_name = :"thredded_user_#{topics_table}_read_states"
       create_table table_name do |t|
-        t.integer :user_id, null: false
+        t.references :user, null: false
         t.integer :postable_id, null: false
         t.integer :page, default: 1, null: false
         t.timestamp :read_at, null: false
@@ -191,7 +192,7 @@ class CreateThredded < ActiveRecord::Migration
     end
 
     create_table :thredded_user_topic_follows do |t|
-      t.integer :user_id, null: false
+      t.references :user, null: false
       t.integer :topic_id, null: false
       t.datetime :created_at, null: false
       t.integer :reason, limit: 1

--- a/db/upgrade_migrations/20160611094616_upgrade_v0_5_to_v0_6.rb
+++ b/db/upgrade_migrations/20160611094616_upgrade_v0_5_to_v0_6.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+class UpgradeV05ToV06 < ActiveRecord::Migration
+  def up
+    add_column :thredded_messageboards, :last_topic_id, :integer
+    Thredded::Messageboard.reset_column_information
+    Thredded::Messageboard.all.each do |messageboard|
+      messageboard.update!(last_topic_id: messageboard.topics.order_recently_updated_first.first.try(:id))
+    end
+    change_column_null :thredded_posts, :postable_id, false
+    # Allow null on user_id and last_user_id because users can get deleted.
+    change_column_null :thredded_topics, :user_id, true
+    change_column_null :thredded_topics, :last_user_id, true
+    change_column_null :thredded_private_topics, :user_id, true
+    change_column_null :thredded_private_topics, :last_user_id, true
+  end
+
+  def down
+    change_column_null :thredded_private_topics, :last_user_id, false
+    change_column_null :thredded_private_topics, :user_id, false
+    change_column_null :thredded_topics, :last_user_id, false
+    change_column_null :thredded_topics, :user_id, false
+    change_column_null :thredded_posts, :postable_id, true
+    remove_column :thredded_messageboards, :last_topic_id
+  end
+end

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class UsersController < ApplicationController
   def show
-    @slug = params[:id].to_s
+    @user = User.find(params[:id])
   end
 end

--- a/spec/dummy/app/helpers/users_helper.rb
+++ b/spec/dummy/app/helpers/users_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+module UsersHelper
+  include ::Thredded::ApplicationHelper
+end

--- a/spec/dummy/app/views/users/show.html.erb
+++ b/spec/dummy/app/views/users/show.html.erb
@@ -1,5 +1,26 @@
+<%
+  user = @user
+  user_detail = user.thredded_user_detail
+%>
 <div class="thredded--main-container">
-  <p>
-    <b><%= @slug %></b>'s profile page stub.
-  </p>
+  <h1>
+    <%= image_tag Thredded.avatar_url.call(user), class: 'thredded--user--avatar' %><%= user %>
+  </h1>
+  <ul>
+    <li><%= t 'thredded.users.user_since_html', time_ago: time_ago(user.created_at) %></li>
+    <% if user_detail.last_seen_at %>
+      <li><%= t 'thredded.users.last_active_html', time_ago: time_ago(user_detail.last_seen_at) %></li>
+    <% end %>
+    <% if user_detail.topics_count > 0 %>
+      <li><%= t 'thredded.users.started_topics_count', count: user_detail.topics_count %></li>
+    <% end %>
+    <% if user_detail.posts_count > 0 %>
+      <li><%= t 'thredded.users.posts_count', count: user_detail.posts_count %></li>
+    <% end %>
+  </ul>
+  <h2><%= t 'thredded.users.recent_activity' %></h2>
+  <%= render 'thredded/users/posts',
+             posts: Thredded.posts_page_view(
+                 scope: user.thredded_posts.order_newest_first.limit(5),
+                 current_user: current_user) %>
 </div>

--- a/spec/dummy/config/initializers/thredded.rb
+++ b/spec/dummy/config/initializers/thredded.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 Thredded.user_class = 'User'
 Thredded.user_name_column = :name
-Thredded.user_path = ->(user) { main_app.user_path(user.to_param) }
+Thredded.user_path = ->(user) { main_app.user_path(user.id) }
 Thredded.current_user_method = :"current_#{Thredded.user_class.name.underscore}"
 Thredded.email_incoming_host = 'incoming.example.com'
 Thredded.email_from = 'no-reply@example.com'

--- a/spec/lib/thredded/content_formatter_spec.rb
+++ b/spec/lib/thredded/content_formatter_spec.rb
@@ -37,9 +37,16 @@ describe Thredded::ContentFormatter do
   end
 
   context '@-mentions' do
-    before { Thredded.user_path = ->(user) { "/whois/#{user}" } }
-    after { Thredded.user_path = nil }
+    around do |ex|
+      begin
+        user_path_was = Thredded.class_variable_get(:@@user_path)
+        ex.call
+      ensure
+        Thredded.user_path = user_path_was
+      end
+    end
     it 'links @names of members' do
+      Thredded.user_path = ->(user) { "/whois/#{user}" }
       post_content = '@"sam 1" but not @al or @kek. And @joe. But not email@jane.com nor email@joe.com.'
       sam = build_stubbed(:user, name: 'sam 1')
       joe = build_stubbed(:user, name: 'joe')

--- a/spec/lib/thredded_spec.rb
+++ b/spec/lib/thredded_spec.rb
@@ -2,29 +2,29 @@
 require 'spec_helper'
 
 describe Thredded, '.user_path' do
-  after { Thredded.user_path = nil }
-
-  it 'returns "/" if lambda is not set' do
-    Thredded.user_path = nil
-    expect(Thredded.user_path(_view_context = nil, _user = nil)).to eq '/'
+  around do |ex|
+    begin
+      user_path_was = Thredded.class_variable_get(:@@user_path)
+      ex.call
+    ensure
+      Thredded.user_path = user_path_was
+    end
   end
 
-  context 'lambda is created and called with a user' do
-    it 'returns one path' do
-      me = build_stubbed(:user, name: 'joel')
-      Thredded.user_path = ->(user) { "/my/name/is/#{user}" }
-      expect(Thredded.user_path(_view_context = nil, _user = me)).to eq '/my/name/is/joel'
-    end
+  it 'returns one path' do
+    me = build_stubbed(:user, name: 'joel')
+    Thredded.user_path = ->(user) { "/my/name/is/#{user}" }
+    expect(Thredded.user_path(_view_context = nil, _user = me)).to eq '/my/name/is/joel'
+  end
 
-    it 'returns another path' do
-      you = build_stubbed(:user, name: 'carl')
-      Thredded.user_path = ->(user) { "/wow/so/#{user}" }
-      expect(Thredded.user_path(_view_context = nil, _user = you)).to eq '/wow/so/carl'
-    end
+  it 'returns another path' do
+    you = build_stubbed(:user, name: 'carl')
+    Thredded.user_path = ->(user) { "/wow/so/#{user}" }
+    expect(Thredded.user_path(_view_context = nil, _user = you)).to eq '/wow/so/carl'
+  end
 
-    it 'executes in the given context' do
-      Thredded.user_path = ->(_user) { reverse }
-      expect(Thredded.user_path(_view_context = 'abc', _user = nil)).to eq 'cba'
-    end
+  it 'executes in the given context' do
+    Thredded.user_path = ->(_user) { reverse }
+    expect(Thredded.user_path(_view_context = 'abc', _user = nil)).to eq 'cba'
   end
 end

--- a/spec/views/thredded/user/link_spec.rb
+++ b/spec/views/thredded/user/link_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe 'partial: thredded/users/link' do
   end
 
   it 'renders a link to the user' do
-    render_partial build_stubbed(:user, name: 'joel')
+    render_partial build_stubbed(:user, id: 5, name: 'joel')
     expect(rendered).to eq(<<-HTML.strip_heredoc)
-      <a href="/u/joel">joel</a>
+      <a href="/u/5">joel</a>
     HTML
   end
 


### PR DESCRIPTION
* Improves the display of posts in the moderation, showing the topic and
  whether the post started the topic.
  ![moderation-history](https://cloud.githubusercontent.com/assets/216339/15985255/420560fc-2fdf-11e6-8d51-acb648afeb84.png)


* Adds a Users tab to moderation, where individual users can be moderated.
![moderation-users](https://cloud.githubusercontent.com/assets/216339/15985256/4912793e-2fdf-11e6-8aff-724013d3dd0f.png)
![moderation-user](https://cloud.githubusercontent.com/assets/216339/15985257/4a53807c-2fdf-11e6-9dac-37d71064e253.png)


* Adds new post partials for rendering the post header with:
  * The topic instead of the user.
  * The topic and the user.

These can be used by the parent app for rendering user profiles.

Piggy-backed:

* Fixes a bug that prevented `user.destroy` for users that posted.
* Changes messageboard's `last_topic` from `has_one` to `belongs_to`
  so that it can be preloaded efficiently.

Refs #324

@jayroh @timdiggins 