### PR TITLE
Improve messageboards layout

### DIFF
--- a/app/assets/stylesheets/thredded/base/_variables.scss
+++ b/app/assets/stylesheets/thredded/base/_variables.scss
@@ -83,3 +83,9 @@ $thredded-badge-active-color: $thredded-button-color !default;
 $thredded-badge-active-background: $thredded-action-color !default;
 $thredded-badge-inactive-color: $thredded-button-color !default;
 $thredded-badge-inactive-background: rgba($thredded-text-color, 0.3) !default;
+
+// Layout features
+// Whether to display messageboards as a grid on the desktop screen sizes.
+$thredded-messageboards-grid: true !default;
+// Minimum width of a grid item
+$thredded-messageboards-grid-item-flex-basis: map-get($thredded-grid-breakpoint-max-widths, tablet) / 3 !default;

--- a/app/assets/stylesheets/thredded/components/_messageboard.scss
+++ b/app/assets/stylesheets/thredded/components/_messageboard.scss
@@ -1,14 +1,14 @@
+.thredded--messageboards-group {
+  margin-bottom: $thredded-base-spacing;
+}
+
 .thredded--messageboard {
   @extend %thredded--link;
   border: $thredded-base-border;
   display: block;
-  margin-bottom: $thredded-base-spacing;
+  margin-bottom: -1px;
   padding: $thredded-base-spacing;
   position: relative;
-
-  header {
-    margin-bottom: $thredded-small-spacing;
-  }
 
   &:hover {
     background-color: rgba($thredded-brand, 0.035);
@@ -21,9 +21,20 @@
   float: left;
   font-size: 1.125rem; // 18px
   line-height: 1.2;
-  margin-bottom: 0;
   margin-right: $thredded-small-spacing;
   vertical-align: baseline;
+}
+
+.thredded--messageboard--title,
+.thredded--messageboard--meta,
+.thredded--messageboard--description {
+  margin-bottom: $thredded-small-spacing / 2;
+}
+
+.thredded--messageboard--description,
+.thredded--messageboard--meta,
+.thredded--messageboard--byline {
+  font-size: 0.875em;
 }
 
 .thredded--messageboard--meta {
@@ -31,21 +42,21 @@
   color: $thredded-secondary-text-color;
   display: inline-block;
   font-weight: normal;
-  margin-bottom: 0;
   vertical-align: baseline;
 }
 
 .thredded--messageboard--description {
   @extend %thredded--paragraph;
   clear: both;
-  margin-bottom: $thredded-small-spacing / 2;
   color: $thredded-text-color;
+  &:empty {
+    margin: 0;
+  }
 }
 
 .thredded--messageboard--byline {
   @extend %thredded--paragraph;
   color: $thredded-secondary-text-color;
-  font-size: 0.875em;
   font-weight: normal;
   margin-bottom: 0;
 }
@@ -54,5 +65,59 @@
   @extend %thredded--buttons-list;
   @media print {
     display: none;
+  }
+}
+
+@supports (flex-wrap: wrap) {
+  .thredded--messageboard {
+    display: flex;
+    flex-direction: column;
+    &--header {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+    }
+    &--meta {
+      text-align: right;
+    }
+    &--byline,
+    &--description {
+      margin-top: auto;
+    }
+  }
+
+  @if $thredded-messageboards-grid {
+    @include thredded-media-desktop-and-up {
+      $item-border-width: 1px;
+      $item-padding-x: ($thredded-base-spacing * 0.8);
+      $item-padding-y: $thredded-base-spacing;
+
+      .thredded--messageboards-group {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        margin-left: $item-border-width;
+
+        &::after {
+          content: "";
+          margin-right: $item-border-width;
+          padding: 0 $item-padding-x;
+        }
+
+      }
+
+      .thredded--messageboard,
+      .thredded--messageboards-group::after {
+        flex-basis: $thredded-messageboards-grid-item-flex-basis;
+        flex-grow: 1;
+      }
+
+      .thredded--messageboard {
+        margin-left: -$item-border-width;
+        padding: $item-padding-y $item-padding-x;
+      }
+
+    }
   }
 }

--- a/app/views/thredded/messageboards/_messageboard.html.erb
+++ b/app/views/thredded/messageboards/_messageboard.html.erb
@@ -1,12 +1,12 @@
 <% if policy(messageboard).read? %>
   <%= view_hooks.messageboards_index.messageboard.render self, messageboard: messageboard do %>
     <%= link_to messageboard_topics_path(messageboard), class: 'thredded--messageboard' do %>
-      <header>
+      <header class="thredded--messageboard--header">
         <h2 class="thredded--messageboard--title"><%= messageboard.name %></h2>
         <h3 class="thredded--messageboard--meta">
           <%= t 'thredded.messageboard.topics_and_posts_counts',
-                topics_count: number_to_human(messageboard.topics_count).downcase,
-                posts_count: number_to_human(messageboard.posts_count).downcase %>
+                topics_count: number_with_delimiter(messageboard.topics_count),
+                posts_count: number_with_delimiter(messageboard.posts_count) %>
         </h3>
       </header>
 

--- a/app/views/thredded/messageboards/index.html.erb
+++ b/app/views/thredded/messageboards/index.html.erb
@@ -6,12 +6,14 @@
     <section class="thredded--main-section thredded--messageboards">
       <%= view_hooks.messageboards_index.list.render self, groups: @groups do %>
         <% @groups.each do |group| %>
-          <%= view_hooks.messageboards_index.group.render self, group: group do %>
-            <% if group.name.present? %>
-              <h3><%= group.name %></h3>
-            <% end %>
-            <%= render group.messageboards %>
+          <% if group.name.present? %>
+            <h3 class="thredded--messageboards-group--title"><%= group.name %></h3>
           <% end %>
+          <div class="thredded--messageboards-group">
+            <%= view_hooks.messageboards_index.group.render self, group: group do %>
+              <%= render group.messageboards %>
+            <% end %>
+          </div>
         <% end %>
       <% end %>
 


### PR DESCRIPTION
Remove the spacing between messageboards, reduce the font size of secondary information, align messageboard card contents better.

On desktop, display messageboards in a grid. All the grid items are the same width, minimum width is customizable via a Sass variable, the number of columns changes automatically with the container size.

Mobile and tablet:

![new-messageboards-layout-mobile](https://cloud.githubusercontent.com/assets/216339/22495634/455fc3be-e83a-11e6-9da8-d20d497e37df.png)


Desktop:

![new-messageboards-layout-desktop](https://cloud.githubusercontent.com/assets/216339/22495632/43a46ae8-e83a-11e6-8272-55eef1f5c7ee.png)

Thoughts?
