### PR TITLE
Remove the &-- top-level class name trick

### DIFF
--- a/app/assets/stylesheets/thredded/_thredded.scss
+++ b/app/assets/stylesheets/thredded/_thredded.scss
@@ -1,32 +1,31 @@
 @import "base";
 
-.thredded {
-  @import "utilities/is-compact";
-  @import "utilities/is-expanded";
+@import "utilities/is-compact";
+@import "utilities/is-expanded";
 
-  @import "layout/main-container";
-  @import "layout/main-navigation";
-  @import "layout/search-navigation";
-  @import "layout/user-navigation";
-  @import "layout/navigation";
-  @import "layout/moderation";
-  @import "layout/user";
+@import "layout/main-container";
+@import "layout/main-navigation";
+@import "layout/search-navigation";
+@import "layout/user-navigation";
+@import "layout/navigation";
+@import "layout/moderation";
+@import "layout/user";
 
-  @import "components/base";
-  @import "components/alerts";
-  @import "components/icons";
-  @import "components/currently-online";
-  @import "components/empty";
-  @import "components/flash-message";
-  @import "components/form-list";
-  @import "components/main-section";
-  @import "components/messageboard";
-  @import "components/pagination";
-  @import "components/post";
-  @import "components/post-form";
-  @import "components/preferences";
-  @import "components/select2";
-  @import "components/topic-delete";
-  @import "components/topic-header";
-  @import "components/topics";
-}
+@import "components/base";
+@import "components/alerts";
+@import "components/icons";
+@import "components/currently-online";
+@import "components/empty";
+@import "components/flash-message";
+@import "components/following";
+@import "components/form-list";
+@import "components/main-section";
+@import "components/messageboard";
+@import "components/pagination";
+@import "components/post";
+@import "components/post-form";
+@import "components/preferences";
+@import "components/select2";
+@import "components/topic-delete";
+@import "components/topic-header";
+@import "components/topics";

--- a/app/assets/stylesheets/thredded/components/_alerts.scss
+++ b/app/assets/stylesheets/thredded/components/_alerts.scss
@@ -1,19 +1,19 @@
-&--alert {
+.thredded--alert {
   @extend %thredded--alert;
 }
 
-&--alert-success {
+.thredded--alert-success {
   @extend %thredded--alert--success;
 }
 
-&--alert-danger {
+.thredded--alert-danger {
   @extend %thredded--alert--danger;
 }
 
-&--alert-info {
+.thredded--alert-info {
   @extend %thredded--alert--info;
 }
 
-&--alert-warning {
+.thredded--alert-warning {
   @extend %thredded--alert--warning;
 }

--- a/app/assets/stylesheets/thredded/components/_base.scss
+++ b/app/assets/stylesheets/thredded/components/_base.scss
@@ -1,21 +1,21 @@
 // Common classes for base placeholders.
 
-&--button, &--form--submit {
+.thredded--button, .thredded--form--submit {
   @extend %thredded--button;
 }
 
-&--form {
+.thredded--form {
   @extend %thredded--form;
 }
 
-&--link {
+.thredded--link {
   @extend %thredded--link;
 }
 
-&--blockquote {
+.thredded--blockquote {
   @extend %thredded--blockquote;
 }
 
-&--table {
+.thredded--table {
   @extend %thredded--table;
 }

--- a/app/assets/stylesheets/thredded/components/_currently-online.scss
+++ b/app/assets/stylesheets/thredded/components/_currently-online.scss
@@ -1,4 +1,4 @@
-&--currently-online {
+.thredded--currently-online {
   background-color: $thredded-base-border-color;
   bottom: -1.25rem;
   padding: $thredded-base-spacing;

--- a/app/assets/stylesheets/thredded/components/_empty.scss
+++ b/app/assets/stylesheets/thredded/components/_empty.scss
@@ -1,10 +1,10 @@
-&--empty {
+.thredded--empty {
   border: $thredded-base-border;
   padding: $thredded-base-spacing;
   text-align: center;
 }
 
-&--empty--title {
+.thredded--empty--title {
   @extend %thredded--heading;
   font-size: 1.5rem; // 24px
   margin-bottom: $thredded-base-spacing;

--- a/app/assets/stylesheets/thredded/components/_flash-message.scss
+++ b/app/assets/stylesheets/thredded/components/_flash-message.scss
@@ -1,19 +1,19 @@
-&--flash-message {
+.thredded--flash-message {
   @extend %thredded--alert;
 }
 
-&--flash-message--success {
+.thredded--flash-message--success {
   @extend %thredded--alert--success;
 }
 
-&--flash-message--error {
+.thredded--flash-message--error {
   @extend %thredded--alert--danger;
 }
 
-&--flash-message--notice {
+.thredded--flash-message--notice {
   @extend %thredded--alert--info;
 }
 
-&--flash-message--alert {
+.thredded--flash-message--alert {
   @extend %thredded--alert--warning;
 }

--- a/app/assets/stylesheets/thredded/components/_following.scss
+++ b/app/assets/stylesheets/thredded/components/_following.scss
@@ -1,0 +1,17 @@
+// Used in both the topics list and the topic posts views.
+%thredded--following-icon {
+  fill: currentColor;
+  display: inline-block;
+  font-size: 1em;
+  width: 1.4rem;
+  height: 1.4rem;
+  position: absolute;
+  top: 0;
+  right: -1.6rem;
+  opacity: 0.4;
+}
+
+%thredded--not-following-icon {
+  @extend %thredded--following-icon;
+  opacity: 0.1;
+}

--- a/app/assets/stylesheets/thredded/components/_form-list.scss
+++ b/app/assets/stylesheets/thredded/components/_form-list.scss
@@ -1,4 +1,4 @@
-&--form-list {
+.thredded--form-list {
   @extend %thredded--list-unstyled;
 
   &.on-top {
@@ -15,7 +15,7 @@
   }
 }
 
-&--form-list--admin-options {
+.thredded--form-list--admin-options {
   label {
     cursor: pointer;
     display: inline-block;
@@ -24,7 +24,7 @@
   }
 }
 
-&--form-list--hint {
+.thredded--form-list--hint {
   @extend %thredded--paragraph;
   color: $thredded-secondary-text-color;
   font-size: $thredded-font-size-small;

--- a/app/assets/stylesheets/thredded/components/_icons.scss
+++ b/app/assets/stylesheets/thredded/components/_icons.scss
@@ -1,3 +1,3 @@
-&--icon {
+.thredded--icon {
   @extend %thredded--icon;
 }

--- a/app/assets/stylesheets/thredded/components/_main-section.scss
+++ b/app/assets/stylesheets/thredded/components/_main-section.scss
@@ -1,3 +1,3 @@
-&--main-section {
+.thredded--main-section {
   margin-bottom: $thredded-large-spacing;
 }

--- a/app/assets/stylesheets/thredded/components/_messageboard.scss
+++ b/app/assets/stylesheets/thredded/components/_messageboard.scss
@@ -1,4 +1,4 @@
-&--messageboard {
+.thredded--messageboard {
   @extend %thredded--link;
   border: $thredded-base-border;
   display: block;
@@ -15,7 +15,7 @@
   }
 }
 
-&--messageboard--title {
+.thredded--messageboard--title {
   @extend %thredded--heading;
   display: inline-block;
   float: left;
@@ -26,7 +26,7 @@
   vertical-align: baseline;
 }
 
-&--messageboard--meta {
+.thredded--messageboard--meta {
   @extend %thredded--heading;
   color: $thredded-secondary-text-color;
   display: inline-block;
@@ -35,14 +35,14 @@
   vertical-align: baseline;
 }
 
-&--messageboard--description {
+.thredded--messageboard--description {
   @extend %thredded--paragraph;
   clear: both;
   margin-bottom: $thredded-small-spacing / 2;
   color: $thredded-text-color;
 }
 
-&--messageboard--byline {
+.thredded--messageboard--byline {
   @extend %thredded--paragraph;
   color: $thredded-secondary-text-color;
   font-size: 0.875em;
@@ -50,6 +50,6 @@
   margin-bottom: 0;
 }
 
-&--messageboards--actions {
+.thredded--messageboards--actions {
   @extend %thredded--buttons-list;
 }

--- a/app/assets/stylesheets/thredded/components/_pagination.scss
+++ b/app/assets/stylesheets/thredded/components/_pagination.scss
@@ -1,4 +1,4 @@
-&--pagination {
+.thredded--pagination {
   border-top: $thredded-base-border;
   margin-top: $thredded-base-spacing;
   padding-top: $thredded-base-spacing;

--- a/app/assets/stylesheets/thredded/components/_post-form.scss
+++ b/app/assets/stylesheets/thredded/components/_post-form.scss
@@ -1,4 +1,4 @@
-&--post-form {
+.thredded--post-form {
   label {
     display: none;
   }

--- a/app/assets/stylesheets/thredded/components/_post.scss
+++ b/app/assets/stylesheets/thredded/components/_post.scss
@@ -1,4 +1,4 @@
-&--post {
+.thredded--post {
   position: relative;
   margin-bottom: $thredded-large-spacing;
   @include thredded-media-mobile {
@@ -6,7 +6,7 @@
   }
 }
 
-&--post--avatar {
+.thredded--post--avatar {
   border-radius: 50%;
   display: inline-block;
   height: 1.75rem; // 28px
@@ -25,16 +25,16 @@
   }
 }
 
-&--post--topic {
+.thredded--post--topic {
   @extend %thredded--heading;
   font-size: $thredded-base-font-size * 1.25; // 24px
   line-height: 1.2;
   margin-bottom: $thredded-small-spacing / 2;
 }
 
-&--post--user,
-&--post--topic,
-&--post--user-and-topic {
+.thredded--post--user,
+.thredded--post--topic,
+.thredded--post--user-and-topic {
   @extend %thredded--heading;
   display: inline;
   font-size: 1.125rem; // 18px
@@ -46,29 +46,30 @@
   }
 }
 
-&--post--user {
+.thredded--post--user {
   a {
     color: $thredded-text-color;
   }
 }
 
-&--post--created-at {
+.thredded--post--created-at {
   @extend %thredded--paragraph;
   font-size: $thredded-font-size-small;
   color: $thredded-secondary-text-color;
   display: inline-block;
 }
 
-&--post--edit, &--post--delete {
+.thredded--post--edit,
+.thredded--post--delete {
   font-size: $thredded-font-size-small;
   @extend %thredded--link;
 }
 
-&--post--delete {
+.thredded--post--delete {
   margin-left: 0.4rem;
 }
 
-&--post--content {
+.thredded--post--content {
   font-size: 1.063rem; // 17px
   line-height: 1.65;
   word-break: break-word;

--- a/app/assets/stylesheets/thredded/components/_preferences.scss
+++ b/app/assets/stylesheets/thredded/components/_preferences.scss
@@ -1,4 +1,4 @@
-&--preferences-header {
+.thredded--preferences-header {
   &--title {
     @extend %thredded--heading;
     font-size: 1.5rem; // 24px

--- a/app/assets/stylesheets/thredded/components/_select2.scss
+++ b/app/assets/stylesheets/thredded/components/_select2.scss
@@ -1,4 +1,4 @@
-&--select2-container {
+.thredded--select2-container {
   width: 100%;
 
   > .select2-choices {
@@ -46,7 +46,7 @@
   }
 }
 
-&--select2-drop {
+.thredded--select2-drop {
   background: inherit;
   border-color: $thredded-form-border-focus-color;
   border-top: $thredded-base-border;
@@ -83,7 +83,7 @@
 }
 
 
-&--select2-user-result {
+.thredded--select2-user-result {
   &__avatar {
     width: 2rem;
     min-height: 2rem;
@@ -97,7 +97,7 @@
   }
 }
 
-&--select2-user-selection {
+.thredded--select2-user-selection {
   &__avatar {
     width: 1rem;
     min-height: 1rem;

--- a/app/assets/stylesheets/thredded/components/_topic-delete.scss
+++ b/app/assets/stylesheets/thredded/components/_topic-delete.scss
@@ -1,9 +1,5 @@
-&--topic-delete {
-
-  &--wrapper {
-    border-top: $thredded-base-border;
-    margin-top: $thredded-base-spacing;
-    padding-top: $thredded-large-spacing;
-  }
-
+.thredded--topic-delete--wrapper {
+  border-top: $thredded-base-border;
+  margin-top: $thredded-base-spacing;
+  padding-top: $thredded-large-spacing;
 }

--- a/app/assets/stylesheets/thredded/components/_topic-header.scss
+++ b/app/assets/stylesheets/thredded/components/_topic-header.scss
@@ -1,4 +1,4 @@
-&--topic-header {
+.thredded--topic-header {
   margin-bottom: $thredded-large-spacing;
   margin-top: $thredded-base-spacing;
   @include thredded-media-mobile {
@@ -7,14 +7,14 @@
   }
 }
 
-&--topic-header--title {
+.thredded--topic-header--title {
   @extend %thredded--heading;
   font-size: 1.5rem; // 24px
   line-height: 1.2;
   margin-bottom: $thredded-small-spacing / 2;
 }
 
-&--topic-header--started-by {
+.thredded--topic-header--started-by {
   font-size: $thredded-font-size-small;
   color: $thredded-secondary-text-color;
   font-style: normal;
@@ -23,12 +23,13 @@
   }
 }
 
-&--topic-header--edit-topic {
+.thredded--topic-header--edit-topic {
   @extend %thredded--link;
   font-size: $thredded-font-size-small;
   margin-left: 0.4rem;
 }
-&--topic-follow-info {
+
+.thredded--topic-header--follow-info {
   float: right;
   color: $thredded-secondary-text-color;
   font-size: $thredded-font-size-small;
@@ -51,66 +52,20 @@
   }
 }
 
-&--topic-followers{
+.thredded--topic-following {
+  .thredded--topic-header--follow-info {
+    position: relative;
+  }
+  .thredded--topic-header--follow-icon {
+    @extend %thredded--following-icon;
+  }
+}
+
+.thredded--topic-followers {
   font-size: $thredded-font-size-small;
   color: $thredded-secondary-text-color;
 }
 
-&--svg-definitions {
-  display:none;
-}
-
-@mixin thredded-following-icon-mixin {
-  svg {
-    fill: currentColor;
-    display: inline-block;
-    font-size: 1em;
-    width: 1.4rem;
-    height: 1.4rem;
-    position: absolute;
-    top: 0;
-    right: -1.6rem;
-    opacity: 0.4;
-  }
-}
-@mixin thredded-not-following-icon-mixin {
-  @include thredded-following-icon-mixin;
-  svg {
-    opacity: 0.1;
-  }
-}
-&--topic-following {
-  &.thredded--topic-unread, &.thredded--topic-read {
-
-    h1.thredded--topics--title {
-      @include thredded-following-icon-mixin;
-    }
-  }
-}
-&--topic-notfollowing {
-  .thredded--topic-follow-icon {
-    @include thredded-not-following-icon-mixin;
-  }
-}
-&--topic-following {
-  .thredded--topic-follow-icon {
-    @include thredded-following-icon-mixin;
-  }
-}
-&--topic-following {
-  .thredded--topic-follow-info {
-    position: relative;
-    @include thredded-following-icon-mixin;
-  }
-}
-
-&--topic-read {
-  h1.thredded--topics--title a {
-    font-weight: lighter;
-  }
-}
-&--topic-unread {
-  h1.thredded--topics--title a {
-    font-weight: bold;
-  }
+.thredded--svg-definitions {
+  display: none;
 }

--- a/app/assets/stylesheets/thredded/components/_topics.scss
+++ b/app/assets/stylesheets/thredded/components/_topics.scss
@@ -1,4 +1,4 @@
-&--topics--topic {
+.thredded--topics--topic {
   margin-bottom: $thredded-base-spacing;
   position: relative;
 
@@ -7,7 +7,7 @@
   }
 }
 
-&--topics--title {
+.thredded--topics--title {
   @extend %thredded--heading;
   display: inline;
   font-size: 1.125rem; // 18px
@@ -24,7 +24,7 @@
   }
 }
 
-&--topics--categories {
+.thredded--topics--categories {
   list-style-type: none;
   margin: 0;
   padding: 0;
@@ -45,8 +45,8 @@
   }
 }
 
-&--topics--started-by,
-&--topics--updated-by {
+.thredded--topics--started-by,
+.thredded--topics--updated-by {
   color: $thredded-secondary-text-color;
   font-size: $thredded-font-size-small;
   font-style: normal;
@@ -68,7 +68,7 @@
   }
 }
 
-&--topics--updated-by {
+.thredded--topics--updated-by {
   margin-right: $thredded-small-spacing;
 
   abbr {
@@ -78,7 +78,7 @@
   }
 }
 
-&--topics--started-by {
+.thredded--topics--started-by {
   display: none;
 
   abbr {
@@ -88,13 +88,13 @@
   }
 }
 
-&--topics--moderation-state {
+.thredded--topics--moderation-state {
   padding: 0.3em 0.5em;
   font-size: $thredded-font-size-small;
   font-style: normal;
 }
 
-&--topics--posts-count {
+.thredded--topics--posts-count {
   border-radius: 50%;
   display: inline-block;
   font-weight: 900;
@@ -110,12 +110,34 @@
   transition: background 0.1s linear, color 0.1s linear;
 }
 
-&--topic-unread > &--topics--posts-count {
-  background: $thredded-badge-active-background;
-  color: $thredded-badge-active-color;
+.thredded--topic-read {
+  > .thredded--topics--title a {
+    font-weight: lighter;
+  }
+  > .thredded--topics--posts-count {
+    background: $thredded-badge-inactive-background;
+    color: $thredded-badge-inactive-color;
+  }
 }
 
-&--topic-read > &--topics--posts-count {
-  background: $thredded-badge-inactive-background;
-  color: $thredded-badge-inactive-color;
+.thredded--topic-unread {
+  > .thredded--topics--title a {
+    font-weight: bold;
+  }
+  > .thredded--topics--posts-count {
+    background: $thredded-badge-active-background;
+    color: $thredded-badge-active-color;
+  }
+}
+
+.thredded--topic-following {
+  .thredded--topics--follow-icon {
+    @extend %thredded--following-icon;
+  }
+}
+
+.thredded--topic-notfollowing {
+  .thredded--topics--follow-icon {
+    @extend %thredded--not-following-icon;
+  }
 }

--- a/app/assets/stylesheets/thredded/layout/_main-container.scss
+++ b/app/assets/stylesheets/thredded/layout/_main-container.scss
@@ -1,4 +1,4 @@
-&--main-container {
+.thredded--main-container {
   @include thredded--clearfix;
   -webkit-font-smoothing: antialiased;
   color: $thredded-text-color;

--- a/app/assets/stylesheets/thredded/layout/_main-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_main-navigation.scss
@@ -1,4 +1,4 @@
-&--main-navigation {
+.thredded--main-navigation {
   @extend %thredded--list-unstyled;
   @include thredded--clearfix;
   display: block;
@@ -7,7 +7,7 @@
   }
 }
 
-&--navigation-breadcrumbs {
+.thredded--navigation-breadcrumbs {
   @extend %thredded--list-unstyled;
 
   li {

--- a/app/assets/stylesheets/thredded/layout/_moderation.scss
+++ b/app/assets/stylesheets/thredded/layout/_moderation.scss
@@ -1,4 +1,4 @@
-&--moderation-navigation {
+.thredded--moderation-navigation {
   position: relative;
   &--items {
     @extend %thredded--nav-tabs;
@@ -8,31 +8,32 @@
   }
 }
 
-.thredded--pending-moderation &--moderation-navigation--pending,
-.thredded--moderation-history &--moderation-navigation--history,
-.thredded--moderation-users &--moderation-navigation--users,
-.thredded--moderation-user &--moderation-navigation--users,
-.thredded--moderation-activity &--moderation-navigation--activity {
+.thredded--pending-moderation .thredded--moderation-navigation--pending,
+.thredded--moderation-history .thredded--moderation-navigation--history,
+.thredded--moderation-users .thredded--moderation-navigation--users,
+.thredded--moderation-user .thredded--moderation-navigation--users,
+.thredded--moderation-activity .thredded--moderation-navigation--activity {
   @extend %thredded--nav-tabs--item-current;
 }
 
-&--post-moderation-actions {
+.thredded--post-moderation-actions {
   @extend %thredded--buttons-list;
 }
 
-&--moderated-notice {
+.thredded--moderated-notice {
   margin-bottom: $thredded-base-spacing;
   padding: $thredded-small-spacing $thredded-base-spacing;
   background: $thredded-light-gray;
 }
 
-&--post-moderation, &--post-moderation-record {
+.thredded--post-moderation,
+.thredded--post-moderation-record {
   .thredded--post--user a {
     color: $thredded-action-color;
   }
 }
 
-&--post-moderation-record {
+.thredded--post-moderation-record {
   .thredded--post {
     margin-bottom: 0;
     margin-left: 1rem;
@@ -60,26 +61,26 @@
   }
 }
 
-&--post-moderation-record + &--post-moderation-record {
+.thredded--post-moderation-record + .thredded--post-moderation-record {
   margin-top: $thredded-large-spacing;
 }
 
-&--moderation--users-table {
+.thredded--moderation--users-table {
   width: 100%;
   a {
     display: block;
   }
 }
 
-&--moderation--user--title {
+.thredded--moderation--user--title {
   margin: 0;
 }
 
-&--moderation--user--info {
+.thredded--moderation--user--info {
   margin-left: 2rem;
 }
 
-&--user--moderation-actions {
+.thredded--user--moderation-actions {
   text-align: left;
   margin-left: 4rem;
   .button_to {

--- a/app/assets/stylesheets/thredded/layout/_navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_navigation.scss
@@ -1,4 +1,4 @@
-&--navigation {
+.thredded--navigation {
   margin-bottom: $thredded-small-spacing;
   position: relative;
   .thredded--icon {
@@ -8,23 +8,23 @@
 
 @include thredded-media-tablet-and-down {
   $icon-nav-item-width: 2.625rem;
-  &--navigation {
+  .thredded--navigation {
     display: table;
     position: relative;
     width: 100%;
   }
-  &--main-navigation {
+  .thredded--main-navigation {
     position: relative;
     border: none;
   }
-  &--navigation-breadcrumbs {
+  .thredded--navigation-breadcrumbs {
     font-size: $thredded-font-size-small;
     padding-right: $icon-nav-item-width * 2;
     .thredded--is-moderator & {
       padding-right: $icon-nav-item-width * 3;
     }
   }
-  &--navigation--search-topics {
+  .thredded--navigation--search-topics {
     display: none;
     .thredded--messageboards-index &,
     .thredded--topics-index &,
@@ -32,7 +32,7 @@
       display: block;
     }
   }
-  &--user-navigation {
+  .thredded--user-navigation {
     display: table-footer-group;
     &-standalone {
       display: block;

--- a/app/assets/stylesheets/thredded/layout/_search-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_search-navigation.scss
@@ -1,4 +1,4 @@
-&--navigation--search {
+.thredded--navigation--search {
   margin-right: 0;
   padding: 0;
   position: absolute;

--- a/app/assets/stylesheets/thredded/layout/_user-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_user-navigation.scss
@@ -1,24 +1,24 @@
-&--user-navigation {
+.thredded--user-navigation {
   @extend %thredded--nav-tabs;
 }
 
-&--user-navigation--item {
+.thredded--user-navigation--item {
   @extend %thredded--nav-tabs--item;
 }
 
-.thredded--preferences &--user-navigation--settings,
-.thredded--new-private-topic &--user-navigation--private-topics,
-.thredded--private-topics-index &--user-navigation--private-topics,
-.thredded--private-topic-show &--user-navigation--private-topics,
-.thredded--pending-moderation &--user-navigation--moderation,
-.thredded--moderation-history &--user-navigation--moderation,
-.thredded--moderation-users &--user-navigation--moderation,
-.thredded--moderation-user &--user-navigation--moderation,
-.thredded--moderation-activity &--user-navigation--moderation {
+.thredded--preferences .thredded--user-navigation--settings,
+.thredded--new-private-topic .thredded--user-navigation--private-topics,
+.thredded--private-topics-index .thredded--user-navigation--private-topics,
+.thredded--private-topic-show .thredded--user-navigation--private-topics,
+.thredded--pending-moderation .thredded--user-navigation--moderation,
+.thredded--moderation-history .thredded--user-navigation--moderation,
+.thredded--moderation-users .thredded--user-navigation--moderation,
+.thredded--moderation-user .thredded--user-navigation--moderation,
+.thredded--moderation-activity .thredded--user-navigation--moderation {
   @extend %thredded--nav-tabs--item-current;
 }
 
-&--user-navigation--private-topics--unread,
-&--user-navigation--moderation--pending-count {
+.thredded--user-navigation--private-topics--unread,
+.thredded--user-navigation--moderation--pending-count {
   @extend %thredded--nav-tabs--item--badge;
 }

--- a/app/assets/stylesheets/thredded/layout/_user.scss
+++ b/app/assets/stylesheets/thredded/layout/_user.scss
@@ -1,4 +1,4 @@
-&--user--avatar {
+.thredded--user--avatar {
   border-radius: 50%;
   display: inline-block;
   height: 1.75em;

--- a/app/assets/stylesheets/thredded/utilities/_is-compact.scss
+++ b/app/assets/stylesheets/thredded/utilities/_is-compact.scss
@@ -1,4 +1,4 @@
-&--is-compact {
+.thredded--is-compact {
 
   input[type="submit"],
   label {

--- a/app/assets/stylesheets/thredded/utilities/_is-expanded.scss
+++ b/app/assets/stylesheets/thredded/utilities/_is-expanded.scss
@@ -1,4 +1,4 @@
-&--is-expanded {
+.thredded--is-expanded {
   label {
     height: auto;
     margin-bottom: $thredded-small-spacing / 2;

--- a/app/views/thredded/topics/_header.html.erb
+++ b/app/views/thredded/topics/_header.html.erb
@@ -11,15 +11,15 @@
   <% end %>
   <% if thredded_current_user %>
     <% if topic.followed? %>
-      <div class="thredded--topic-follow-info">
-        <%= inline_svg 'thredded/follow.svg'%>
+      <div class="thredded--topic-header--follow-info">
+        <%= inline_svg 'thredded/follow.svg', class: 'thredded--topic-header--follow-icon' %>
         <div>
           <%= topic_follow_reason_text topic.follow_reason %>
           <%= button_to 'Stop following', topic.unfollow_path %>
         </div>
       </div>
     <% else %>
-      <div class="thredded--topic-follow-info">
+      <div class="thredded--topic-header--follow-info">
         <%= button_to 'Follow this topic', topic.follow_path %>
       </div>
     <% end %>

--- a/app/views/thredded/topics/_topic.html.erb
+++ b/app/views/thredded/topics/_topic.html.erb
@@ -4,8 +4,8 @@
                 data: {topic: topic.id, messageboard: topic.messageboard_id} do %>
   <div class="thredded--topics--posts-count"><%= topic.posts_count %></div>
 
-  <div class="thredded--topic-follow-icon" title="<%= topic_follow_reason_text topic.follow_reason %>">
-    <svg viewBox="0 0 116 121" role="img">
+  <div class="thredded--topics--follow-info" title="<%= topic_follow_reason_text topic.follow_reason %>">
+    <svg class="thredded--topics--follow-icon" viewBox="0 0 116 121" role="img">
       <% if topic.followed? %>
         <use xlink:href="#thredded-follow-icon"/>
       <% else %>


### PR DESCRIPTION
These serve no purpose and do not play well with %-placeholder selectors (extra styles were generated because of the `.thredded` wrapper). I had initially added these thinking the `.thredded` wrapper class name could be changed, but it can't and making it possible is not worth the effort.

Additionally, this updates the "follow" icons styles to use %-placeholders, and adjusts their class names to conform to the naming scheme, i.e.: `--topic-header--` for the topic posts view, and `--topics--` for
the topics list views.