### PR TITLE
Make global preferences url helpers explicit

### DIFF
--- a/app/helpers/thredded/urls_helper.rb
+++ b/app/helpers/thredded/urls_helper.rb
@@ -83,7 +83,7 @@ module Thredded
       if messageboard.try(:persisted?)
         edit_messageboard_preferences_url(messageboard, params)
       else
-        super(params)
+        edit_global_preferences_url(params)
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Thredded::Engine.routes.draw do
     end
   end
 
-  resource :preferences, only: [:edit, :update]
+  resource :preferences, only: [:edit, :update], as: :global_preferences
   resource :messageboard, path: 'messageboards', only: [:new]
   resources :messageboards, only: [:edit, :update]
   resources :messageboards, only: [:index, :create], path: '' do


### PR DESCRIPTION
the `.super` doesn't work when you include Thredded::Engine.routes.url_helpers in another engine.

Plus this is easier to understand and more explicit