### PR TITLE
[JRO] Bundle update heroku.gemfile

### DIFF
--- a/heroku.gemfile
+++ b/heroku.gemfile
@@ -12,6 +12,7 @@ gem 'puma'
 gem 'pg'
 gem 'rails_email_preview', '>= 1.0.3'
 gem 'jquery-turbolinks'
+gem 'pundit'
 # TODO: upgrade once Turbolinks 5 is supported by jquery-turbolinks:
 # https://github.com/kossnocorp/jquery.turbolinks/pull/58
 gem 'turbolinks', '~> 2.5'

--- a/heroku.gemfile.lock
+++ b/heroku.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    thredded (0.6.3)
+    thredded (0.7.0)
       active_record_union (>= 1.2.0)
       autoprefixer-rails
       autosize-rails
@@ -71,7 +71,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (7.1.2)
-    autoprefixer-rails (6.4.1.1)
+    autoprefixer-rails (6.5.1)
       execjs
     autosize-rails (1.18.17)
       rails (>= 3.1)
@@ -202,7 +202,7 @@ GEM
     request_store (1.3.1)
     rollbar (2.13.1)
       multi_json
-    sanitize (4.3.0)
+    sanitize (4.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
       nokogumbo (~> 1.4.1)
@@ -252,6 +252,7 @@ DEPENDENCIES
   newrelic_rpm
   pg
   puma
+  pundit
   rack-canonical-host
   rails (~> 5.0.0)
   rails-i18n
@@ -265,4 +266,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.4


### PR DESCRIPTION
Recent updates to the demo ran into issues because pundit was unable to be loaded. Odd.

Adding it to the heroku gemfile, `bundle install --gemfile=heroku.gemfile`, and pushing to heroku seem to fix things.

It's possible the gemfile just needed updating (without explicitly adding pundit to it) or not.