### PR TITLE
Remove config / code regarding incoming mail

### DIFF
--- a/app/mailers/thredded/post_mailer.rb
+++ b/app/mailers/thredded/post_mailer.rb
@@ -10,7 +10,6 @@ module Thredded
       mail from:     email_details.no_reply,
            to:       email_details.no_reply,
            bcc:      emails,
-           reply_to: email_details.reply_to,
            subject:  email_details.subject
     end
   end

--- a/app/mailers/thredded/private_topic_mailer.rb
+++ b/app/mailers/thredded/private_topic_mailer.rb
@@ -10,7 +10,6 @@ module Thredded
       mail from:     email_details.no_reply,
            to:       email_details.no_reply,
            bcc:      emails,
-           reply_to: email_details.reply_to,
            subject:  email_details.subject
     end
   end

--- a/app/view_models/thredded/topic_email_view.rb
+++ b/app/view_models/thredded/topic_email_view.rb
@@ -14,10 +14,6 @@ module Thredded
       "#{Thredded.email_outgoing_prefix} #{@topic.title}"
     end
 
-    def reply_to
-      Thredded.email_reply_to.call(@topic)
-    end
-
     def no_reply
       Thredded.email_from
     end

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -59,14 +59,8 @@ Thredded.messageboards_order = :position
 # Email "From:" field will use the following
 # Thredded.email_from = 'no-reply@example.com'
 
-# Incoming email will be directed to this host
-# Thredded.email_incoming_host = 'example.com'
-
 # Emails going out will prefix the "Subject:" with the following string
 # Thredded.email_outgoing_prefix = '[My Forum] '
-
-# Reply to field for email notifications
-# Thredded.email_reply_to = -> postable { "#{postable.hash_id}@#{Thredded.email_incoming_host}" }
 
 # ==> View Configuration
 # Set the layout for rendering the thredded views.

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -36,9 +36,7 @@ module Thredded
     :active_user_threshold,
     :avatar_url,
     :email_from,
-    :email_incoming_host,
     :email_outgoing_prefix,
-    :email_reply_to,
     :layout,
     :messageboards_order,
     :user_class,
@@ -67,7 +65,6 @@ module Thredded
   self.active_user_threshold = 5.minutes
   self.admin_column = :admin
   self.avatar_url = ->(user) { Gravatar.src(user.email, 128, 'mm') }
-  self.email_reply_to = -> (postable) { "#{postable.hash_id}@#{Thredded.email_incoming_host}" }
   self.layout = 'thredded/application'
   self.moderator_column = :admin
   self.user_name_column = :name

--- a/spec/dummy/config/initializers/thredded.rb
+++ b/spec/dummy/config/initializers/thredded.rb
@@ -3,7 +3,6 @@ Thredded.user_class = 'User'
 Thredded.user_name_column = :name
 Thredded.user_path = ->(user) { main_app.user_path(user.id) }
 Thredded.current_user_method = :"the_current_#{Thredded.user_class.name.underscore}"
-Thredded.email_incoming_host = 'incoming.example.com'
 Thredded.email_from = 'no-reply@example.com'
 Thredded.email_outgoing_prefix = '[Thredded] '
 Thredded.layout = 'application' unless ENV['THREDDED_DUMMY_LAYOUT_STANDALONE']

--- a/spec/mailers/thredded/post_mailer_spec.rb
+++ b/spec/mailers/thredded/post_mailer_spec.rb
@@ -7,7 +7,6 @@ module Thredded
       expect(email.from).to eq(['no-reply@example.com'])
       expect(email.to).to eq(['no-reply@example.com'])
       expect(email.bcc).to eq(%w(john@email.com sam@email.com))
-      expect(email.reply_to).to eq(['abcd@incoming.example.com'])
       expect(email.subject).to eq('[Thredded] A title')
     end
 

--- a/spec/view_models/thredded/topic_email_view_spec.rb
+++ b/spec/view_models/thredded/topic_email_view_spec.rb
@@ -27,12 +27,5 @@ module Thredded
           .to eq(Thredded.email_from)
       end
     end
-
-    describe '.reply_to' do
-      it 'returns the reply-to address for the app' do
-        expect(decorated_topic.reply_to)
-          .to eq("#{topic.hash_id}@#{Thredded.email_incoming_host}")
-      end
-    end
   end
 end


### PR DESCRIPTION
Considering there is no infrastructure in the app to handle incoming
email the following code is, for all intents and purposes, noise.
"Bit-rot" as a term comes to mind. That being said - the gem can
function without the presence of this removed code.

Addresses issue #371