### PR TITLE
Split ContentFormatter filters into groups

### DIFF
--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -76,8 +76,9 @@ Thredded.layout = 'thredded/application'
 # Customize the way Thredded handles post formatting.
 
 # Change the default html-pipeline filters used by thredded.
-# E.g. to remove BBCode support:
-# Thredded::ContentFormatter.pipeline_filters -= [HTML::Pipeline::BbcodeFilter]
+# E.g. to replace default emoji filter with your own:
+# Thredded::ContentFormatter.markup_filters[
+#   Thredded::ContentFormatter.markup_filters.index(HTML::Pipeline::EmojiFilter)] = MyEmojiFilter
 
 # Change the HTML sanitization settings used by Thredded.
 # See the Sanitize docs for more information on the underlying library: https://github.com/rgrove/sanitize/#readme

--- a/lib/thredded/content_formatter.rb
+++ b/lib/thredded/content_formatter.rb
@@ -39,21 +39,50 @@ module Thredded
       }
     )
 
-    # HTML::Pipeline filters.
-    mattr_accessor :pipeline_filters
-
-    self.pipeline_filters = [
+    # Filters that run before processing the markup.
+    # input: markup, output: markup.
+    mattr_accessor :before_markup_filters
+    self.before_markup_filters = [
       HTML::Pipeline::VimeoFilter,
       HTML::Pipeline::YoutubeFilter,
+    ]
+
+    # Markup filters, such as BBCode, Markdown, Autolink, etc.
+    # input: markup, output: html.
+    mattr_accessor :markup_filters
+    self.markup_filters = [
       Thredded::HtmlPipeline::BbcodeFilter,
       Thredded::HtmlPipeline::KramdownFilter,
+    ]
+
+    # Filters that run after processing the markup.
+    # input: html, output: html.
+    mattr_accessor :after_markup_filters
+    self.after_markup_filters = [
       # AutolinkFilter is required because Kramdown does not autolink by default.
       # https://github.com/gettalong/kramdown/issues/306
       Thredded::HtmlPipeline::AutolinkFilter,
-      Thredded::HtmlPipeline::AtMentionFilter,
       HTML::Pipeline::EmojiFilter,
+      Thredded::HtmlPipeline::AtMentionFilter,
       HTML::Pipeline::SanitizationFilter,
-    ].freeze
+    ]
+
+    # Filters that sanitize the resulting HTML.
+    # input: html, output: sanitized html.
+    mattr_accessor :sanitization_filters
+    self.sanitization_filters = [
+      HTML::Pipeline::SanitizationFilter,
+    ]
+
+    # All HTML::Pipeline filters.
+    def self.pipeline_filters
+      [
+        *before_markup_filters,
+        *markup_filters,
+        *after_markup_filters,
+        *sanitization_filters,
+      ]
+    end
 
     # @param view_context [Object] the context of the rendering view.
     # @param pipeline_options [Hash]

--- a/lib/thredded/content_formatter.rb
+++ b/lib/thredded/content_formatter.rb
@@ -74,14 +74,18 @@ module Thredded
       HTML::Pipeline::SanitizationFilter,
     ]
 
-    # All HTML::Pipeline filters.
+    # All the HTML::Pipeline filters, read-only.
     def self.pipeline_filters
-      [
+      filters = [
         *before_markup_filters,
         *markup_filters,
         *after_markup_filters,
         *sanitization_filters,
       ]
+      # Changing the result in-place has no effect on the ContentFormatter output,
+      # and is most likely the result of a programmer error.
+      # Freeze the array so that in-place changes raise an error.
+      filters.freeze
     end
 
     # @param view_context [Object] the context of the rendering view.


### PR DESCRIPTION
Splits filters into 4 groups based on what they process:

* Pre-processing (`before_markup_filters`), input: markup, output: markup.
* Core markup processing (`markup_filters`). input: markup, output: html.
* Output post-processing (`after_markup_filters`). input: html, output: html.
* Sanitization (`sanitization_filters`). input: html, output: sanitized html.

Also these new filter arrays are not frozen.
Doesn't seem very important to freeze them, and makes customization a bit
simpler.

This makes registering content formatting plugins easier for plugin authors.

@jayroh @timdiggins 