### PR TITLE
Simplify private topic participants style

### DIFF
--- a/app/assets/stylesheets/thredded/components/_topic-header.scss
+++ b/app/assets/stylesheets/thredded/components/_topic-header.scss
@@ -18,17 +18,16 @@
   }
 }
 
-.thredded--topic-header--participants--participant {
-  > a {
-    @extend %thredded--link;
-    display: inline-block;
-    font-size: $thredded-font-size-small;
-    border: $thredded-base-border;
-    border-radius: $thredded-button-border-radius;
-    padding: $thredded-inline-spacing;
+.thredded--topic-header--participants {
+  color: $thredded-secondary-text-color;
 
-    &:hover {
-      border-color: darken($thredded-base-border-color, 15%);
+  &--participant {
+    > a {
+      @extend %thredded--link;
+      font-size: $thredded-font-size-small;
+    }
+    &::before {
+      content: '\2022\00A0'; // • and a non-breaking space
     }
   }
 }

--- a/app/views/thredded/private_topics/_header.html.erb
+++ b/app/views/thredded/private_topics/_header.html.erb
@@ -1,14 +1,14 @@
 <header class="thredded--topic-header">
   <h1 class="thredded--topic-header--title"><%= topic.title %></h1>
-  <div class="thredded--topic-header--participants">
-    <%= render partial: 'thredded/private_topics/header/participant',
-               collection: [topic.user, *topic.users.without(topic.user)] %>
-  </div>
   <cite class="thredded--topic-header--started-by">
     <%= t 'thredded.topics.started_by_html',
           time_ago: time_ago(topic.created_at),
           user:     user_link(topic.user) %>
   </cite>
+  <span class="thredded--topic-header--participants">
+    <%= render partial: 'thredded/private_topics/header/participant',
+               collection: topic.users.without(topic.user) %>
+  </span>
   <% if topic.can_update? %>
     <%= link_to t('thredded.private_topics.edit'), topic.edit_path,
                 class: 'thredded--topic-header--edit-topic' %>


### PR DESCRIPTION
Simplifies the style, making it more consistent with the style on the
index page, and avoiding the use of color functions making it easier to
theme via variables.

Before:
![pt-before](https://cloud.githubusercontent.com/assets/216339/20504620/5482d8e0-b040-11e6-9fec-567544b2d0ba.png)

After:
![pt-after](https://cloud.githubusercontent.com/assets/216339/20504623/55eb5e14-b040-11e6-9223-72654786024a.png)

/cc @zapnap 