### PR TITLE
Update thredded.scss

### DIFF
--- a/app/assets/stylesheets/thredded.scss
+++ b/app/assets/stylesheets/thredded.scss
@@ -1,3 +1,7 @@
++/* prevents from website jumping
+ +html {overflow-y: scroll}
+ +*/
+
 @import "thredded/dependencies";
 @import "thredded/thredded";
 


### PR DESCRIPTION
jumping scrollbar issue fix.
disabled by default but it's a good practice to enable when a website / forum is too short = no scrollbar.