### PR TITLE
Do not use `require_dependency`

### DIFF
--- a/app/commands/thredded/autofollow_mentioned_users.rb
+++ b/app/commands/thredded/autofollow_mentioned_users.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency 'thredded/at_notification_extractor'
 module Thredded
   class AutofollowMentionedUsers
     def initialize(post)

--- a/app/controllers/thredded/moderation_controller.rb
+++ b/app/controllers/thredded/moderation_controller.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
-require_dependency 'thredded/moderate_post'
-require_dependency 'thredded/posts_page_view'
 module Thredded
   class ModerationController < Thredded::ApplicationController
     before_action :thredded_require_login!
     before_action :load_moderatable_messageboards
 
     def pending
-      @posts = PostsPageView.new(
+      @posts = Thredded::PostsPageView.new(
         thredded_current_user,
         moderatable_posts
           .pending_moderation
@@ -25,7 +23,7 @@ module Thredded
     end
 
     def activity
-      @posts = PostsPageView.new(
+      @posts = Thredded::PostsPageView.new(
         thredded_current_user,
         moderatable_posts
           .order_newest_first
@@ -37,7 +35,7 @@ module Thredded
 
     def moderate_post
       return head(:bad_request) unless Thredded::Post.moderation_states.include?(params[:moderation_state])
-      flash[:last_moderated_record_id] = ModeratePost.run!(
+      flash[:last_moderated_record_id] = Thredded::ModeratePost.run!(
         post: moderatable_posts.find(params[:id]),
         moderation_state: params[:moderation_state],
         moderator: thredded_current_user,
@@ -64,7 +62,7 @@ module Thredded
         .order_newest_first
         .includes(:postable)
         .page(current_page)
-      @posts = PostsPageView.new(thredded_current_user, posts_scope)
+      @posts = Thredded::PostsPageView.new(thredded_current_user, posts_scope)
     end
 
     def moderate_user

--- a/app/controllers/thredded/private_topics_controller.rb
+++ b/app/controllers/thredded/private_topics_controller.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require_dependency 'thredded/posts_page_view'
-require_dependency 'thredded/topics_page_view'
 module Thredded
   class PrivateTopicsController < Thredded::ApplicationController
     before_action :thredded_require_login!
@@ -8,7 +6,7 @@ module Thredded
     def index
       @private_topics = Thredded::PrivateTopicsPageView.new(
         thredded_current_user,
-        PrivateTopic
+        Thredded::PrivateTopic
           .distinct
           .for_user(thredded_current_user)
           .order_recently_posted_first
@@ -16,7 +14,7 @@ module Thredded
           .page(params[:page])
       )
 
-      PrivateTopicForm.new(user: thredded_current_user).tap do |form|
+      Thredded::PrivateTopicForm.new(user: thredded_current_user).tap do |form|
         @new_private_topic = form if policy(form.private_topic).create?
       end
     end
@@ -32,19 +30,21 @@ module Thredded
       @posts = Thredded::TopicPostsPageView.new(thredded_current_user, private_topic, page_scope)
 
       if signed_in?
-        UserPrivateTopicReadState.touch!(thredded_current_user.id, private_topic.id, page_scope.last, current_page)
+        Thredded::UserPrivateTopicReadState.touch!(
+          thredded_current_user.id, private_topic.id, page_scope.last, current_page
+        )
       end
 
       @post = private_topic.posts.build
     end
 
     def new
-      @private_topic = PrivateTopicForm.new(user: thredded_current_user)
+      @private_topic = Thredded::PrivateTopicForm.new(user: thredded_current_user)
       authorize_creating @private_topic.private_topic
     end
 
     def create
-      @private_topic = PrivateTopicForm.new(new_private_topic_params)
+      @private_topic = Thredded::PrivateTopicForm.new(new_private_topic_params)
       if @private_topic.save
         redirect_to @private_topic.private_topic
       else

--- a/app/mailers/thredded/post_mailer.rb
+++ b/app/mailers/thredded/post_mailer.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-require_dependency 'thredded/topic_email_view'
 module Thredded
   class PostMailer < Thredded::BaseMailer
     def post_notification(post_id, emails)
-      @post                = find_record Post, post_id
-      email_details        = TopicEmailView.new(@post.postable)
+      @post                = find_record Thredded::Post, post_id
+      email_details        = Thredded::TopicEmailView.new(@post.postable)
       headers['X-SMTPAPI'] = email_details.smtp_api_tag('post_notification')
 
       mail from:     email_details.no_reply,

--- a/app/mailers/thredded/private_topic_mailer.rb
+++ b/app/mailers/thredded/private_topic_mailer.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
-require_dependency 'thredded/topic_email_view'
 module Thredded
   class PrivateTopicMailer < Thredded::BaseMailer
     def message_notification(private_topic_id, emails)
-      @topic               = find_record PrivateTopic, private_topic_id
-      email_details        = TopicEmailView.new(@topic)
+      @topic               = find_record Thredded::PrivateTopic, private_topic_id
+      email_details        = Thredded::TopicEmailView.new(@topic)
       headers['X-SMTPAPI'] = email_details.smtp_api_tag('private_topic_mailer')
 
       mail from:     email_details.no_reply,

--- a/app/policies/thredded/post_policy.rb
+++ b/app/policies/thredded/post_policy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency 'thredded/topic_policy'
 module Thredded
   class PostPolicy
     # The scope of readable posts.
@@ -30,7 +29,7 @@ module Thredded
     end
 
     def read?
-      TopicPolicy.new(@user, @post.postable).read? && @post.moderation_state_visible_to_user?(@user)
+      Thredded::TopicPolicy.new(@user, @post.postable).read? && @post.moderation_state_visible_to_user?(@user)
     end
 
     def update?
@@ -46,7 +45,7 @@ module Thredded
     private
 
     def messageboard_policy
-      @messageboard_policy ||= MessageboardPolicy.new(@user, @post.messageboard)
+      @messageboard_policy ||= Thredded::MessageboardPolicy.new(@user, @post.messageboard)
     end
 
     def own_post?

--- a/app/policies/thredded/private_post_policy.rb
+++ b/app/policies/thredded/private_post_policy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency 'thredded/private_topic_policy'
 module Thredded
   class PrivatePostPolicy
     # @param user [Thredded.user_class]
@@ -14,7 +13,7 @@ module Thredded
     end
 
     def read?
-      PrivateTopicPolicy.new(@user, @post.postable).read?
+      Thredded::PrivateTopicPolicy.new(@user, @post.postable).read?
     end
 
     def update?

--- a/app/policies/thredded/topic_policy.rb
+++ b/app/policies/thredded/topic_policy.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency 'thredded/messageboard_policy'
 module Thredded
   class TopicPolicy
     # The scope of readable topics.
@@ -23,7 +22,7 @@ module Thredded
     def initialize(user, topic)
       @user                = user
       @topic               = topic
-      @messageboard_policy = MessageboardPolicy.new(user, topic.messageboard)
+      @messageboard_policy = Thredded::MessageboardPolicy.new(user, topic.messageboard)
     end
 
     def create?

--- a/app/view_models/thredded/base_topic_view.rb
+++ b/app/view_models/thredded/base_topic_view.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency 'thredded/urls_helper'
 module Thredded
   # A view model for TopicCommon.
   class BaseTopicView

--- a/app/view_models/thredded/post_view.rb
+++ b/app/view_models/thredded/post_view.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency 'thredded/urls_helper'
 module Thredded
   # A view model for PostCommon.
   class PostView

--- a/app/view_models/thredded/posts_page_view.rb
+++ b/app/view_models/thredded/posts_page_view.rb
@@ -1,7 +1,4 @@
 # frozen_string_literal: true
-require_dependency 'thredded/post_view'
-require_dependency 'thredded/topic_view'
-require_dependency 'thredded/private_topic_view'
 module Thredded
   # A view model for a page of PostViews.
   class PostsPageView
@@ -20,7 +17,7 @@ module Thredded
     # @param paginated_scope [ActiveRecord::Relation<Thredded::PostCommon>]
     def initialize(user, paginated_scope)
       @paginated_scope = paginated_scope
-      @post_views      = paginated_scope.map { |post| PostView.new(post, Pundit.policy!(user, post)) }
+      @post_views      = paginated_scope.map { |post| Thredded::PostView.new(post, Pundit.policy!(user, post)) }
     end
   end
 end

--- a/app/view_models/thredded/private_topic_view.rb
+++ b/app/view_models/thredded/private_topic_view.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Thredded
   # A view model for PrivateTopic.
-  class PrivateTopicView < BaseTopicView
+  class PrivateTopicView < Thredded::BaseTopicView
     def edit_path
       Thredded::UrlsHelper.edit_private_topic_path(@topic)
     end

--- a/app/view_models/thredded/private_topics_page_view.rb
+++ b/app/view_models/thredded/private_topics_page_view.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency 'thredded/private_topic_view'
 module Thredded
   # A view model for a page of BaseTopicViews.
   class PrivateTopicsPageView
@@ -17,7 +16,7 @@ module Thredded
     def initialize(user, topics_page_scope)
       @topics_page_scope = topics_page_scope
       @topic_views = @topics_page_scope.with_read_states(user).map do |(topic, read_state)|
-        PrivateTopicView.new(topic, read_state, Pundit.policy!(user, topic))
+        Thredded::PrivateTopicView.new(topic, read_state, Pundit.policy!(user, topic))
       end
     end
   end

--- a/app/view_models/thredded/topic_posts_page_view.rb
+++ b/app/view_models/thredded/topic_posts_page_view.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
-require_dependency 'thredded/posts_page_view'
 module Thredded
   # A view model for a page of PostViews of a Topic.
-  class TopicPostsPageView < PostsPageView
+  class TopicPostsPageView < Thredded::PostsPageView
     # @return [Thredded::BaseTopicView]
     attr_reader :topic
 

--- a/app/view_models/thredded/topic_view.rb
+++ b/app/view_models/thredded/topic_view.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Thredded
   # A view model for Topic.
-  class TopicView < BaseTopicView
+  class TopicView < Thredded::BaseTopicView
     delegate :categories, :id, :blocked?, :last_moderation_record, :followers,
              :last_post, :messageboard_id, :messageboard_name,
              to: :@topic
@@ -17,8 +17,8 @@ module Thredded
     def self.from_user(topic, user)
       read_state = follow = nil
       if user && !user.thredded_anonymous?
-        read_state = UserTopicReadState.find_by(user_id: user.id, postable_id: topic.id)
-        follow = UserTopicFollow.find_by(user_id: user.id, topic_id: topic.id)
+        read_state = Thredded::UserTopicReadState.find_by(user_id: user.id, postable_id: topic.id)
+        follow = Thredded::UserTopicFollow.find_by(user_id: user.id, topic_id: topic.id)
       end
       new(topic, read_state, follow, Pundit.policy!(user, topic))
     end

--- a/app/view_models/thredded/topics_page_view.rb
+++ b/app/view_models/thredded/topics_page_view.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency 'thredded/topic_view'
 module Thredded
   # A view model for a page of BaseTopicViews.
   class TopicsPageView


### PR DESCRIPTION
`require_dependency` is unnecessary, as per the findings in
https://github.com/thredded/thredded/issues/478#issuecomment-261743820

However, when not using `require_dependency`, the absolute constant name
must be used (e.g. `Thredded::Post` instead of `Post`) whenever
there is a chance that the constant has not been loaded yet.
This is because if the `Post` constant is already loaded, autoload will
not get triggered for `Thredded::Post` when referencing just `Post`.