### PR TITLE
Attempt to fix onPageLoad

### DIFF
--- a/app/assets/javascripts/thredded/core/on_page_load.es6
+++ b/app/assets/javascripts/thredded/core/on_page_load.es6
@@ -1,7 +1,6 @@
-(($) => {
+(() => {
   const isTurbolinks = 'Turbolinks' in window && window.Turbolinks.supported;
   const isTurbolinks5 = isTurbolinks && 'clearCache' in window.Turbolinks;
-  const isjQueryTurbolinks = 'turbo' in $.fn;
 
   let onPageLoadFiredOnce = false;
   const pageLoadCallbacks = [];
@@ -19,31 +18,29 @@
   // has already fired, will execute the callback immediately.
   window.Thredded.onPageLoad = (callback) => {
     pageLoadCallbacks.push(callback);
-    // With async script loading, a callback may be added
-    // after the DOMContentLoaded event has already triggered.
-    // This means we will not receive turbolinks:load on Turbolinks 5.
-    if (isTurbolinks5 && !onPageLoadFiredOnce && window.Thredded.DOMContentLoadedFired) {
+    // With async script loading, a callback may be added after the DOMContentLoaded event has already triggered.
+    // This means we will receive neither a DOMContentLoaded event, nor a turbolinks:load event on Turbolinks 5.
+    if (!onPageLoadFiredOnce && window.Thredded.DOMContentLoadedFired) {
       callback();
     }
   };
-
-  if (!isTurbolinks || isjQueryTurbolinks) {
-    $(() => triggerOnPageLoad());
-    return;
-  }
 
   if (isTurbolinks5) {
     document.addEventListener('turbolinks:load', () => {
       triggerOnPageLoad();
     });
   } else {
-    // Turbolinks Classic with no jQuery.Turbolinks:
-    $(() => {
-      triggerOnPageLoad();
+    // Turbolinks Classic (with or without jQuery.Turbolinks):
+    if (!window.Thredded.DOMContentLoadedFired) {
+      document.addEventListener('DOMContentLoaded', () => {
+        triggerOnPageLoad();
+      });
+    }
+    if (isTurbolinks) {
       document.addEventListener('page:load', () => {
         triggerOnPageLoad();
       })
-    });
+    }
   }
-})(jQuery);
+})();
 

--- a/app/assets/javascripts/thredded/core/on_page_load.es6
+++ b/app/assets/javascripts/thredded/core/on_page_load.es6
@@ -30,7 +30,7 @@
       triggerOnPageLoad();
     });
   } else {
-    // Turbolinks Classic (with or without jQuery.Turbolinks):
+    // Turbolinks Classic (with or without jQuery.Turbolinks), or no Turbolinks:
     if (!window.Thredded.DOMContentLoadedFired) {
       document.addEventListener('DOMContentLoaded', () => {
         triggerOnPageLoad();


### PR DESCRIPTION
Remove the use of jQuery.fn.ready, as it falls back to window.load if
DOMContentLoaded had already fired, but window.load fires much later.

This means we no longer have to distinguish between Turbolinks Classic
with vs without jQuery.Turbolinks.

@timdiggins Does this resolve #464?