### PR TITLE
notify when a new messageboard group is created

### DIFF
--- a/app/controllers/thredded/messageboard_groups_controller.rb
+++ b/app/controllers/thredded/messageboard_groups_controller.rb
@@ -12,7 +12,7 @@ module Thredded
       authorize @messageboard_group, :create?
 
       if @messageboard_group.save
-        redirect_to root_path, notice: I18n.t('thredded.messageboard_group.create')
+        redirect_to root_path, notice: I18n.t('thredded.messageboard_group.created_notice')
       else
         render action: :new
       end

--- a/app/controllers/thredded/messageboard_groups_controller.rb
+++ b/app/controllers/thredded/messageboard_groups_controller.rb
@@ -12,7 +12,7 @@ module Thredded
       authorize @messageboard_group, :create?
 
       if @messageboard_group.save
-        redirect_to root_path
+        redirect_to root_path, notice: I18n.t('thredded.messageboard_group.create')
       else
         render action: :new
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
       update: :thredded.form.update
       updated_notice: Messageboard has been updated
     messageboard_group:
-      create: Create a New Messageboard Group
+      create: Messageboard group has been created
     moderation:
       approve_btn: Approve
       block_btn: Block
@@ -153,4 +153,3 @@ en:
       posts_count:
         one: "Posted once"
         other: "Posted %{count} times"
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,8 @@ en:
       update: :thredded.form.update
       updated_notice: Messageboard has been updated
     messageboard_group:
-      create: Messageboard group has been created
+      create: Create a New Messageboard Group
+      created_notice: Messageboard group has been created
     moderation:
       approve_btn: Approve
       block_btn: Block

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -23,6 +23,7 @@ pt-BR:
       updated_notice: Fórum de mensagem foi atualizado
     messageboard_group:
       create: Criar um novo grupo de mensagens
+      created_notice: Grupo de mensagens foi criado
     moderation:
       approve_btn: Aprovar
       block_btn: Quadra
@@ -33,9 +34,8 @@ pt-BR:
       post_approved_html: Pós aprovado por %{moderator} %{time_ago}.
       post_blocked_html: Pós bloqueado por %{moderator} %{time_ago}.
       post_deleted_notice: Este post foi apagado.
-      posts_content_changed_since_moderation_html: >-
-        O <a href="%{post_url}">de pós</a> alteração de conteúdo, uma vez que foi moderado. Abaixo está o conteúdo
-        no momento em que foi moderado.
+      posts_content_changed_since_moderation_html: O <a href="%{post_url}">de pós</a> alteração de conteúdo, uma
+        vez que foi moderado. Abaixo está o conteúdo no momento em que foi moderado.
       search_users:
         form_label: Buscar usuários
         form_placeholder: :thredded.moderation.search_users.form_label
@@ -71,15 +71,13 @@ pt-BR:
       form:
         global_preferences_label: Configurações Globais
         messageboard_notify_on_mention:
-          hint: >-
-            Quando alguém mencionar você através do seu usuário (ex.: @sam) neste fórum de mensagens, você irá receber
-            um e-mail com o conteúdo deste post.
+          hint: 'Quando alguém mencionar você através do seu usuário (ex.: @sam) neste fórum de mensagens, você
+            irá receber um e-mail com o conteúdo deste post.'
           label: :thredded.preferences.form.notify_on_mention.label
         messageboard_preferences_label_html: Configurações de Notificação para <em>%{messageboard}</em>
         notify_on_mention:
-          hint: >-
-            Quando alguém mencionar você através do seu usuário (ex.: @sam) você irá receber um e-mail com o conteúdo
-            deste post.
+          hint: 'Quando alguém mencionar você através do seu usuário (ex.: @sam) você irá receber um e-mail com
+            o conteúdo deste post.'
           label: "@ Notificações"
         notify_on_message:
           hint: Quando você for adicionado a uma conversa privada, você receberá um e-mail com o conteúdo desta
@@ -141,7 +139,7 @@ pt-BR:
       unfollowed_notice: Você não está mais acompanhando este tópico
       updated_notice: Tópico atualizado
     users:
-      last_active_html: Última %{time_ago} ativa
+      last_active_html: "Última %{time_ago} ativa"
       posted_in_topic_html: Postou em %{topic_link}
       posts_count:
         one: Postado uma vez


### PR DESCRIPTION
Just a little tweak to add a notify message when a messageboard group is created. There was even a message ready in the locales file but it just wasn't being called. 