### PR TITLE
Private topic searching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Gemfile.lock
 *.gemfile.lock
 !heroku.gemfile.lock
 .bundle/
+.ruby-version
 bin/*
 !bin/rails
 log/*.log

--- a/app/controllers/thredded/private_topics_controller.rb
+++ b/app/controllers/thredded/private_topics_controller.rb
@@ -21,6 +21,25 @@ module Thredded
       end
     end
 
+    def search
+      @query = params[:q].to_s
+
+      @private_topics = Thredded::PrivateTopicsPageView.new(
+        thredded_current_user,
+        PrivateTopic
+          .search_query(@query)
+          .distinct
+          .for_user(thredded_current_user)
+          .order_recently_updated_first
+          .includes(:last_user, :user)
+          .page(params[:page])
+      )
+
+      PrivateTopicForm.new(user: thredded_current_user).tap do |form|
+        @new_private_topic = form if policy(form.private_topic).create?
+      end
+    end
+
     def show
       authorize private_topic, :read?
 

--- a/app/helpers/thredded/urls_helper.rb
+++ b/app/helpers/thredded/urls_helper.rb
@@ -97,7 +97,9 @@ module Thredded
     # @param messageboard [Thredded::Messageboard, nil]
     # @return [String] the path to the global or messageboard search.
     def search_path(messageboard = nil)
-      if messageboard.try(:persisted?)
+      if controller_name == 'private_topics'
+        private_topics_search_path
+      elsif messageboard.try(:persisted?)
         messageboard_search_path(messageboard)
       else
         messageboards_search_path

--- a/app/models/thredded/private_topic.rb
+++ b/app/models/thredded/private_topic.rb
@@ -5,6 +5,8 @@ module Thredded
 
     scope :for_user, -> (user) { joins(:private_users).merge(PrivateUser.where(user_id: user.id)) }
 
+    scope :search_query, -> (query) { ::Thredded::PrivateTopicsSearch.new(query, self).search }
+
     extend FriendlyId
     friendly_id :slug_candidates,
                 use:            [:history, :reserved],

--- a/app/views/thredded/private_topics/search.html.erb
+++ b/app/views/thredded/private_topics/search.html.erb
@@ -1,0 +1,21 @@
+<% content_for :thredded_page_title, t('thredded.topics.search.page_title') %>
+<% content_for :thredded_page_id, 'thredded--topic-search-results' %>
+<% content_for :thredded_breadcrumbs, render('thredded/private_topics/breadcrumbs') %>
+
+<%= thredded_page do %>
+  <% if @private_topics.present? %>
+    <p class="thredded--alert thredded--alert-success">
+      <%= t 'thredded.topics.search.results_message', query: "'#{@query}'" %>
+    </p>
+    <section class="thredded--main-section thredded--topics">
+      <%= render @private_topics %>
+    </section>
+    <footer>
+      <%= paginate @private_topics %>
+    </footer>
+  <% else %>
+    <p class="thredded--alert thredded--alert-danger">
+      <%= t 'thredded.topics.search.no_results_message', query: "'#{@query}'" %>
+    </p>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Thredded::Engine.routes.draw do
   positive_int = /[1-9]\d*/
   page_constraint = { page: positive_int }
 
+  resources :autocomplete_users, only: [:index], path: 'autocomplete-users'
+
   constraints(->(req) { req.env['QUERY_STRING'].include? 'q=' }) do
     get '/' => 'topics#search', as: :messageboards_search
     get '/private-topics(/:topic_id)' => 'private_topics#search', as: :private_topics_search
@@ -25,8 +27,6 @@ Thredded::Engine.routes.draw do
     resources :private_post_permalinks, path: 'private-posts'
     resources :post_permalinks, path: 'posts'
   end
-
-  resources :autocomplete_users, only: [:index], path: 'autocomplete-users'
 
   scope path: 'admin' do
     resources :messageboard_groups, only: [:new, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,12 @@ Thredded::Engine.routes.draw do
   positive_int = /[1-9]\d*/
   page_constraint = { page: positive_int }
 
+  constraints(->(req) { req.env['QUERY_STRING'].include? 'q=' }) do
+    get '/' => 'topics#search', as: :messageboards_search
+    get '/private-topics(/:topic_id)' => 'private_topics#search', as: :private_topics_search
+    get '/:messageboard_id(.:format)' => 'topics#search', as: :messageboard_search
+  end
+
   scope path: 'private-topics' do
     resource :private_topic, only: [:new], path: ''
     resources :private_topics, except: [:new, :show], path: '' do
@@ -21,11 +27,6 @@ Thredded::Engine.routes.draw do
   end
 
   resources :autocomplete_users, only: [:index], path: 'autocomplete-users'
-
-  constraints(->(req) { req.env['QUERY_STRING'].include? 'q=' }) do
-    get '/' => 'topics#search', as: :messageboards_search
-    get '/:messageboard_id(.:format)' => 'topics#search', as: :messageboard_search
-  end
 
   scope path: 'admin' do
     resources :messageboard_groups, only: [:new, :create]

--- a/lib/thredded/private_topics_search.rb
+++ b/lib/thredded/private_topics_search.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require_dependency 'thredded/search_parser'
+module Thredded
+  class PrivateTopicsSearch
+    def initialize(query, scope)
+      @terms = SearchParser.new(query).parse
+      @scope = scope
+
+      @search_text = nil
+    end
+
+    # @return [ActiveRecord::Relation<Thredded::Topic>]
+    def search
+      if text.present?
+        [search_topics, search_posts].compact.reduce(:union)
+      else
+        @scope
+      end
+    end
+
+    protected
+
+    def search_topics
+      scope = @scope
+      scope = DbTextSearch::FullText.new(scope, :title).search(text) if text.present?
+      scope
+    end
+
+    def search_posts
+      posts_scope = Thredded::PrivatePost
+      posts_scope = DbTextSearch::FullText.new(posts_scope, :content).search(text) if text.present?
+      @scope.joins(:posts).merge(posts_scope)
+    end
+
+    # @return [Array<String>]
+    def text
+      @terms['text']
+    end
+  end
+end

--- a/spec/features/thredded/user_searches_for_private_topics_spec.rb
+++ b/spec/features/thredded/user_searches_for_private_topics_spec.rb
@@ -40,5 +40,4 @@ feature 'User searching private topics' do
   def them
     create(:user, name: 'them')
   end
-
 end

--- a/spec/features/thredded/user_searches_for_private_topics_spec.rb
+++ b/spec/features/thredded/user_searches_for_private_topics_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+feature 'User searching private topics' do
+  title = 'Rando thread'
+
+  # On MySQL, a transaction has to complete before the full text search index is updated
+  before :all do
+    user.log_in
+    create(:private_topic, title: title, user: @user, users: [@user, them], posts: build_list(:private_post, 1))
+    create_list(:private_topic, 2, user: @user)
+
+    @private_topics = PageObject::PrivateTopics.new(title)
+  end
+
+  after :all do
+    Thredded::PrivateTopic.destroy_all
+  end
+
+  search_and_expect_found = lambda do
+    @private_topics.search_for(title)
+    expect(page).to have_content(I18n.t('thredded.topics.search.results_message', query: "'#{title}'"))
+    expect(@private_topics.private_topics.size).to eq(1)
+    expect(@private_topics).to have_topic_titled(title)
+  end
+
+  scenario 'from index and within a topic' do
+    @private_topics.visit_index
+    instance_exec(&search_and_expect_found)
+
+    @private_topics.view_private_topic
+    instance_exec(&search_and_expect_found)
+  end
+
+  def user
+    @user ||= create(:user)
+    PageObject::User.new(@user)
+  end
+
+  def them
+    create(:user, name: 'them')
+  end
+
+end

--- a/spec/support/features/page_object/private_topics.rb
+++ b/spec/support/features/page_object/private_topics.rb
@@ -51,6 +51,15 @@ module PageObject
       has_css? 'article h1 a', text: private_title
     end
 
+    def search_for(title)
+      fill_in 'q', with: title
+      find('.thredded--navigation--search [type="submit"]').click
+    end
+
+    def has_topic_titled?(title)
+      has_css?('article.thredded--topics--topic h1 a', text: title)
+    end
+
     private
 
     attr_reader :messageboard, :private_title


### PR DESCRIPTION
Here's a take on searching within Private Topics. The urls_helper conditional seems a bit inelegant, but it works (along with moving the query constrained routes up above the private-topics block).

There's some duplication that could be refactored out between the two TopicsSearch classes but wasn't sure how far to take that. Also didn't see much of a need for User or Category(?) searching in the PrivateTopicSearch.
