### PR TITLE
Add pagination on top of the page

### DIFF
--- a/app/assets/stylesheets/thredded/components/_pagination.scss
+++ b/app/assets/stylesheets/thredded/components/_pagination.scss
@@ -1,6 +1,5 @@
 .thredded--pagination {
   border-top: $thredded-base-border;
-  margin-top: $thredded-base-spacing;
   padding-top: $thredded-base-spacing;
   text-align: center;
 
@@ -23,4 +22,14 @@
       padding: ($thredded-small-spacing / 2) $thredded-small-spacing;
     }
   }
+}
+
+.thredded--pagination-top > .thredded--pagination {
+  border-bottom: $thredded-base-border;
+  margin-bottom: $thredded-base-spacing;
+  padding-bottom: $thredded-base-spacing;
+}
+
+.thredded--pagination-bottom > .thredded--pagination {
+  margin-top: $thredded-base-spacing;
 }

--- a/app/view_hooks/thredded/all_view_hooks.rb
+++ b/app/view_hooks/thredded/all_view_hooks.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Thredded
   class AllViewHooks
+    # @return [PostsCommon]
+    attr_reader :posts_common
     # @return [PostForm]
     attr_reader :post_form
     # @return [ModerationUserPage]
@@ -19,8 +21,22 @@ module Thredded
     end
 
     def initialize
+      @posts_common = PostsCommon.new
       @post_form = PostForm.new
       @moderation_user_page = ModerationUserPage.new
+    end
+
+    # View hooks for collections of public or private posts.
+    class PostsCommon
+      # @return [Thredded::AllViewHooks::ViewHook]
+      attr_reader :pagination_top
+      # @return [Thredded::AllViewHooks::ViewHook]
+      attr_reader :pagination_bottom
+
+      def initialize
+        @pagination_top = ViewHook.new
+        @pagination_bottom = ViewHook.new
+      end
     end
 
     class PostForm

--- a/app/views/thredded/private_topics/index.html.erb
+++ b/app/views/thredded/private_topics/index.html.erb
@@ -26,7 +26,7 @@
     <% end -%>
   <% end %>
 
-  <footer>
+  <footer class="thredded--pagination-bottom">
     <%= paginate @private_topics %>
   </footer>
 <% end %>

--- a/app/views/thredded/private_topics/show.html.erb
+++ b/app/views/thredded/private_topics/show.html.erb
@@ -8,8 +8,13 @@
                   id: dom_id(private_topic),
                   class: ['thredded--main-section', 'thredded--topic', *topic_css_classes(private_topic)] do %>
     <%= render 'thredded/private_topics/header', topic: private_topic %>
+    <%= view_hooks.posts_common.pagination_top.render(self, posts: @posts) do %>
+      <footer class="thredded--pagination-top"><%= paginate @posts %></footer>
+    <% end %>
     <%= render partial: 'thredded/private_posts/private_post', collection: @posts, cached: true %>
-    <%= paginate @posts %>
+    <%= view_hooks.posts_common.pagination_bottom.render(self, posts: @posts) do %>
+      <footer class="thredded--pagination-bottom"><%= paginate @posts %></footer>
+    <% end %>
     <%= render 'thredded/private_posts/form',
                topic: private_topic,
                post:  @post %>

--- a/app/views/thredded/topics/index.html.erb
+++ b/app/views/thredded/topics/index.html.erb
@@ -17,7 +17,7 @@
     <%= render @topics %>
   <% end %>
 
-  <footer>
+  <footer class="thredded--pagination-bottom">
     <%= paginate @topics %>
   </footer>
 

--- a/app/views/thredded/topics/search.html.erb
+++ b/app/views/thredded/topics/search.html.erb
@@ -10,7 +10,7 @@
     <section class="thredded--main-section thredded--topics">
       <%= render @topics %>
     </section>
-    <footer>
+    <footer class="thredded--pagination-bottom">
       <%= paginate @topics %>
     </footer>
   <% else %>

--- a/app/views/thredded/topics/show.html.erb
+++ b/app/views/thredded/topics/show.html.erb
@@ -7,9 +7,15 @@
   <%= content_tag :section,
                   id: dom_id(topic),
                   class: ['thredded--main-section', 'thredded--topic', *topic_css_classes(topic)] do %>
+
     <%= render 'thredded/topics/header', topic: topic %>
+    <%= view_hooks.posts_common.pagination_top.render(self, posts: @posts) do %>
+      <footer class="thredded--pagination-top"><%= paginate @posts %></footer>
+    <% end %>
     <%= render partial: 'thredded/posts/post', collection: @posts, cached: true %>
-    <%= paginate @posts %>
+    <%= view_hooks.posts_common.pagination_bottom.render(self, posts: @posts) do %>
+      <footer class="thredded--pagination-bottom"><%= paginate @posts %></footer>
+    <% end %>
 
     <% if policy(@new_post).create? %>
       <div class="thredded--post-form--wrapper">


### PR DESCRIPTION
We show quite a few posts per page, and it's not always clear which page you're on.

This adds the pagination bar to the `topics#show` and `private_topics#show` pages by default. View hooks are provided so it's easy to disable it.

---

![thredded-pagination-top](https://cloud.githubusercontent.com/assets/216339/20869135/ee501712-ba63-11e6-9134-21f23d14fb3b.png "Top pagination screenshot")
