### PR TITLE
Feature: move topic to another messageboard

### DIFF
--- a/app/forms/thredded/edit_topic_form.rb
+++ b/app/forms/thredded/edit_topic_form.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+module Thredded
+  class EditTopicForm
+    include ActiveModel::Model
+
+    delegate :id, :title, :category_ids, :locked, :sticky, :messageboard, :messageboard_id, :valid?,
+             to: :@topic
+
+    # @param user [Thredded.user_class]
+    # @param topic [Thredded::Topic]
+    def initialize(user:, topic:)
+      @user = user
+      @topic = topic
+    end
+
+    def self.model_name
+      Thredded::Topic.model_name
+    end
+
+    def category_options
+      @topic.messageboard.categories.map { |cat| [cat.name, cat.id] }
+    end
+
+    def messageboard_options
+      @user.thredded_can_write_messageboards.map { |messageboard| [messageboard.name, messageboard.id] }
+    end
+
+    def save
+      return false unless valid?
+      @topic.save!
+      true
+    end
+
+    def persisted?
+      true
+    end
+
+    def path
+      Thredded::UrlsHelper.messageboard_topic_path(@topic.messageboard, @topic)
+    end
+
+    def edit_path
+      Thredded::UrlsHelper.edit_messageboard_topic_path(@topic.messageboard, @topic)
+    end
+
+    def messageboard_path
+      Thredded::UrlsHelper.messageboard_topics_path(@topic.messageboard)
+    end
+  end
+end

--- a/app/forms/thredded/topic_form.rb
+++ b/app/forms/thredded/topic_form.rb
@@ -22,12 +22,8 @@ module Thredded
       Thredded::Topic.model_name
     end
 
-    def categories
-      topic.messageboard.categories
-    end
-
     def category_options
-      categories.map { |cat| [cat.name, cat.id] }
+      messageboard.categories.map { |cat| [cat.name, cat.id] }
     end
 
     def save

--- a/app/view_models/thredded/post_view.rb
+++ b/app/view_models/thredded/post_view.rb
@@ -56,13 +56,14 @@ module Thredded
       [
         I18n.locale,
         @post.cache_key,
+        (@post.messageboard_id unless @post.private_topic_post?),
         @post.user ? @post.user.cache_key : 'users/nil',
         moderation_state || '+',
         [
           can_update?,
           can_destroy?
         ].map { |p| p ? '+' : '-' } * ''
-      ].join('/')
+      ].compact.join('/')
     end
     # rubocop:enable Metrics/CyclomaticComplexity
   end

--- a/app/views/thredded/topics/_form.html.erb
+++ b/app/views/thredded/topics/_form.html.erb
@@ -11,7 +11,7 @@
       <%= form.text_field :title, placeholder: placeholder, required: true %>
     </li>
 
-    <% if form.object.categories.any? %>
+    <% if form.object.category_options.any? %>
       <li class="category">
         <%= form.select :category_ids,
                         form.object.category_options,

--- a/app/views/thredded/topics/edit.html.erb
+++ b/app/views/thredded/topics/edit.html.erb
@@ -1,16 +1,17 @@
-<% content_for :thredded_page_title, t('thredded.nav.edit_private_topic') %>
+<% content_for :thredded_page_title, t('thredded.nav.edit_topic') %>
 <% content_for :thredded_page_id, 'thredded--edit-topic' %>
 <% content_for :thredded_breadcrumbs do %>
   <ul class="thredded--navigation-breadcrumbs">
     <li><%= link_to t('thredded.nav.all_messageboards'), messageboards_path %></li>
-    <li><%= link_to messageboard.name, messageboard_topics_path(@topic.messageboard) %></li>
-    <li><%= link_to @topic.title, topic_path(@topic) %></li>
-    <li><%= link_to t('thredded.nav.edit_topic'), edit_messageboard_topic_path(@topic.messageboard, @topic) %></li>
+    <li><%= link_to messageboard.name, @edit_topic.messageboard_path %></li>
+    <li><%= link_to @edit_topic.title, @edit_topic.path %></li>
+    <li><%= link_to t('thredded.nav.edit_topic'), @edit_topic.edit_path %></li>
   </ul>
 <% end %>
 
 <%= thredded_page do %>
-  <%= form_for [@topic.messageboard, @topic],
+  <%= form_for @edit_topic,
+               url: @edit_topic.path,
                html: { class: 'thredded--form thredded--is-expanded', 'data-thredded-topic-form' => true } do |form| %>
     <ul class="thredded--form-list on-top">
 
@@ -22,13 +23,18 @@
                             required:    true %>
       </li>
 
-      <% if form.object.categories.any? %>
+      <% if form.object.category_options.any? %>
         <li class="category">
           <%= form.select :category_ids, form.object.category_options, {},
                           multiple:          true,
                           'data-placeholder' => t('thredded.topics.form.categories_placeholder') %>
         </li>
       <% end %>
+
+      <li>
+        <%= form.label :messageboard_id, t('thredded.topics.form.messageboard_label') %>
+        <%= form.select :messageboard_id, form.object.messageboard_options %>
+      </li>
 
       <%= render 'thredded/topics/topic_form_admin_options', form: form %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,6 +150,7 @@ en:
         categories_placeholder: Categories
         content_label: :thredded.posts.form.content_label
         create_btn: Create New Topic
+        messageboard_label: Messageboard
         title_label: Title
         title_placeholder: :thredded.topics.form.title_label
         title_placeholder_start: Start a New Topic

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -150,6 +150,7 @@ es:
         categories_placeholder: Categorías
         content_label: :thredded.posts.form.content_label
         create_btn: Crear Nuevo Tema
+        messageboard_label: Foro
         title_label: Título
         title_placeholder: :thredded.topics.form.title_label
         title_placeholder_start: Crear un Nuevo Tema

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -149,6 +149,7 @@ pl:
         categories_placeholder: Kategorie
         content_label: :thredded.posts.form.content_label
         create_btn: Stwórz nowy temat
+        messageboard_label: Tablica
         title_label: Tytuł
         title_placeholder: :thredded.topics.form.title_label
         title_placeholder_start: Rozpocznij nowy temat

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -153,6 +153,7 @@ pt-BR:
         categories_placeholder: Categorias
         content_label: :thredded.posts.form.content_label
         create_btn: Criar Novo Tópico
+        messageboard_label: Fórum
         title_label: Título
         title_placeholder: :thredded.topics.form.title_label
         title_placeholder_start: Iniciar um novo tópico

--- a/spec/features/thredded/user_edits_topic_spec.rb
+++ b/spec/features/thredded/user_edits_topic_spec.rb
@@ -17,7 +17,18 @@ feature 'User editing topics' do
     topic.change_title_to('this is changed')
     topic.submit
 
-    expect(topic).to have_content('this is changed')
+    expect(topic).to be_saved.and have_content('this is changed')
+  end
+
+  scenario 'updates topic messageboard' do
+    user.log_in
+    create(:messageboard, name: 'Another Messageboard')
+    topic = users_topic
+    topic.visit_topic_edit
+    topic.change_messageboard_to('Another Messageboard')
+    topic.submit
+
+    expect(topic).to be_saved.and have_content('Another Messageboard')
   end
 
   scenario "cannot edit someone else's topic" do

--- a/spec/support/features/page_object/topic.rb
+++ b/spec/support/features/page_object/topic.rb
@@ -36,8 +36,16 @@ module PageObject
       all('a', text: @topic.title).any?
     end
 
+    def saved?
+      has_content?(I18n.t('thredded.topics.updated_notice'))
+    end
+
     def change_title_to(title)
       fill_in I18n.t('thredded.topics.form.title_label'), with: title
+    end
+
+    def change_messageboard_to(name)
+      select name, from: I18n.t('thredded.topics.form.messageboard_label')
     end
 
     def make_locked


### PR DESCRIPTION
Allow users with permissions to edit a topic to re-assign the topic to
any messageboard they can post in.

Fixes #507