### PR TITLE
Preview posts and topics

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,8 +6,6 @@ engines:
       languages:
       - ruby
       - javascript
-  fixme:
-    enabled: true
   rubocop:
     enabled: true
 ratings:

--- a/app/assets/javascripts/thredded/components/post_form.es6
+++ b/app/assets/javascripts/thredded/components/post_form.es6
@@ -1,3 +1,5 @@
+//= require ./preview_area
+
 (($) => {
   const COMPONENT_SELECTOR = '[data-thredded-post-form]';
 
@@ -9,6 +11,9 @@
     init($nodes) {
       let $textarea = $nodes.find(this.textareaSelector);
       this.autosize($textarea);
+      $nodes.each(function() {
+        new ThreddedPreviewArea($(this));
+      });
       new ThreddedMentionAutocompletion($).init($nodes);
     }
 

--- a/app/assets/javascripts/thredded/components/preview_area.es6
+++ b/app/assets/javascripts/thredded/components/preview_area.es6
@@ -1,0 +1,52 @@
+//= require ./preview_area
+
+(function($) {
+  const PREVIEW_AREA_SELECTOR = '[data-thredded-preview-area]';
+  const PREVIEW_AREA_POST_SELECTOR = '[data-thredded-preview-area-post]';
+
+  class ThreddedPreviewArea {
+
+    constructor($form) {
+      const $preview = $form.find(PREVIEW_AREA_SELECTOR);
+      if (!$preview.length) return;
+      this.$form = $form;
+      const $textarea = $form.find('textarea');
+      this.textarea = $textarea.get(0);
+      this.preview = $preview.get(0);
+      this.previewPost = $form.find(PREVIEW_AREA_POST_SELECTOR).get(0);
+      this.previewUrl = this.preview.getAttribute('data-thredded-preview-url');
+
+      const onChange = Thredded.debounce(() => {
+        this.updatePreview()
+      }, 200, false);
+
+      this.textarea.addEventListener('input', onChange, false);
+      // Listen to the jQuery change event as that's what is triggered by plugins such as jQuery.textcomplete.
+      $textarea.on('change', onChange);
+
+      this.requestId = 0;
+    }
+
+    updatePreview() {
+      this.requestId++;
+      const requestId = this.requestId;
+      $.ajax({
+        type: this.$form.attr('method'),
+        url: this.previewUrl,
+        data: this.$form.serialize(),
+      }).done((data) => {
+        if (requestId == this.requestId) {
+          // Ignore older responses received out-of-order
+          this.onPreviewResponse(data);
+        }
+      });
+    }
+
+    onPreviewResponse(data) {
+      this.preview.style.display = 'block';
+      this.previewPost.innerHTML = data;
+    }
+  }
+
+  window.ThreddedPreviewArea = ThreddedPreviewArea;
+})(jQuery);

--- a/app/assets/javascripts/thredded/components/topic_form.es6
+++ b/app/assets/javascripts/thredded/components/topic_form.es6
@@ -16,6 +16,9 @@
 
     init($nodes) {
       $nodes.find(this.textareaSelector).autosize();
+      $nodes.each(function() {
+        new ThreddedPreviewArea($(this));
+      });
       new ThreddedMentionAutocompletion($).init($nodes);
       $nodes.filter(this.compactSelector).
         on('focus', this.titleSelector, e => {

--- a/app/assets/javascripts/thredded/core/debounce.es6
+++ b/app/assets/javascripts/thredded/core/debounce.es6
@@ -1,0 +1,32 @@
+//= require ./thredded
+
+/**
+ * Return a function, that, as long as it continues to be invoked, will
+ * not be triggered. The function will be called after it stops being
+ * called for `wait` milliseconds. If `immediate` is passed, trigger the
+ * function on the leading edge, instead of the trailing.
+ * Based on https://john-dugan.com/javascript-debounce/.
+ *
+ * @param {Function} func
+ * @param {Number} wait in milliseconds
+ * @param {Boolean} immediate
+ * @returns {Function}
+ */
+window.Thredded.debounce = function(func, wait, immediate) {
+  let timeoutId = null;
+  return function() {
+    const context = this, args = arguments;
+    const later = function() {
+      timeoutId = null;
+      if (!immediate) {
+        func.apply(context, args);
+      }
+    };
+    const callNow = immediate && !timeoutId;
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(later, wait || 200);
+    if (callNow) {
+      func.apply(context, args);
+    }
+  };
+};

--- a/app/assets/javascripts/thredded/core/hide_soft_keyboard.es6
+++ b/app/assets/javascripts/thredded/core/hide_soft_keyboard.es6
@@ -1,4 +1,5 @@
-window.Thredded = window.Thredded || {};
+//= require ./thredded
+
 window.Thredded.hideSoftKeyboard = () => {
   const activeElement = document.activeElement;
   if (!activeElement || !activeElement.blur) return;

--- a/app/assets/javascripts/thredded/core/on_page_load.es6
+++ b/app/assets/javascripts/thredded/core/on_page_load.es6
@@ -1,3 +1,5 @@
+//= require ./thredded
+
 (() => {
   const isTurbolinks = 'Turbolinks' in window && window.Turbolinks.supported;
   const isTurbolinks5 = isTurbolinks && 'clearCache' in window.Turbolinks;
@@ -10,8 +12,6 @@
     });
     onPageLoadFiredOnce = true;
   };
-
-  window.Thredded = window.Thredded || {};
 
   // Fires the callback on DOMContentLoaded or a Turbolinks page load.
   // If called from an async script on the first page load, and the DOMContentLoad event

--- a/app/assets/javascripts/thredded/core/thredded.es6
+++ b/app/assets/javascripts/thredded/core/thredded.es6
@@ -1,0 +1,1 @@
+window.Thredded = window.Thredded || {};

--- a/app/assets/stylesheets/thredded/_thredded.scss
+++ b/app/assets/stylesheets/thredded/_thredded.scss
@@ -30,3 +30,4 @@
 @import "components/topic-delete";
 @import "components/topic-header";
 @import "components/topics";
+@import "components/preview_area";

--- a/app/assets/stylesheets/thredded/components/_preview_area.scss
+++ b/app/assets/stylesheets/thredded/components/_preview_area.scss
@@ -1,0 +1,11 @@
+.thredded--preview-area {
+  display: none;
+
+  &--title {
+    @extend %thredded--heading;
+  }
+
+  &--post {
+    margin-bottom: $thredded-base-spacing;
+  }
+}

--- a/app/controllers/concerns/thredded/new_private_topic_params.rb
+++ b/app/controllers/concerns/thredded/new_private_topic_params.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module Thredded
+  # @api private
+  module NewPrivateTopicParams
+    protected
+
+    def new_private_topic_params
+      params
+        .require(:private_topic)
+        .permit(:title, :content, :user_ids, user_ids: [])
+        .merge(
+          user: thredded_current_user,
+          ip: request.remote_ip
+        ).tap { |p| adapt_user_ids! p }
+    end
+
+    private
+
+    # select2 returns a string of IDs joined with commas.
+    def adapt_user_ids!(p)
+      p[:user_ids] = p[:user_ids].split(',') if p[:user_ids].is_a?(String)
+    end
+  end
+end

--- a/app/controllers/concerns/thredded/new_topic_params.rb
+++ b/app/controllers/concerns/thredded/new_topic_params.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Thredded
+  # @api private
+  module NewTopicParams
+    protected
+
+    def new_topic_params
+      params
+        .fetch(:topic, {})
+        .permit(:title, :locked, :sticky, :content, category_ids: [])
+        .merge(
+          messageboard: messageboard,
+          user: thredded_current_user,
+          ip: request.remote_ip,
+        )
+    end
+  end
+end

--- a/app/controllers/concerns/thredded/render_preview.rb
+++ b/app/controllers/concerns/thredded/render_preview.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Thredded
+  module RenderPreview
+    protected
+
+    def render_preview
+      if request.xhr?
+        render layout: false
+      else
+        @preview_content = render_to_string(layout: false)
+        render template: 'thredded/shared/preview'
+      end
+    end
+  end
+end

--- a/app/controllers/thredded/post_previews_controller.rb
+++ b/app/controllers/thredded/post_previews_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module Thredded
+  class PostPreviewsController < Thredded::ApplicationController
+    include Thredded::RenderPreview
+
+    # Preview a new post
+    def preview
+      @post = Post.new(post_params)
+      @post.postable = Topic.friendly_find!(params[:topic_id])
+      render_preview
+    end
+
+    # Preview an update to an existing post
+    def update
+      @post = Post.find(params[:post_id])
+      @post.assign_attributes(post_params)
+      render_preview
+    end
+
+    private
+
+    def post_params
+      params.require(:post)
+        .permit(:content)
+        .merge(user: thredded_current_user, messageboard: messageboard)
+    end
+  end
+end

--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 module Thredded
+  # This currently handles both {Post}s and {PrivatePost}s.
+  # TODO: split up the PrivatePost functionality into a separate controller.
   class PostsController < Thredded::ApplicationController
     include ActionView::RecordIdentifier
 

--- a/app/controllers/thredded/private_post_previews_controller.rb
+++ b/app/controllers/thredded/private_post_previews_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module Thredded
+  class PrivatePostPreviewsController < Thredded::ApplicationController
+    include Thredded::RenderPreview
+
+    # Preview a new post
+    def preview
+      @private_post = PrivatePost.new(private_post_params)
+      @private_post.postable = PrivateTopic.friendly_find!(params[:private_topic_id])
+      render_preview
+    end
+
+    # Preview an update to an existing post
+    def update
+      @private_post = PrivatePost.find(params[:private_post_id])
+      @private_post.assign_attributes(private_post_params)
+      render_preview
+    end
+
+    private
+
+    def private_post_params
+      params.require(:post)
+        .permit(:content)
+        .merge(user: thredded_current_user)
+    end
+  end
+end

--- a/app/controllers/thredded/private_topic_previews_controller.rb
+++ b/app/controllers/thredded/private_topic_previews_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Thredded
+  class PrivateTopicPreviewsController < Thredded::ApplicationController
+    include Thredded::NewPrivateTopicParams
+    include Thredded::RenderPreview
+
+    def preview
+      form = PrivateTopicForm.new(new_private_topic_params)
+      @private_post = form.post
+      @private_post.postable = form.private_topic
+      render_preview
+    end
+  end
+end

--- a/app/controllers/thredded/private_topics_controller.rb
+++ b/app/controllers/thredded/private_topics_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Thredded
   class PrivateTopicsController < Thredded::ApplicationController
+    include Thredded::NewPrivateTopicParams
+
     before_action :thredded_require_login!
 
     def index
@@ -84,21 +86,6 @@ module Thredded
       params
         .require(:private_topic)
         .permit(:title)
-    end
-
-    def new_private_topic_params
-      params
-        .require(:private_topic)
-        .permit(:title, :content, :user_ids, user_ids: [])
-        .merge(
-          user: thredded_current_user,
-          ip:   request.remote_ip
-        ).tap { |p| adapt_user_ids! p }
-    end
-
-    # select2 returns a string of IDs joined with commas.
-    def adapt_user_ids!(p)
-      p[:user_ids] = p[:user_ids].split(',') if p[:user_ids].is_a?(String)
     end
   end
 end

--- a/app/controllers/thredded/topic_previews_controller.rb
+++ b/app/controllers/thredded/topic_previews_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Thredded
+  class TopicPreviewsController < Thredded::ApplicationController
+    include Thredded::NewTopicParams
+    include Thredded::RenderPreview
+
+    def preview
+      form = TopicForm.new(new_topic_params)
+      @post = form.post
+      @post.postable = form.topic
+      render_preview
+    end
+  end
+end

--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
-# rubocop:disable Metrics/ClassLength
 module Thredded
   class TopicsController < Thredded::ApplicationController
+    include Thredded::NewTopicParams
+
     before_action :thredded_require_login!,
                   only: %i(edit new update create destroy follow unfollow)
     after_action :update_user_activity
@@ -147,20 +148,8 @@ module Thredded
         .permit(:title, :locked, :sticky, category_ids: [])
     end
 
-    def new_topic_params
-      params
-        .fetch(:topic, {})
-        .permit(:title, :locked, :sticky, :content, category_ids: [])
-        .merge(
-          messageboard: messageboard,
-          user: thredded_current_user,
-          ip: request.remote_ip,
-        )
-    end
-
     def current_page
       (params[:page] || 1).to_i
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/view_hooks/thredded/all_view_hooks.rb
+++ b/app/view_hooks/thredded/all_view_hooks.rb
@@ -27,8 +27,12 @@ module Thredded
       # @return [Thredded::AllViewHooks::ViewHook]
       attr_reader :content_text_area
 
+      # @return [Thredded::AllViewHooks::ViewHook]
+      attr_reader :preview_area
+
       def initialize
         @content_text_area = ViewHook.new
+        @preview_area = ViewHook.new
       end
     end
 

--- a/app/view_models/thredded/private_topic_view.rb
+++ b/app/view_models/thredded/private_topic_view.rb
@@ -15,5 +15,9 @@ module Thredded
                    end
       new(topic, read_state, Pundit.policy!(user, topic))
     end
+
+    def new_post_preview_path
+      Thredded::UrlsHelper.preview_new_private_topic_private_post_path(@topic)
+    end
   end
 end

--- a/app/view_models/thredded/topic_view.rb
+++ b/app/view_models/thredded/topic_view.rb
@@ -63,5 +63,9 @@ module Thredded
     def messageboard_path
       Thredded::UrlsHelper.messageboard_topics_path(@topic.messageboard)
     end
+
+    def new_post_preview_path
+      Thredded::UrlsHelper.preview_new_messageboard_topic_post_path(@topic.messageboard, @topic)
+    end
   end
 end

--- a/app/views/thredded/post_previews/preview.html.erb
+++ b/app/views/thredded/post_previews/preview.html.erb
@@ -1,0 +1,1 @@
+<%= @post.filtered_content(self) %>

--- a/app/views/thredded/post_previews/update.html.erb
+++ b/app/views/thredded/post_previews/update.html.erb
@@ -1,0 +1,1 @@
+<%= @post.filtered_content(self) %>

--- a/app/views/thredded/posts/_form.html.erb
+++ b/app/views/thredded/posts/_form.html.erb
@@ -1,6 +1,7 @@
 <%= render 'thredded/posts_common/form',
            topic: topic,
            post: post,
+           preview_url: preview_url,
            content_label: t('thredded.posts.form.content_label'),
            button_text: button_text,
            button_submitting_text: local_assigns.key?(:button_submitting_text) ? button_submitting_text : nil %>

--- a/app/views/thredded/posts/edit.html.erb
+++ b/app/views/thredded/posts/edit.html.erb
@@ -12,6 +12,8 @@
                messageboard: (messageboard unless @post.private_topic_post?),
                topic:        topic,
                post:         @post,
+               preview_url:  (@post.private_topic_post? ? private_topic_private_post_preview_path(@post.postable, @post)
+                                                        : messageboard_topic_post_preview_path(messageboard, @post.postable, @post)),
                button_text:  t('thredded.posts.form.update_btn'),
                button_submitting_text: t('thredded.posts.form.update_btn_submitting')%>
   </section>

--- a/app/views/thredded/posts_common/_form.html.erb
+++ b/app/views/thredded/posts_common/_form.html.erb
@@ -1,4 +1,4 @@
-<%# locals: messageboard, topic, post, content_label, button_text, button_submitting_text. %>
+<%# locals: messageboard, topic, post, preview_url, content_label, button_text, button_submitting_text. %>
 <%= form_for (post.private_topic_post? ? [topic, post] : [messageboard, topic, post]), as: :post,
              html: {
                  class: 'thredded--form thredded--post-form',
@@ -7,7 +7,8 @@
                  'data-autocomplete-min-length' => Thredded.autocomplete_min_length,
              } do |form| %>
   <ul class="thredded--form-list">
-    <%= render 'thredded/posts_common/form/content_field', form: form, content_label: content_label %>
+    <%= render 'thredded/posts_common/form/content',
+               form: form, content_label: content_label, preview_url: preview_url %>
     <li>
       <% button_submitting_text ||=
              post.persisted? ? t('thredded.form.update_btn_submitting') : t('thredded.form.create_btn_submitting') %>

--- a/app/views/thredded/posts_common/form/_content.html.erb
+++ b/app/views/thredded/posts_common/form/_content.html.erb
@@ -1,0 +1,7 @@
+<%= render 'thredded/posts_common/form/content_field',
+           form: form,
+           content_label: content_label %>
+
+<%= render 'thredded/posts_common/form/preview_area',
+           form: form,
+           preview_url: preview_url %>

--- a/app/views/thredded/posts_common/form/_preview_area.html.erb
+++ b/app/views/thredded/posts_common/form/_preview_area.html.erb
@@ -1,0 +1,16 @@
+<%= view_hooks.post_form.preview_area.render self, form: form, preview_url: preview_url do %>
+  <li>
+    <noscript>
+      <button type="submit" class="thredded--button thredded--post--preview-btn"
+              formtarget="_blank" formaction="<%= preview_url %>">
+        <%= t 'thredded.form.preview' %>
+      </button>
+    </noscript>
+
+    <div class="thredded--preview-area"
+         data-thredded-preview-area data-thredded-preview-url="<%= preview_url %>">
+      <h4 class="thredded--preview-area--title"><%= t 'thredded.form.preview' %></h4>
+      <div class="thredded--preview-area--post thredded--post--content" data-thredded-preview-area-post></div>
+    </div>
+  </li>
+<% end %>

--- a/app/views/thredded/private_post_previews/preview.html.erb
+++ b/app/views/thredded/private_post_previews/preview.html.erb
@@ -1,0 +1,1 @@
+<%= @private_post.filtered_content(self) %>

--- a/app/views/thredded/private_post_previews/update.html.erb
+++ b/app/views/thredded/private_post_previews/update.html.erb
@@ -1,0 +1,1 @@
+<%= @private_post.filtered_content(self) %>

--- a/app/views/thredded/private_posts/_form.html.erb
+++ b/app/views/thredded/private_posts/_form.html.erb
@@ -1,6 +1,8 @@
+<%# TODO: For private topics, only autocomplete users in this private topic %>
 <%= render 'thredded/posts_common/form',
            topic: topic,
            post: post,
+           preview_url: preview_url,
            button_text: t('thredded.private_posts.form.create_btn'),
            button_submitting_text: t('thredded.private_posts.form.create_btn_submitting'),
            content_label: t('thredded.private_posts.form.content_label') %>

--- a/app/views/thredded/private_topic_previews/preview.html.erb
+++ b/app/views/thredded/private_topic_previews/preview.html.erb
@@ -1,0 +1,1 @@
+<%= @private_post.filtered_content(self) %>

--- a/app/views/thredded/private_topics/_form.html.erb
+++ b/app/views/thredded/private_topics/_form.html.erb
@@ -1,6 +1,12 @@
 <%= form_for private_topic,
-             url:  private_topics_path(@private_topic),
-             html: { class: "thredded--form thredded--new-private-topic-form #{local_assigns[:css_class]}", 'data-thredded-topic-form' => true } do |form| %>
+             url: private_topics_path(@private_topic),
+             html: {
+                 class: "thredded--form thredded--new-private-topic-form #{local_assigns[:css_class]}",
+                 'data-thredded-topic-form' => true,
+                 # TODO: only autocomplete users in this private topic
+                 'data-autocomplete-url' => autocomplete_users_path,
+                 'data-autocomplete-min-length' => Thredded.autocomplete_min_length,
+             } do |form| %>
 
   <ul class="thredded--form-list on-top">
     <li class="title">
@@ -10,15 +16,16 @@
     <li>
       <%= form.label :user_ids, t('thredded.private_topics.form.users_label') %>
       <%= form.text_field :user_ids,
-                          placeholder:                   t('thredded.private_topics.form.users_placeholder'),
-                          'data-thredded-users-select'   => true,
-                          'data-autocomplete-url'        => autocomplete_users_path,
+                          placeholder: t('thredded.private_topics.form.users_placeholder'),
+                          'data-thredded-users-select' => true,
+                          'data-autocomplete-url' => autocomplete_users_path,
                           'data-autocomplete-min-length' => Thredded.autocomplete_min_length %>
     </li>
 
-    <%= render 'thredded/posts_common/form/content_field',
-               form:          form,
-               content_label: t('thredded.private_topics.form.content_label') %>
+    <%= render 'thredded/posts_common/form/content',
+               form: form,
+               content_label: t('thredded.private_topics.form.content_label'),
+               preview_url: preview_url %>
 
     <li>
       <button type="submit" class="thredded--form--submit"

--- a/app/views/thredded/private_topics/index.html.erb
+++ b/app/views/thredded/private_topics/index.html.erb
@@ -11,9 +11,10 @@
       <%= render 'thredded/private_topics/no_private_topics' %>
     <% else -%>
       <%= render 'thredded/private_topics/form',
-        private_topic: @new_private_topic,
-        css_class:     'thredded--is-compact',
-        placeholder:   t('thredded.private_topics.form.title_placeholder_start') %>
+                 private_topic: @new_private_topic,
+                 preview_url: preview_new_private_topic_path,
+                 css_class: 'thredded--is-compact',
+                 placeholder: t('thredded.private_topics.form.title_placeholder_start') %>
 
       <%= render @private_topics %>
 

--- a/app/views/thredded/private_topics/new.html.erb
+++ b/app/views/thredded/private_topics/new.html.erb
@@ -6,6 +6,7 @@
   <section class="thredded--main-section">
     <%= render 'thredded/private_topics/form',
                private_topic: @private_topic,
+               preview_url: preview_new_private_topic_path,
                placeholder:   t('thredded.private_topics.form.title_placeholder_new') if @private_topic %>
   </section>
 <% end %>

--- a/app/views/thredded/private_topics/show.html.erb
+++ b/app/views/thredded/private_topics/show.html.erb
@@ -12,6 +12,7 @@
     <%= paginate @posts %>
     <%= render 'thredded/private_posts/form',
                topic: private_topic,
-               post:  @post %>
+               post: @post,
+               preview_url: private_topic.new_post_preview_path %>
   <% end %>
 <% end %>

--- a/app/views/thredded/shared/preview.html.erb
+++ b/app/views/thredded/shared/preview.html.erb
@@ -1,0 +1,10 @@
+<% content_for :thredded_page_title, t('thredded.form.preview') %>
+<% content_for :thredded_page_id, 'thredded--post-preview' %>
+
+<%# The noscript version of a post preview %>
+<%= thredded_page do %>
+  <h1><%= t 'thredded.form.preview' %></h1>
+  <div class="thredded--preview-area--post thredded--post--content">
+    <%= @preview_content %>
+  </div>
+<% end %>

--- a/app/views/thredded/theme_previews/show.html.erb
+++ b/app/views/thredded/theme_previews/show.html.erb
@@ -21,6 +21,7 @@
     <%= render 'thredded/topics/form',
                messageboard: @messageboard,
                topic:        @new_topic,
+               preview_url:  preview_new_messageboard_topic_path(@messageboard),
                css_class:    'thredded--is-compact',
                placeholder:  'Start a New Topic' %>
     <%= render @topics %>
@@ -39,6 +40,7 @@
                messageboard: @messageboard,
                topic:        @topic,
                post:         @new_post,
+               preview_url:  @topic.new_post_preview_path,
                button_text:  t('thredded.posts.form.create_btn')
     %>
   <% end %>
@@ -47,6 +49,7 @@
   <%= render 'thredded/topics/form',
              messageboard: @messageboard,
              topic:        @new_topic,
+             preview_url:  preview_new_messageboard_topic_path(@messageboard),
              placeholder:  'Start a New Topic' %>
 
   <%= render 'section_title', label: 'posts#edit', href: edit_messageboard_topic_post_path(@messageboard, @post.postable, @post) %>
@@ -57,6 +60,7 @@
                messageboard: @messageboard,
                topic:        @topic,
                post:         @post,
+               preview_url:  @topic.new_post_preview_path,
                button_text:  t('thredded.posts.form.update_btn')
     %>
   <% end %>
@@ -72,6 +76,7 @@
     <%= render 'thredded/private_topics/form',
                private_topic: @new_private_topic,
                css_class:     'thredded--is-compact',
+               preview_url:   preview_new_private_topic_path,
                placeholder:   t('thredded.private_topics.form.title_placeholder_start') %>
     <%= render @private_topics %>
   <% end %>
@@ -80,6 +85,7 @@
   <section class="thredded--thredded--main-section">
     <%= render 'thredded/private_topics/form',
                private_topic: @new_private_topic,
+               preview_url:   preview_new_private_topic_path,
                placeholder:   t('thredded.private_topics.form.title_placeholder_new') %>
   </section>
 
@@ -90,6 +96,7 @@
     <%= render 'thredded/private_posts/form',
                topic:       @private_topic,
                post:        @private_post,
+               preview_url: @private_topic.new_post_preview_path,
                button_text: t('thredded.private_posts.form.create_btn')
     %>
   </section>

--- a/app/views/thredded/topic_previews/preview.html.erb
+++ b/app/views/thredded/topic_previews/preview.html.erb
@@ -1,0 +1,1 @@
+<%= @post.filtered_content(self) %>

--- a/app/views/thredded/topics/_form.html.erb
+++ b/app/views/thredded/topics/_form.html.erb
@@ -20,9 +20,10 @@
       </li>
     <% end %>
 
-    <%= render 'thredded/posts_common/form/content_field',
-               form:          form,
-               content_label: t('thredded.topics.form.content_label') %>
+    <%= render 'thredded/posts_common/form/content',
+               form: form,
+               content_label: t('thredded.topics.form.content_label'),
+               preview_url: preview_url %>
     <%= render 'thredded/topics/topic_form_admin_options', form: form %>
 
     <li><%= form.submit t('thredded.topics.form.create_btn'), class: 'thredded--form--submit' %></li>

--- a/app/views/thredded/topics/index.html.erb
+++ b/app/views/thredded/topics/index.html.erb
@@ -11,9 +11,10 @@
   <%= content_tag :section, class: 'thredded--main-section thredded--topics', 'data-thredded-topics' => true do %>
     <%= render 'thredded/topics/form',
                messageboard: messageboard,
-               topic:        @new_topic,
-               css_class:    'thredded--is-compact',
-               placeholder:  t('thredded.topics.form.title_placeholder_start') if @new_topic %>
+               topic: @new_topic,
+               css_class: 'thredded--is-compact',
+               preview_url: preview_new_messageboard_topic_path(messageboard),
+               placeholder: t('thredded.topics.form.title_placeholder_start') if @new_topic %>
     <%= render @topics %>
   <% end %>
 

--- a/app/views/thredded/topics/new.html.erb
+++ b/app/views/thredded/topics/new.html.erb
@@ -5,7 +5,8 @@
 <%= thredded_page do %>
   <%= render 'thredded/topics/form',
              messageboard: messageboard,
-             topic:        @new_topic,
-             css_class:    'thredded--is-expanded',
-             placeholder:  t('thredded.topics.form.title_placeholder_start') %>
+             topic: @new_topic,
+             css_class: 'thredded--is-expanded',
+             preview_url: preview_new_messageboard_topic_path(messageboard),
+             placeholder: t('thredded.topics.form.title_placeholder_start') %>
 <% end %>

--- a/app/views/thredded/topics/show.html.erb
+++ b/app/views/thredded/topics/show.html.erb
@@ -17,6 +17,7 @@
         <%= render 'thredded/posts/form',
                    topic:       topic,
                    post:        @new_post,
+                   preview_url: topic.new_post_preview_path,
                    button_text: t('thredded.posts.form.create_btn'),
                    button_submitting_text: t('thredded.posts.form.create_btn_submitting') %>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
       create_btn_submitting: Creating...
       update: Update
       update_btn_submitting: Updating...
+      preview: Preview
     messageboard:
       create: Create a New Messageboard
       form:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -13,6 +13,7 @@ es:
       private_topic_not_found: Este tema privado no existe.
     form:
       create_btn_submitting: Creando...
+      preview: Vista previa
       update: Actualizar
       update_btn_submitting: Actualizando...
     messageboard:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -13,6 +13,7 @@ pl:
       private_topic_not_found: Ten prywatny temat nie istnieje.
     form:
       create_btn_submitting: Tworzenie...
+      preview: Zapowiedź
       update: Zaktualizuj
       update_btn_submitting: Aktualizowanie...
     messageboard:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -13,6 +13,7 @@ pt-BR:
       private_topic_not_found: Este tópico privado não existe.
     form:
       create_btn_submitting: Criando...
+      preview: Pré-visualização
       update: Atualizar
       update_btn_submitting: Atualizando...
     messageboard:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,12 +7,17 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
 
   scope path: 'private-topics' do
     resource :read_state, only: [:update], as: :mark_all_private_topics_read
-    resource :private_topic, only: [:new], path: ''
+    resource :private_topic, only: [:new], path: '' do
+      post :preview, on: :new, controller: 'private_topic_previews'
+    end
     resources :private_topics, except: [:new, :show], path: '' do
       member do
         get '(page-:page)', action: :show, as: '', constraints: page_constraint
       end
-      resources :private_posts, path: '', except: [:index, :show], controller: 'posts'
+      resources :private_posts, path: '', except: [:index, :show], controller: 'posts' do
+        post :preview, on: :new, controller: 'private_post_previews'
+        resource :preview, only: [:update], controller: 'private_post_previews'
+      end
     end
   end
 
@@ -48,7 +53,9 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
   resources :messageboards, only: [:edit, :update]
   resources :messageboards, only: [:index, :create], path: '' do
     resource :preferences, only: [:edit, :update]
-    resource :topic, path: 'topics', only: [:new]
+    resource :topic, path: 'topics', only: [:new] do
+      post :preview, on: :new, controller: 'topic_previews'
+    end
     resources :topics, path: '', except: [:index, :new, :show] do
       collection do
         get '(page-:page)', action: :index, as: '', constraints: page_constraint
@@ -61,7 +68,10 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
         match 'follow', via: [:post, :get]
         match 'unfollow', via: [:post, :get]
       end
-      resources :posts, except: [:index, :show], path: ''
+      resources :posts, except: [:index, :show], path: '' do
+        post :preview, on: :new, controller: 'post_previews'
+        resource :preview, only: [:update], controller: 'post_previews'
+      end
     end
   end
 

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -27,7 +27,7 @@ development:
 
 test:
   <<: *defaults
-  database: <%= db_adapter == 'sqlite3' ? ENV.fetch('DATABASE_FILE', "':memory:'") : 'thredded_gem_test' %>
+  database: <%= db_adapter == 'sqlite3' ? ENV.fetch('DATABASE_FILE', 'db/test.sqlite3') : 'thredded_gem_test' %>
 
 production:
   <<: *defaults

--- a/spec/features/thredded/user_creates_new_topic_spec.rb
+++ b/spec/features/thredded/user_creates_new_topic_spec.rb
@@ -2,10 +2,13 @@
 require 'spec_helper'
 
 feature 'User creates new topic' do
-  scenario 'with title and content' do
+  scenario 'with title and content', js: true do
     topic = new_topic
 
-    topic.create_topic
+    topic.fill_topic_form('Hello *world*!')
+    expect(topic.preview_html).to eq("<p>Hello <em>world</em>!</p>\n")
+    topic.submit
+
     expect(topic).to be_listed
     expect(topic).to be_read
 

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -56,6 +56,7 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
 
   # test dependencies
   s.add_development_dependency 'capybara', '~> 2.4'
+  s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'faker', '>= 1.6.2'


### PR DESCRIPTION
This adds preview to Thredded.

If JavaScript is enabled, the UI is preview-as-you-type and looks like this:

![preview screenshot](https://cloud.githubusercontent.com/assets/216339/22182568/3cde5c06-e0a0-11e6-8fbc-d46a1f938de5.png)

If JavaScript is disabled, instead there is a preview button that opens the preview in a new tab when clicked.

Resolves #237 