### PR TITLE
Optionally show all following users (on topic page)

### DIFF
--- a/app/assets/stylesheets/thredded/components/_topic-header.scss
+++ b/app/assets/stylesheets/thredded/components/_topic-header.scss
@@ -55,3 +55,8 @@
     }
   }
 }
+
+&--topic-following-users{
+  font-size: $thredded-font-size-small;
+  color: $thredded-secondary-text-color;
+}

--- a/app/assets/stylesheets/thredded/components/_topic-header.scss
+++ b/app/assets/stylesheets/thredded/components/_topic-header.scss
@@ -56,7 +56,7 @@
   }
 }
 
-&--topic-following-users{
+&--topic-followers{
   font-size: $thredded-font-size-small;
   color: $thredded-secondary-text-color;
 }

--- a/app/commands/thredded/notify_following_users.rb
+++ b/app/commands/thredded/notify_following_users.rb
@@ -12,7 +12,7 @@ module Thredded
     end
 
     def targeted_users
-      @targeted_users ||= @post.postable.following_users.reject { |u| u == @post.user }
+      @targeted_users ||= @post.postable.followers.reject { |u| u == @post.user }
     end
   end
 end

--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -17,6 +17,16 @@ module Thredded
       render partial: 'thredded/users/link', locals: { user: user }
     end
 
+    # @param user [Thredded.user_class]
+    # @return [String] wrapped @mention string
+    def user_mention(user)
+      if user.to_s.include?(' ')
+        %(@"#{user}")
+      else
+        "@#{user}"
+      end
+    end
+
     # @param datetime [DateTime]
     # @param default [String] a string to return if time is nil.
     # @return [String] html_safe datetime presentation

--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -20,10 +20,11 @@ module Thredded
     # @param user [Thredded.user_class]
     # @return [String] wrapped @mention string
     def user_mention(user)
-      if user.to_s.include?(' ')
-        %(@"#{user}")
+      username = user.send(Thredded.user_name_column)
+      if username.include?(' ')
+        %(@"#{username}")
       else
-        "@#{user}"
+        "@#{username}"
       end
     end
 

--- a/app/models/thredded/topic.rb
+++ b/app/models/thredded/topic.rb
@@ -67,7 +67,7 @@ module Thredded
              class_name: 'Thredded::UserTopicFollow',
              inverse_of: :topic,
              dependent: :destroy
-    has_many :following_users,
+    has_many :followers,
              class_name: Thredded.user_class,
              source: :user,
              through: :user_follows

--- a/app/view_models/thredded/topic_view.rb
+++ b/app/view_models/thredded/topic_view.rb
@@ -2,7 +2,7 @@
 module Thredded
   # A view model for Topic.
   class TopicView < BaseTopicView
-    delegate :categories, :id, :blocked?, :last_moderation_record,
+    delegate :categories, :id, :blocked?, :last_moderation_record, :following_users,
              :last_post,
              to: :@topic
 

--- a/app/view_models/thredded/topic_view.rb
+++ b/app/view_models/thredded/topic_view.rb
@@ -2,7 +2,7 @@
 module Thredded
   # A view model for Topic.
   class TopicView < BaseTopicView
-    delegate :categories, :id, :blocked?, :last_moderation_record, :following_users,
+    delegate :categories, :id, :blocked?, :last_moderation_record, :followers,
              :last_post,
              to: :@topic
 

--- a/app/views/thredded/topics/_followers.html.erb
+++ b/app/views/thredded/topics/_followers.html.erb
@@ -1,8 +1,8 @@
 <% if Thredded.show_following_users_in_topic %>
-  <div class="thredded--topic-following-users">
-    <% if topic.following_users.present? %>
+  <div class="thredded--topic-followers">
+    <% if topic.followers.present? %>
       Following:
-      <% topic.following_users.each do |user| %>
+      <% topic.followers.each do |user| %>
         <%= "@#{user}" %>
       <% end %>
     <% else %>

--- a/app/views/thredded/topics/_followers.html.erb
+++ b/app/views/thredded/topics/_followers.html.erb
@@ -3,7 +3,7 @@
     <% if topic.followers.present? %>
       <%= t('thredded.topics.followed_by')%>
       <% topic.followers.each do |user| %>
-        <%= "@#{user}" %>
+        <%= user_mention(user) %>
       <% end %>
     <% else %>
       <%= t('thredded.topics.followed_by_noone')%>

--- a/app/views/thredded/topics/_followers.html.erb
+++ b/app/views/thredded/topics/_followers.html.erb
@@ -1,4 +1,4 @@
-<% if Thredded.show_following_users_in_topic %>
+<% if Thredded.show_topic_followers %>
   <div class="thredded--topic-followers">
     <% if topic.followers.present? %>
       <%= t('thredded.topics.followed_by')%>

--- a/app/views/thredded/topics/_followers.html.erb
+++ b/app/views/thredded/topics/_followers.html.erb
@@ -1,12 +1,12 @@
 <% if Thredded.show_following_users_in_topic %>
   <div class="thredded--topic-followers">
     <% if topic.followers.present? %>
-      Following:
+      <%= t('thredded.topics.followed_by')%>
       <% topic.followers.each do |user| %>
         <%= "@#{user}" %>
       <% end %>
     <% else %>
-      No one is following this topic
+      <%= t('thredded.topics.followed_by_noone')%>
     <% end %>
   </div>
 <% end %>

--- a/app/views/thredded/topics/_following_users.html.erb
+++ b/app/views/thredded/topics/_following_users.html.erb
@@ -1,0 +1,12 @@
+<% if Thredded.show_following_users_in_topic %>
+  <div class="thredded--topic-following-users">
+    <% if @topic.following_users.present? %>
+      Following:
+      <% @topic.following_users.each do |user| %>
+        <%= "@#{user}" %>
+      <% end %>
+    <% else %>
+      No one is following this topic
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/thredded/topics/_following_users.html.erb
+++ b/app/views/thredded/topics/_following_users.html.erb
@@ -1,8 +1,8 @@
 <% if Thredded.show_following_users_in_topic %>
   <div class="thredded--topic-following-users">
-    <% if @topic.following_users.present? %>
+    <% if topic.following_users.present? %>
       Following:
-      <% @topic.following_users.each do |user| %>
+      <% topic.following_users.each do |user| %>
         <%= "@#{user}" %>
       <% end %>
     <% else %>

--- a/app/views/thredded/topics/_header.html.erb
+++ b/app/views/thredded/topics/_header.html.erb
@@ -24,14 +24,16 @@
       </div>
     <% end %>
   <% end %>
-  <div class="thredded--topic-following-users">
-    <% if @topic.following_users.present? %>
-      Following:
-      <% @topic.following_users.each do |user| %>
-        <%= user %>
+  <% if Thredded.show_following_users_in_topic %>
+    <div class="thredded--topic-following-users">
+      <% if @topic.following_users.present? %>
+        Following:
+        <% @topic.following_users.each do |user| %>
+          <%= "@#{user}" %>
+        <% end %>
+      <% else %>
+        No one is following this topic
       <% end %>
-    <% else %>
-      No one is following this topic
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </header>

--- a/app/views/thredded/topics/_header.html.erb
+++ b/app/views/thredded/topics/_header.html.erb
@@ -24,5 +24,5 @@
       </div>
     <% end %>
   <% end %>
-  <%= render partial: 'thredded/topics/following_users', locals: {topic: topic} %>
+  <%= render partial: 'thredded/topics/followers', locals: {topic: topic} %>
 </header>

--- a/app/views/thredded/topics/_header.html.erb
+++ b/app/views/thredded/topics/_header.html.erb
@@ -24,5 +24,5 @@
       </div>
     <% end %>
   <% end %>
-  <%= render 'thredded/topics/following_users' %>
+  <%= render partial: 'thredded/topics/following_users', locals: {topic: topic} %>
 </header>

--- a/app/views/thredded/topics/_header.html.erb
+++ b/app/views/thredded/topics/_header.html.erb
@@ -24,16 +24,5 @@
       </div>
     <% end %>
   <% end %>
-  <% if Thredded.show_following_users_in_topic %>
-    <div class="thredded--topic-following-users">
-      <% if @topic.following_users.present? %>
-        Following:
-        <% @topic.following_users.each do |user| %>
-          <%= "@#{user}" %>
-        <% end %>
-      <% else %>
-        No one is following this topic
-      <% end %>
-    </div>
-  <% end %>
+  <%= render 'thredded/topics/following_users' %>
 </header>

--- a/app/views/thredded/topics/_header.html.erb
+++ b/app/views/thredded/topics/_header.html.erb
@@ -24,4 +24,12 @@
       </div>
     <% end %>
   <% end %>
+  <div class="thredded--topic-following-users">
+    <p>
+      Following users
+      <% @topic.following_users.each do |user| %>
+        <%= user.name %>
+      <% end %>
+    </p>
+  </div>
 </header>

--- a/app/views/thredded/topics/_header.html.erb
+++ b/app/views/thredded/topics/_header.html.erb
@@ -25,11 +25,13 @@
     <% end %>
   <% end %>
   <div class="thredded--topic-following-users">
-    <p>
-      Following users
+    <% if @topic.following_users.present? %>
+      Following:
       <% @topic.following_users.each do |user| %>
-        <%= user.name %>
+        <%= user %>
       <% end %>
-    </p>
+    <% else %>
+      No one is following this topic
+    <% end %>
   </div>
 </header>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,8 @@ en:
         mentioned: You are following this topic because you were mentioned on it.
         posted: You are following this topic because you posted to it.
       following_will_receive_emails: You will receive email updates.
+      followed_by: "Followed by:"
+      followed_by_noone: No one is following this topic
       form:
         categories_placeholder: Categories
         content_label: :thredded.posts.form.content_label

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -125,6 +125,8 @@ pt-BR:
         mentioned: Você está acompanhando este tópico porque você foi mencionado nele.
         posted: Você está acompanhando este tópico porque foi você que o publicou.
       following_will_receive_emails: Você irá receber e-mail com atualizações.
+      followed_by: "Seguido por:"
+      followed_by_noone: Ninguém está seguindo este tópico
       form:
         categories_placeholder: Categorias
         content_label: :thredded.posts.form.content_label

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -37,6 +37,9 @@ Thredded.admin_column = :admin
 # Whether posts and topics pending moderation are visible to regular users.
 Thredded.content_visible_while_pending_moderation = true
 
+# Whether users that are following a topic are listed on topic page.
+Thredded.show_following_users_in_topic = false
+
 # This model can be customized further by overriding a handful of methods on the User model.
 # For more information, see app/models/thredded/user_extender.rb.
 

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -38,7 +38,7 @@ Thredded.admin_column = :admin
 Thredded.content_visible_while_pending_moderation = true
 
 # Whether users that are following a topic are listed on topic page.
-Thredded.show_following_users_in_topic = false
+Thredded.show_topic_followers = false
 
 # This model can be customized further by overriding a handful of methods on the User model.
 # For more information, see app/models/thredded/user_extender.rb.

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -50,7 +50,7 @@ module Thredded
   mattr_accessor :content_visible_while_pending_moderation
 
   # @return [Boolean] Whether users that are following a topic are listed on topic page.
-  mattr_accessor :show_following_users_in_topic
+  mattr_accessor :show_topic_followers
 
   self.active_user_threshold = 5.minutes
   self.admin_column = :admin
@@ -60,7 +60,7 @@ module Thredded
   self.moderator_column = :admin
   self.user_name_column = :name
   self.content_visible_while_pending_moderation = true
-  self.show_following_users_in_topic = false
+  self.show_topic_followers = false
 
   # @return [Class<Thredded::UserExtender>] the user class from the host application.
   def self.user_class

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -49,6 +49,9 @@ module Thredded
   # @return [Boolean] Whether posts that are pending moderation are visible to regular users.
   mattr_accessor :content_visible_while_pending_moderation
 
+  # @return [Boolean] Whether users that are following a topic are listed on topic page.
+  mattr_accessor :show_following_users_in_topic
+
   self.active_user_threshold = 5.minutes
   self.admin_column = :admin
   self.avatar_url = ->(user) { Gravatar.src(user.email, 128, 'mm') }
@@ -57,6 +60,7 @@ module Thredded
   self.moderator_column = :admin
   self.user_name_column = :name
   self.content_visible_while_pending_moderation = true
+  self.show_following_users_in_topic = false
 
   # @return [Class<Thredded::UserExtender>] the user class from the host application.
   def self.user_class

--- a/spec/features/thredded/user_views_a_topic_spec.rb
+++ b/spec/features/thredded/user_views_a_topic_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 feature 'User views a topic' do

--- a/spec/features/thredded/user_views_a_topic_spec.rb
+++ b/spec/features/thredded/user_views_a_topic_spec.rb
@@ -7,12 +7,12 @@ feature 'User views a topic' do
 
   context 'when Thredded.display_following_users' do
     around do |ex|
-      was = Thredded.show_following_users_in_topic
+      was = Thredded.show_topic_followers
       begin
-        Thredded.show_following_users_in_topic = true
+        Thredded.show_topic_followers = true
         ex.call
       ensure
-        Thredded.show_following_users_in_topic = was
+        Thredded.show_topic_followers = was
       end
     end
 
@@ -48,12 +48,12 @@ feature 'User views a topic' do
 
   context 'when not Thredded.display_following_users' do
     around do |ex|
-      was = Thredded.show_following_users_in_topic
+      was = Thredded.show_topic_followers
       begin
-        Thredded.show_following_users_in_topic = false
+        Thredded.show_topic_followers = false
         ex.call
       ensure
-        Thredded.show_following_users_in_topic = was
+        Thredded.show_topic_followers = was
       end
     end
 

--- a/spec/features/thredded/user_views_a_topic_spec.rb
+++ b/spec/features/thredded/user_views_a_topic_spec.rb
@@ -5,31 +5,84 @@ feature 'User views a topic' do
   let(:user) { create(:user) }
   let(:messageboard) { create(:messageboard) }
 
-  context 'for a followed topic' do
-    let(:a_followed_topic) do
-      topic = create(:topic, with_posts: 1, messageboard: messageboard)
-      Thredded::UserTopicFollow.create_unless_exists(user.id, topic.id)
-      PageObject::Topic.new(topic)
+  context 'when Thredded.display_following_users' do
+    around do |ex|
+      was = Thredded.show_following_users_in_topic
+      begin
+        Thredded.show_following_users_in_topic = true
+        ex.call
+      ensure
+        Thredded.show_following_users_in_topic = was
+      end
     end
 
-    scenario 'can see list of users following topic' do
-      a_followed_topic.visit_topic
-      within '.thredded--topic-header' do
-        expect(page).to have_content(user.name)
+    context 'for a followed topic' do
+      let(:a_followed_topic) do
+        topic = create(:topic, with_posts: 1, messageboard: messageboard)
+        Thredded::UserTopicFollow.create_unless_exists(user.id, topic.id)
+        PageObject::Topic.new(topic)
+      end
+
+      scenario 'can see list of users following topic' do
+        a_followed_topic.visit_topic
+        within '.thredded--topic-header' do
+          expect(page).to have_content(user.name)
+        end
+      end
+    end
+
+    context 'for an unfollowed topic' do
+      let(:a_unfollowed_topic) do
+        topic = create(:topic, messageboard: messageboard)
+        PageObject::Topic.new(topic)
+      end
+
+      scenario 'can see that no one is following' do
+        a_unfollowed_topic.visit_topic
+        within '.thredded--topic-header' do
+          expect(page).to have_content('No one is following this topic')
+        end
       end
     end
   end
 
-  context 'for an unfollowed topic' do
-    let(:a_unfollowed_topic) do
-      topic = create(:topic, messageboard: messageboard)
-      PageObject::Topic.new(topic)
+  context 'when not Thredded.display_following_users' do
+    around do |ex|
+      was = Thredded.show_following_users_in_topic
+      begin
+        Thredded.show_following_users_in_topic = false
+        ex.call
+      ensure
+        Thredded.show_following_users_in_topic = was
+      end
     end
 
-    scenario 'can see that no one is following' do
-      a_unfollowed_topic.visit_topic
-      within '.thredded--topic-header' do
-        expect(page).to have_content('No one is following this topic')
+    context 'for a followed topic' do
+      let(:a_followed_topic) do
+        topic = create(:topic, with_posts: 1, messageboard: messageboard)
+        Thredded::UserTopicFollow.create_unless_exists(user.id, topic.id)
+        PageObject::Topic.new(topic)
+      end
+
+      scenario 'can not see list of users following topic' do
+        a_followed_topic.visit_topic
+        within '.thredded--topic-header' do
+          expect(page).to_not have_content(user.name)
+        end
+      end
+    end
+
+    context 'for an unfollowed topic' do
+      let(:a_unfollowed_topic) do
+        topic = create(:topic, messageboard: messageboard)
+        PageObject::Topic.new(topic)
+      end
+
+      scenario 'can not see that no one is following' do
+        a_unfollowed_topic.visit_topic
+        within '.thredded--topic-header' do
+          expect(page).to_not have_content('No one is following this topic')
+        end
       end
     end
   end

--- a/spec/features/thredded/user_views_a_topic_spec.rb
+++ b/spec/features/thredded/user_views_a_topic_spec.rb
@@ -4,16 +4,33 @@ require 'spec_helper'
 feature 'User views a topic' do
   let(:user) { create(:user) }
   let(:messageboard) { create(:messageboard) }
-  let(:a_followed_topic) do
-    topic = create(:topic, with_posts: 1, messageboard: messageboard)
-    Thredded::UserTopicFollow.create_unless_exists(user.id, topic.id)
-    PageObject::Topic.new(topic)
+
+  context 'for a followed topic' do
+    let(:a_followed_topic) do
+      topic = create(:topic, with_posts: 1, messageboard: messageboard)
+      Thredded::UserTopicFollow.create_unless_exists(user.id, topic.id)
+      PageObject::Topic.new(topic)
+    end
+
+    scenario 'can see list of users following topic' do
+      a_followed_topic.visit_topic
+      within '.thredded--topic-header' do
+        expect(page).to have_content(user.name)
+      end
+    end
   end
 
-  scenario 'can see list of users following topic' do
-    a_followed_topic.visit_topic
-    within '.thredded--topic-header' do
-      expect(page).to have_content(user.name)
+  context 'for an unfollowed topic' do
+    let(:a_unfollowed_topic) do
+      topic = create(:topic, messageboard: messageboard)
+      PageObject::Topic.new(topic)
+    end
+
+    scenario 'can see that no one is following' do
+      a_unfollowed_topic.visit_topic
+      within '.thredded--topic-header' do
+        expect(page).to have_content('No one is following this topic')
+      end
     end
   end
 end

--- a/spec/features/thredded/user_views_a_topic_spec.rb
+++ b/spec/features/thredded/user_views_a_topic_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+feature 'User views a topic' do
+  let(:user) { create(:user) }
+  let(:messageboard) { create(:messageboard) }
+  let(:a_followed_topic) do
+    topic = create(:topic, with_posts: 1, messageboard: messageboard)
+    Thredded::UserTopicFollow.create_unless_exists(user.id, topic.id)
+    PageObject::Topic.new(topic)
+  end
+
+  scenario 'can see list of users following topic' do
+    a_followed_topic.visit_topic
+    within '.thredded--topic-header' do
+      expect(page).to have_content(user.name)
+    end
+  end
+end

--- a/spec/features/thredded/user_views_a_topic_spec.rb
+++ b/spec/features/thredded/user_views_a_topic_spec.rb
@@ -5,7 +5,7 @@ feature 'User views a topic' do
   let(:user) { create(:user) }
   let(:messageboard) { create(:messageboard) }
 
-  context 'when Thredded.display_following_users' do
+  context 'when Thredded.show_topic_followers' do
     around do |ex|
       was = Thredded.show_topic_followers
       begin
@@ -46,7 +46,7 @@ feature 'User views a topic' do
     end
   end
 
-  context 'when not Thredded.display_following_users' do
+  context 'when not Thredded.show_topic_followers' do
     around do |ex|
       was = Thredded.show_topic_followers
       begin

--- a/spec/helpers/thredded/application_helper_spec.rb
+++ b/spec/helpers/thredded/application_helper_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+module Thredded
+  describe ApplicationHelper do
+    include ApplicationHelper
+    describe '#user_mention' do
+      it 'can create user_mention without quotes' do
+        expect(user_mention(build(:user, name: 'eric'))).to eq('@eric')
+      end
+      it 'can create user_mention with quotes when need' do
+        expect(user_mention(build(:user, name: 'eric the bee'))).to eq('@"eric the bee"')
+      end
+    end
+  end
+end

--- a/spec/helpers/thredded/application_helper_spec.rb
+++ b/spec/helpers/thredded/application_helper_spec.rb
@@ -8,8 +8,14 @@ module Thredded
       it 'can create user_mention without quotes' do
         expect(user_mention(build(:user, name: 'eric'))).to eq('@eric')
       end
-      it 'can create user_mention with quotes when need' do
+      it 'can create user_mention with quotes when needed' do
         expect(user_mention(build(:user, name: 'eric the bee'))).to eq('@"eric the bee"')
+      end
+
+      it 'can uses correct name, even if to_s provides something different' do
+        eric = build(:user, name: 'eric')
+        allow(eric).to receive(:to_s).and_return('Eric the Half-a-bee')
+        expect(user_mention(eric)).to eq('@eric')
       end
     end
   end


### PR DESCRIPTION
There's an initialization configuration option (default false):

```
# self.show_following_users_in_topic = false
```

When this is true, it adds the list of following people to the topic page: 

![it_s_not_impossible__i_used_to_bullseye_womp_rats_in_my_t-16_back_home__they_re_not_much_bigger_than_two_meters____thredded_demo](https://cloud.githubusercontent.com/assets/18395/18137897/3bbfb0b4-6fa2-11e6-8dd8-6cf945c74278.png)

This is not appropriate for every Thredded installation, but it is appropriate for some (particularly with a smaller set of followers).

resolves #348 
