### PR TITLE
Add global settings for auto-following

### DIFF
--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -32,7 +32,7 @@ module Thredded
       Thredded::ContentFormatter.new(view_context, users_provider: users_provider).format_content(content)
     end
 
-    def first_in_topic?
+    def first_post_in_topic?
       postable.first_post == self
     end
 

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -32,6 +32,10 @@ module Thredded
       Thredded::ContentFormatter.new(view_context, users_provider: users_provider).format_content(content)
     end
 
+    def first_in_topic?
+      postable.first_post == self
+    end
+
     private
 
     def ensure_user_detail

--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -54,7 +54,7 @@ module Thredded
     def auto_follow_and_notify
       return unless user
       # need to do this in-process so that it appears to them immediately
-      if first_in_topic? ? Thredded.auto_follow_when_creating_topic : Thredded.auto_follow_when_posting_in_topic
+      if first_post_in_topic? ? Thredded.auto_follow_when_creating_topic : Thredded.auto_follow_when_posting_in_topic
         UserTopicFollow.create_unless_exists(user.id, postable_id, :posted)
       end
       # everything else can happen later

--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -54,7 +54,9 @@ module Thredded
     def auto_follow_and_notify
       return unless user
       # need to do this in-process so that it appears to them immediately
-      UserTopicFollow.create_unless_exists(user.id, postable_id, :posted)
+      if first_in_topic? ? Thredded.auto_follow_when_creating_topic : Thredded.auto_follow_when_posting_in_topic
+        UserTopicFollow.create_unless_exists(user.id, postable_id, :posted)
+      end
       # everything else can happen later
       AutoFollowAndNotifyJob.perform_later(id)
     end

--- a/app/policies/thredded/post_policy.rb
+++ b/app/policies/thredded/post_policy.rb
@@ -37,7 +37,7 @@ module Thredded
     end
 
     def destroy?
-      !@post.first_in_topic? && update?
+      !@post.first_post_in_topic? && update?
     end
 
     delegate :moderate?, to: :messageboard_policy

--- a/app/policies/thredded/post_policy.rb
+++ b/app/policies/thredded/post_policy.rb
@@ -37,7 +37,7 @@ module Thredded
     end
 
     def destroy?
-      @post.postable.first_post != @post && update?
+      !@post.first_in_topic? && update?
     end
 
     delegate :moderate?, to: :messageboard_policy

--- a/app/policies/thredded/private_post_policy.rb
+++ b/app/policies/thredded/private_post_policy.rb
@@ -21,7 +21,7 @@ module Thredded
     end
 
     def destroy?
-      @post.postable.first_post != @post && update?
+      !@post.first_in_topic? && update?
     end
 
     private

--- a/app/policies/thredded/private_post_policy.rb
+++ b/app/policies/thredded/private_post_policy.rb
@@ -21,7 +21,7 @@ module Thredded
     end
 
     def destroy?
-      !@post.first_in_topic? && update?
+      !@post.first_post_in_topic? && update?
     end
 
     private

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -109,6 +109,21 @@ Thredded.layout = 'thredded/application'
 #   end
 # end
 
+# ==> Topic following
+#
+# By default, a user will be subscribed to a topic they've created. Uncomment this to not subscribe them:
+#
+# Thredded.auto_follow_when_creating_topic = false
+#
+# By default, a user will be subscribed to (follow) a topic they post in. Uncomment this to not subscribe them:
+#
+# Thredded.auto_follow_when_posting_in_topic = false
+#
+# By default, a user will be subscribed to the topic they get @-mentioned in.
+# Individual users can disable this in the Notification Settings.
+# To change the default for all users, simply change the default value of the `follow_topics_on_mention` column
+# of the `thredded_user_preferences` and `thredded_user_messageboard_preferences` tables.
+
 # ==> Notifiers
 #
 # Change how users can choose to be notified, by adding notifiers here, or removing the initializer altogether

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -74,6 +74,14 @@ module Thredded
   # @return [Symbol] The name of the method used by Thredded to display users
   mattr_accessor :user_display_name_method
 
+  # @return [Boolean] Whether the user should get subscribed to a new topic they've created.
+  mattr_accessor :auto_follow_when_creating_topic
+  self.auto_follow_when_creating_topic = true
+
+  # @return [Boolean] Whether the user should get subscribed to a topic after posting in it.
+  mattr_accessor :auto_follow_when_posting_in_topic
+  self.auto_follow_when_posting_in_topic = true
+
   self.active_user_threshold = 5.minutes
   self.admin_column = :admin
   self.avatar_url = ->(user) { Gravatar.src(user.email, 128, 'mm') }

--- a/spec/models/thredded/post_spec.rb
+++ b/spec/models/thredded/post_spec.rb
@@ -79,6 +79,38 @@ module Thredded
       expect(Thredded::UserTopicFollow.last).to be_posted
     end
 
+    context 'when Thredded.auto_follow_when_creating_topic is false',
+            thredded_reset: %i(@@auto_follow_when_creating_topic) do
+      before { Thredded.auto_follow_when_creating_topic = false }
+      it 'does not create a follow for the creator of the first post' do
+        user = create(:user)
+        expect { create(:post, user: user, postable: create(:topic)) }
+          .to_not change { user.thredded_topic_follows.reload.count }
+      end
+
+      it 'creates a follow for the creator of the non-first post' do
+        user = create(:user)
+        expect { create(:post, user: user, postable: create(:topic, with_posts: 1)) }
+          .to change { user.thredded_topic_follows.reload.count }.from(0).to(1)
+      end
+    end
+
+    context 'when Thredded.auto_follow_when_posting_in_topic is false',
+            thredded_reset: %i(@@auto_follow_when_posting_in_topic) do
+      before { Thredded.auto_follow_when_posting_in_topic = false }
+      it 'does not create a follow for the creator of the non-first post' do
+        user = create(:user)
+        expect { create(:post, user: user, postable: create(:topic, with_posts: 1)) }
+          .to_not change { user.thredded_topic_follows.reload.count }
+      end
+
+      it 'creates a follow for the creator of the first post' do
+        user = create(:user)
+        expect { create(:post, user: user, postable: create(:topic)) }
+          .to change { user.thredded_topic_follows.reload.count }.from(0).to(1)
+      end
+    end
+
     it "doesn't create a follow if creator already has a follow" do
       shaun = create(:user)
       topic = create(:topic)


### PR DESCRIPTION
* Whether the user should get subscribed to a new topic they've created.
* Whether the user should get subscribed to a topic after posting in it.

Also, document (in the initializer) how to change the global default for
auto-follow on mention.

Resolves #372