### PR TITLE
update messageboard timestamp when last topic changes

### DIFF
--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -68,9 +68,8 @@ module Thredded
 
     def update_last_topic!
       return if destroyed?
-      update_column(
-        :last_topic_id, topics.order_recently_updated_first.moderation_state_visible_to_all.select(:id).first.try(:id)
-      )
+      self.last_topic = topics.order_recently_updated_first.moderation_state_visible_to_all.select(:id).first
+      save! if last_topic_id_changed?
     end
   end
 end

--- a/spec/models/thredded/messageboard_spec.rb
+++ b/spec/models/thredded/messageboard_spec.rb
@@ -84,4 +84,25 @@ module Thredded
       end
     end
   end
+
+  describe '#update_last_topic!' do
+    let(:messageboard) { create(:messageboard) }
+    let(:new_topic) { create(:topic, messageboard: messageboard) }
+    let(:the_last_topic) { create(:topic, messageboard: messageboard) }
+    let(:an_hour_ago) { 1.hour.ago }
+    before do
+      travel_to(an_hour_ago) { messageboard.reload.update!(last_topic: the_last_topic) }
+      expect(messageboard.updated_at).to be_within(10.seconds).of(an_hour_ago)
+    end
+    it 'when last topic changes, updated_at changes' do
+      expect do
+        create(:post, postable: new_topic)
+      end.to change { messageboard.reload.updated_at }.to be_within(10.seconds).of(Time.zone.now)
+    end
+    it "when last topic doesn't change, updated_at doesn't change" do
+      expect do
+        create(:post, postable: the_last_topic)
+      end.not_to change { messageboard.reload.updated_at }
+    end
+  end
 end


### PR DESCRIPTION
Adds last_post_at to messageboard and ensure it get changed to last post date (last topic's updated_at), when a topic is updated (post is added or deleted). Closes #358.