### PR TITLE
current_user reference updated

### DIFF
--- a/app/controllers/thredded/moderation_controller.rb
+++ b/app/controllers/thredded/moderation_controller.rb
@@ -68,7 +68,7 @@ module Thredded
         .order_newest_first
         .includes(:postable)
         .page(current_page)
-      @posts = PostsPageView.new(current_user, posts_scope)
+      @posts = PostsPageView.new(@user, posts_scope)
     end
 
     def moderate_user


### PR DESCRIPTION
The current_user reference didn't work in our app because the helper was current_member (we're using Thredded with RefineryCMS). Having looked at what the current_user reference was doing, I think it's ok to change that to be @user, which is already defined in the same method and is based on the Thredded.user_class config option. I've checked that it still does what I expect in our app and the tests all pass so let me know if that's an appropriate change to make? 