### PR TITLE
rename dummy's current_user to make specs trap misuse of it.

### DIFF
--- a/spec/controllers/thredded/topics_controller_spec.rb
+++ b/spec/controllers/thredded/topics_controller_spec.rb
@@ -14,7 +14,7 @@ module Thredded
         topics:        [@topic],
         sticky_topics: [],
         cannot?:       false,
-        current_user:  user,
+        the_current_user:  user,
         messageboard:  @messageboard
       )
     end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
   include SetLocale
-  helper_method :signed_in?, :current_user
+  helper_method :signed_in?, :the_current_user
 
   def index
     @messageboard = Thredded::Messageboard.first
@@ -11,12 +11,12 @@ class ApplicationController < ActionController::Base
   protected
 
   def signed_in?
-    current_user.present?
+    the_current_user.present?
   end
 
-  def current_user
+  def the_current_user
     return unless session[:user_id]
-    @current_user ||= Thredded.user_class.find_by_id(session[:user_id]).tap do |user|
+    @the_current_user ||= Thredded.user_class.find_by_id(session[:user_id]).tap do |user|
       # If the database has been recreated, user_id may be invalid.
       session.delete(:user_id) if user.nil?
     end

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
       <header class="app-container-header">
         <span class="app-nav-auth">
           <% if signed_in? %>
-            You are <%= link_to current_user, current_user %> |
+            You are <%= link_to the_current_user, the_current_user %> |
             <%= link_to 'Sign out', destroy_user_session_path, method: :delete %>
           <% else %>
             You are an anonymous visitor |

--- a/spec/dummy/app/views/users/show.html.erb
+++ b/spec/dummy/app/views/users/show.html.erb
@@ -22,5 +22,5 @@
   <%= render 'thredded/users/posts',
              posts: Thredded.posts_page_view(
                  scope: user.thredded_posts.order_newest_first.limit(5),
-                 current_user: current_user) %>
+                 current_user: the_current_user) %>
 </div>

--- a/spec/dummy/config/initializers/rollbar.heroku.rb
+++ b/spec/dummy/config/initializers/rollbar.heroku.rb
@@ -16,7 +16,7 @@ if ENV['HEROKU']
     # By default, Rollbar will try to call the `current_user` controller method
     # to fetch the logged-in user object, and then call that object's `id`,
     # `username`, and `email` methods to fetch those properties. To customize:
-    # config.person_method = "my_current_user"
+    config.person_method = 'the_current_user'
     # config.person_id_method = "my_id"
     # config.person_username_method = "my_username"
     # config.person_email_method = "my_email"

--- a/spec/dummy/config/initializers/thredded.rb
+++ b/spec/dummy/config/initializers/thredded.rb
@@ -2,7 +2,7 @@
 Thredded.user_class = 'User'
 Thredded.user_name_column = :name
 Thredded.user_path = ->(user) { main_app.user_path(user.id) }
-Thredded.current_user_method = :"current_#{Thredded.user_class.name.underscore}"
+Thredded.current_user_method = :"the_current_#{Thredded.user_class.name.underscore}"
 Thredded.email_incoming_host = 'incoming.example.com'
 Thredded.email_from = 'no-reply@example.com'
 Thredded.email_outgoing_prefix = '[Thredded] '


### PR DESCRIPTION
It would be nice to prevent mistaken uses of current_user, when
we should be using thredded_current_user (see #391) - so maybe
we can have the spec smoke it out by having the dummy use a differently
named (and thus configured) current_user.