### PR TITLE
Idempotent notifications + policy checks

### DIFF
--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -21,6 +21,9 @@ module Thredded
     has_many :moderation_records,
              class_name: 'Thredded::PostModerationRecord',
              dependent: :nullify
+    has_many :user_notifications,
+             class_name: 'Thredded::UserPostNotification',
+             dependent: :destroy
     has_one :last_moderation_record, -> { order_newest_first },
             class_name: 'Thredded::PostModerationRecord'
 

--- a/app/models/thredded/user_extender.rb
+++ b/app/models/thredded/user_extender.rb
@@ -26,6 +26,7 @@ module Thredded
         opt.has_many :thredded_user_messageboard_preferences, class_name: 'Thredded::UserMessageboardPreference'
         opt.has_many :thredded_notifications_for_followed_topics, class_name: 'Thredded::NotificationsForFollowedTopics'
         opt.has_many :thredded_notifications_for_private_topics, class_name: 'Thredded::NotificationsForPrivateTopics'
+        opt.has_many :thredded_post_notifications, class_name: 'Thredded::UserPostNotification'
         opt.has_many :thredded_private_users, class_name: 'Thredded::PrivateUser'
         opt.has_many :thredded_topic_read_states, class_name: 'Thredded::UserTopicReadState'
         opt.has_many :thredded_private_topic_read_states, class_name: 'Thredded::UserPrivateTopicReadState'

--- a/app/models/thredded/user_post_notification.rb
+++ b/app/models/thredded/user_post_notification.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module Thredded
+  # Delivery records for Thredded::Post notifications.
+  class UserPostNotification < ActiveRecord::Base
+    belongs_to :user, class_name: Thredded.user_class, inverse_of: :thredded_post_notifications
+    belongs_to :post, class_name: 'Thredded::Post', inverse_of: :user_notifications
+
+    # @param post [Thredded::Post]
+    # @return [Array<Integer>] The IDs of users who were already notified about the given post.
+    def self.notified_user_ids(post)
+      where(post_id: post.id).pluck(:user_id)
+    end
+
+    # Create a user-post notification record for a given post and a user.
+    # @param post [Thredded::Post]
+    # @param user [Thredded.user_class]
+    # @return [Boolean] true if a new record was created, false otherwise (e.g. if a record had already existed).
+    def self.create_from_post_and_user(post, user)
+      create(
+        post_id: post.id,
+        user_id: user.id,
+        notified_at: Time.zone.now
+      )
+    rescue ActiveRecord::RecordNotUnique
+      false
+    end
+  end
+end

--- a/db/migrate/20160329231848_create_thredded.rb
+++ b/db/migrate/20160329231848_create_thredded.rb
@@ -237,6 +237,16 @@ class CreateThredded < ActiveRecord::Migration
       t.index [:user_id, :messageboard_id, :notifier_key],
               name: 'thredded_messageboard_notifications_for_followed_topics_unique', unique: true
     end
+
+    create_table :thredded_user_post_notifications do |t|
+      t.references :user, null: false
+      t.foreign_key Thredded.user_class.table_name, column: :user_id, on_delete: :cascade
+      t.references :post, null: false
+      t.foreign_key :thredded_posts, column: :post_id, on_delete: :cascade
+      t.datetime :notified_at, null: false
+      t.index :post_id, name: :index_thredded_user_post_notifications_on_post_id
+      t.index [:user_id, :post_id], name: :index_thredded_user_post_notifications_on_user_id_and_post_id, unique: true
+    end
   end
 end
 # rubocop:enable Metrics/MethodLength

--- a/db/upgrade_migrations/20170125033319_upgrade_v0_9_to_v0_10.rb
+++ b/db/upgrade_migrations/20170125033319_upgrade_v0_9_to_v0_10.rb
@@ -9,7 +9,7 @@ class UpgradeV09ToV010 < ActiveRecord::Migration
     create_table :thredded_user_post_notifications do |t|
       t.references :user, null: false
       t.foreign_key Thredded.user_class.table_name, column: :user_id, on_delete: :cascade
-      t.references :post, foreign_key: { on_delete: :cascade, to_table: :thredded_posts }, null: false
+      t.references :post, null: false
       t.foreign_key :thredded_posts, column: :post_id, on_delete: :cascade
       t.datetime :notified_at, null: false
       t.index :post_id, name: :index_thredded_user_post_notifications_on_post_id

--- a/db/upgrade_migrations/20170125033319_upgrade_v0_9_to_v0_10.rb
+++ b/db/upgrade_migrations/20170125033319_upgrade_v0_9_to_v0_10.rb
@@ -1,9 +1,28 @@
 # frozen_string_literal: true
 class UpgradeV09ToV010 < ActiveRecord::Migration
-  def change
+  def up
     remove_foreign_key :thredded_messageboard_users, :thredded_messageboards
     add_foreign_key :thredded_messageboard_users, :thredded_messageboards, on_delete: :cascade
     remove_foreign_key :thredded_messageboard_users, :thredded_user_details
     add_foreign_key :thredded_messageboard_users, :thredded_user_details, on_delete: :cascade
+
+    create_table :thredded_user_post_notifications do |t|
+      t.references :user, null: false
+      t.foreign_key Thredded.user_class.table_name, column: :user_id, on_delete: :cascade
+      t.references :post, foreign_key: { on_delete: :cascade, to_table: :thredded_posts }, null: false
+      t.foreign_key :thredded_posts, column: :post_id, on_delete: :cascade
+      t.datetime :notified_at, null: false
+      t.index :post_id, name: :index_thredded_user_post_notifications_on_post_id
+      t.index [:user_id, :post_id], name: :index_thredded_user_post_notifications_on_user_id_and_post_id, unique: true
+    end
+  end
+
+  def down
+    drop_table :thredded_user_post_notifications
+
+    remove_foreign_key :thredded_messageboard_users, :thredded_user_details
+    add_foreign_key :thredded_messageboard_users, :thredded_user_details
+    remove_foreign_key :thredded_messageboard_users, :thredded_messageboards
+    add_foreign_key :thredded_messageboard_users, :thredded_messageboards
   end
 end

--- a/spec/commands/thredded/moderate_post_spec.rb
+++ b/spec/commands/thredded/moderate_post_spec.rb
@@ -38,5 +38,27 @@ module Thredded
       expect { Thredded::ModeratePost.run!(post: topic.first_post, moderation_state: :blocked, moderator: moderator) }
         .to_not change { topic.first_post.reload.updated_at }
     end
+
+    context 'when not Thredded.content_visible_while_pending_moderation' do
+      around { |ex| with_thredded_setting(:content_visible_while_pending_moderation, false, &ex) }
+
+      it 'notifies followers on approval' do
+        topic = post = nil
+        # Create a topic and an additional post in that topic by another user.
+        # Nobody should get notified as the posts are approved yet.
+        expect do
+          topic = create(:topic, with_posts: 1)
+          post = create(:post, postable: topic, user: create(:user))
+        end.to_not change { UserPostNotification.count }
+        # Approving the original topic should notify the follower who is not the topic creator.
+        expect do
+          Thredded::ModeratePost.run!(post: topic.first_post, moderation_state: :approved, moderator: moderator)
+        end.to change { UserPostNotification.count }.by(1)
+        # Approving the additional post in the topic should notify the topic creator.
+        expect do
+          Thredded::ModeratePost.run!(post: post, moderation_state: :approved, moderator: moderator)
+        end.to change { UserPostNotification.count }.by(1)
+      end
+    end
   end
 end

--- a/spec/commands/thredded/moderate_post_spec.rb
+++ b/spec/commands/thredded/moderate_post_spec.rb
@@ -40,20 +40,24 @@ module Thredded
     end
 
     context 'when not Thredded.content_visible_while_pending_moderation' do
-      around { |ex| with_thredded_setting(:content_visible_while_pending_moderation, false, &ex) }
+      around do |example|
+        with_thredded_setting(:content_visible_while_pending_moderation, false, &example)
+      end
 
       it 'notifies followers on approval' do
-        topic = post = nil
         # Create a topic and an additional post in that topic by another user.
         # Nobody should get notified as the posts are approved yet.
+        topic = post = nil
         expect do
           topic = create(:topic, with_posts: 1)
           post = create(:post, postable: topic, user: create(:user))
         end.to_not change { UserPostNotification.count }
+
         # Approving the original topic should notify the follower who is not the topic creator.
         expect do
           Thredded::ModeratePost.run!(post: topic.first_post, moderation_state: :approved, moderator: moderator)
         end.to change { UserPostNotification.count }.by(1)
+
         # Approving the additional post in the topic should notify the topic creator.
         expect do
           Thredded::ModeratePost.run!(post: post, moderation_state: :approved, moderator: moderator)

--- a/spec/commands/thredded/notify_following_users_spec.rb
+++ b/spec/commands/thredded/notify_following_users_spec.rb
@@ -12,6 +12,13 @@ module Thredded
       let(:notifier) { EmailNotifier.new }
       subject { NotifyFollowingUsers.new(post).targeted_users(notifier) }
 
+      before do
+        # Creating a post will trigger the NotifyFollowingUsers job, creating UserPostNotification records.
+        # Create the post and then delete all the created UserPostNotification records for testing.
+        post
+        Thredded::UserPostNotification.destroy_all
+      end
+
       it 'includes followers where preference to receive these notifications' do
         create(:notifications_for_followed_topics,
                notifier_key: 'email',
@@ -21,8 +28,13 @@ module Thredded
         expect(subject).to include(follower)
       end
 
+      it 'excludes followers that have already been notified' do
+        expect(Thredded::UserPostNotification.create_from_post_and_user(post, follower)).to be_truthy
+        expect(subject).to_not include(follower)
+      end
+
       it "doesn't include the poster, even if they follow" do
-        create(:user_topic_follow, user: poster, topic: topic)
+        expect(UserTopicFollow.find_by(user_id: poster.id, topic_id: topic.id)).to_not be_nil
         expect(subject).to_not include(poster)
       end
 
@@ -98,7 +110,7 @@ module Thredded
       let(:post) { create(:post) }
 
       let(:command) { NotifyFollowingUsers.new(post) }
-      let(:targeted_users) { [build_stubbed(:user)] }
+      let(:targeted_users) { [create(:user)] }
       before { allow(command).to receive(:targeted_users).and_return(targeted_users) }
 
       it 'sends email' do
@@ -111,8 +123,9 @@ module Thredded
         it "doesn't send any emails" do
           expect { command.run }.not_to change { ActionMailer::Base.deliveries.count }
         end
-        it 'uses MockNotifier' do
+        it 'notifies exactly once' do
           expect { command.run }.to change { MockNotifier.users_notified_of_new_post }
+          expect { command.run }.to_not change { MockNotifier.users_notified_of_new_post }
         end
       end
     end


### PR DESCRIPTION
From #522:

> As a result, users get notifications for posts they cannot read, such as posts in the moderation queue (when pre-moderation is on) and posts from banned users. A proper fix to this would fire a notification job when the moderation state of a post changes.

This PR fixes #522 and enables a safe implementation of #488 (#517).

It does so by adding a table that keeps track of notifications that have already been sent and ensuring the PostPolicy is applied to notifications.

Fixes issues such as:

1. Users getting notified on post edits.
2. Users getting notified when a post is created even if it is not visible to them (i.e. pending approval with pre-emptive moderation, or posts from blocked users).
3. Users getting notified of posts they do not have permissions to see.

/cc @zapnap @timdiggins @jayroh 