### PR TITLE
fix broken migration

### DIFF
--- a/db/upgrade_migrations/20161019150201_upgrade_v0_7_to_v0_8.rb
+++ b/db/upgrade_migrations/20161019150201_upgrade_v0_7_to_v0_8.rb
@@ -3,15 +3,15 @@ class UpgradeV07ToV08 < ActiveRecord::Migration
   def up
     add_column :thredded_user_preferences, :followed_topic_emails, :boolean, default: true, null: false
     add_column :thredded_user_messageboard_preferences, :followed_topic_emails, :boolean, default: true, null: false
-    rename_column :thredded_user_preferences, :auto_follow_topics, :follow_topics_on_mention
-    rename_column :thredded_user_messageboard_preferences, :auto_follow_topics, :follow_topics_on_mention
+    rename_column :thredded_user_preferences, :notify_on_mention, :follow_topics_on_mention
+    rename_column :thredded_user_messageboard_preferences, :notify_on_mention, :follow_topics_on_mention
     change_column :thredded_messageboards, :name, :string, limit: 191
   end
 
   def down
     change_column :thredded_messageboards, :name, :string, limit: 255
-    rename_column :thredded_user_messageboard_preferences, :follow_topics_on_mention, :auto_follow_topics
-    rename_column :thredded_user_preferences, :follow_topics_on_mention, :auto_follow_topics
+    rename_column :thredded_user_messageboard_preferences, :follow_topics_on_mention, :notify_on_mention
+    rename_column :thredded_user_preferences, :follow_topics_on_mention, :notify_on_mention
     remove_column :thredded_user_messageboard_preferences, :followed_topic_emails
     remove_column :thredded_user_preferences, :followed_topic_emails
   end


### PR DESCRIPTION
As part of the renaming yesterday I accidentally over-rode the migration. Only noticed today when I tried to run it in our main app and it blew up. Sorry! Fix here...  