### PR TITLE
remove to_i in ReadState comparison which serves no purpose

### DIFF
--- a/app/models/concerns/thredded/user_topic_read_state_common.rb
+++ b/app/models/concerns/thredded/user_topic_read_state_common.rb
@@ -9,7 +9,7 @@ module Thredded
 
     # @return [Boolean]
     def read?
-      postable.last_post_at.to_i <= read_at.to_i
+      postable.last_post_at <= read_at
     end
 
     module ClassMethods


### PR DESCRIPTION
if we want to be more lenient we should do
postable.last_post_at.floor <= read_at.ceil
but this won't help mysql anyway (unless we change accuracy of timestamps in schema), so it will only confuse us. 