### PR TITLE
fixing rubocop to 0.41.2 as that is green and doesn't error

### DIFF
--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -57,7 +57,7 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
   s.add_development_dependency 'faker', '>= 1.6.2'
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'rspec-rails', '>= 3.5.0'
-  s.add_development_dependency 'rubocop', '~> 0.41'
+  s.add_development_dependency 'rubocop', '= 0.41.2'
   s.add_development_dependency 'test-unit'
 
   # dummy app dependencies


### PR DESCRIPTION
addresses #350 