### PR TITLE
Implement render_collection_to_strings_with_cache

### DIFF
--- a/app/controllers/thredded/preferences_controller.rb
+++ b/app/controllers/thredded/preferences_controller.rb
@@ -4,8 +4,7 @@ module Thredded
     before_action :thredded_require_login!,
                   :init_preferences
 
-    def edit
-    end
+    def edit; end
 
     def update
       if @preferences.save

--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -3,6 +3,7 @@ module Thredded
   module ApplicationHelper
     include ::Thredded::UrlsHelper
     include ::Thredded::NavHelper
+    include ::Thredded::RenderHelper
 
     # @return [AllViewHooks] View hooks configuration.
     def view_hooks
@@ -66,6 +67,16 @@ module Thredded
       else
         I18n.l time.to_date, format: time_options[:format]
       end
+    end
+
+    # @param posts [Thredded::PostsPageView, Array<Thredded::PostView>]
+    # @param partial [String]
+    # @param content_partial [String]
+    def render_posts(posts, partial: 'thredded/posts/post', content_partial: 'thredded/posts/content')
+      posts_with_contents = render_collection_to_strings_with_cache(
+        partial: content_partial, collection: posts, as: :post, expires_in: 1.week
+      )
+      render partial: partial, collection: posts_with_contents, as: :post_and_content
     end
 
     def paginate(collection, args = {})

--- a/app/helpers/thredded/render_helper.rb
+++ b/app/helpers/thredded/render_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module Thredded
+  module RenderHelper
+    # @param collection [Array<T>]
+    # @param partial [String]
+    # @param expires_in [ActiveSupport::Duration]
+    # @return Array<[T, String]>
+    def render_collection_to_strings_with_cache(collection:, partial:, expires_in:, **opts)
+      CollectionToStringsWithCacheRenderer.new(lookup_context).render_collection_to_strings_with_cache(
+        self, collection: collection, partial: partial, expires_in: expires_in, **opts
+      )
+    end
+  end
+end

--- a/app/view_models/thredded/post_view.rb
+++ b/app/view_models/thredded/post_view.rb
@@ -50,30 +50,10 @@ module Thredded
       Thredded::UrlsHelper.post_permalink_path(@post.id)
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity
+    # This cache key is used only for caching the content.
     def cache_key
-      moderation_state = unless @post.private_topic_post?
-                           if @post.pending_moderation? && !Thredded.content_visible_while_pending_moderation
-                             'p'
-                           elsif @post.blocked?
-                             '-'
-                           end
-                         end
-      [
-        I18n.locale,
-        @post.cache_key,
-        (@post.messageboard_id unless @post.private_topic_post?),
-        @post.user ? @post.user.cache_key : 'users/nil',
-        read_state,
-        moderation_state || '+',
-        [
-          can_update?,
-          can_destroy?
-        ].map { |p| p ? '+' : '-' } * ''
-
-      ].compact.join('/')
+      @post.cache_key
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
 
     POST_IS_READ = :read
     POST_IS_UNREAD = :unread

--- a/app/views/thredded/moderation/_post.html.erb
+++ b/app/views/thredded/moderation/_post.html.erb
@@ -1,4 +1,4 @@
-<%# @param post [Thredded::PostView] %>
+<% post, content = post_and_content if local_assigns.key?(:post_and_content) %>
 <%= content_tag :article, id: dom_id(post), class: 'thredded--post thredded--post-moderation' do %>
   <%= render 'thredded/posts_common/header_with_user_and_topic',
              post:           post,
@@ -8,7 +8,7 @@
                                content_tag :em, t('thredded.null_user_name')
                              end
   %>
-  <%= render 'thredded/posts_common/content', post: post %>
+  <%= content || render('thredded/posts/content', post: post) %>
   <%= render 'thredded/posts_common/actions', post: post %>
   <% if post.blocked? %>
     <p class="thredded--alert thredded--alert-danger">

--- a/app/views/thredded/moderation/_user_post.html.erb
+++ b/app/views/thredded/moderation/_user_post.html.erb
@@ -1,7 +1,7 @@
-<%# @param post [Thredded::PostView] %>
+<% post, content = post_and_content if local_assigns.key?(:post_and_content) %>
 <%= content_tag :article, id: dom_id(post), class: 'thredded--post thredded--post-moderation' do %>
   <%= render 'thredded/posts_common/header_with_topic', post: post %>
-  <%= render 'thredded/posts_common/content', post: post %>
+  <%= content || render('thredded/posts/content', post: post) %>
   <%= render 'thredded/posts_common/actions', post: post %>
   <% if post.blocked? %>
     <p class="thredded--alert thredded--alert-danger">

--- a/app/views/thredded/moderation/activity.html.erb
+++ b/app/views/thredded/moderation/activity.html.erb
@@ -11,7 +11,9 @@
       </div>
     <% end %>
     <% if @posts.present? %>
-      <%= render partial: 'post', collection: @posts %>
+      <%= render_posts @posts,
+                       partial: 'thredded/moderation/post',
+                       content_partial: 'thredded/posts/content' %>
       <%= paginate @posts %>
     <% end %>
   <% end %>

--- a/app/views/thredded/moderation/pending.html.erb
+++ b/app/views/thredded/moderation/pending.html.erb
@@ -10,7 +10,9 @@
       </div>
     <% end %>
     <% if @posts.present? %>
-      <%= render partial: 'post', collection: @posts %>
+      <%= render_posts @posts,
+                       partial: 'thredded/moderation/post',
+                       content_partial: 'thredded/posts/content' %>
       <%= paginate @posts %>
     <% else %>
       <div class="thredded--empty">

--- a/app/views/thredded/moderation/user.html.erb
+++ b/app/views/thredded/moderation/user.html.erb
@@ -42,7 +42,9 @@
   <% end %>
   <% if @posts.present? %>
     <h2><%= t 'thredded.users.recent_activity' %></h2>
-    <%= render partial: 'user_post', collection: @posts, as: :post %>
+    <%= render_posts @posts,
+                     partial: 'thredded/moderation/user_post',
+                     content_partial: 'thredded/posts/content' %>
     <%= paginate @posts %>
   <% end %>
 <% end %>

--- a/app/views/thredded/posts/_content.html.erb
+++ b/app/views/thredded/posts/_content.html.erb
@@ -1,0 +1,1 @@
+<%= render 'thredded/posts_common/content', post: post %>

--- a/app/views/thredded/posts/_post.html.erb
+++ b/app/views/thredded/posts/_post.html.erb
@@ -1,14 +1,13 @@
-<% cache(post, expires_in: 1.week) do %>
-  <%= content_tag :article, id: dom_id(post), class: "thredded--post thredded--#{post.read_state}--post" do %>
-    <%= render 'thredded/posts_common/actions', post: post %>
-    <%= render 'thredded/posts_common/header', post: post %>
-    <%= render 'thredded/posts_common/content', post: post %>
-    <% if post.pending_moderation? && !Thredded.content_visible_while_pending_moderation %>
-      <p class="thredded--alert thredded--alert-warning"><%= t 'thredded.posts.pending_moderation_notice' %></p>
-    <% elsif post.blocked? && post.can_moderate? %>
-      <p class="thredded--alert thredded--alert-danger">
-        <%= render 'thredded/shared/content_moderation_blocked_state', moderation_record: post.last_moderation_record %>
-      </p>
-    <% end %>
+<% post, content = post_and_content if local_assigns.key?(:post_and_content) %>
+<%= content_tag :article, id: dom_id(post), class: "thredded--post thredded--#{post.read_state}--post" do %>
+  <%= render 'thredded/posts_common/actions', post: post %>
+  <%= render 'thredded/posts_common/header', post: post %>
+  <%= content || render('thredded/posts/content', post: post) %>
+  <% if post.pending_moderation? && !Thredded.content_visible_while_pending_moderation %>
+    <p class="thredded--alert thredded--alert-warning"><%= t 'thredded.posts.pending_moderation_notice' %></p>
+  <% elsif post.blocked? && post.can_moderate? %>
+    <p class="thredded--alert thredded--alert-danger">
+      <%= render 'thredded/shared/content_moderation_blocked_state', moderation_record: post.last_moderation_record %>
+    </p>
   <% end %>
 <% end %>

--- a/app/views/thredded/private_posts/_content.html.erb
+++ b/app/views/thredded/private_posts/_content.html.erb
@@ -1,0 +1,1 @@
+<%= render 'thredded/posts_common/content', post: post %>

--- a/app/views/thredded/private_posts/_private_post.html.erb
+++ b/app/views/thredded/private_posts/_private_post.html.erb
@@ -1,7 +1,6 @@
-<% cache(private_post, expires_in: 1.week) do %>
-  <%= content_tag :article, id: dom_id(private_post), class: 'thredded--post' do %>
-    <%= render 'thredded/posts_common/actions', post: private_post %>
-    <%= render 'thredded/posts_common/header', post: private_post %>
-    <%= render 'thredded/posts_common/content', post: private_post %>
-  <% end %>
+<% private_post, content = post_and_content if local_assigns.key?(:post_and_content) %>
+<%= content_tag :article, id: dom_id(private_post), class: 'thredded--post' do %>
+  <%= render 'thredded/posts_common/actions', post: private_post %>
+  <%= render 'thredded/posts_common/header', post: private_post %>
+  <%= content || render('thredded/private_posts/content', post: post) %>
 <% end %>

--- a/app/views/thredded/private_topics/show.html.erb
+++ b/app/views/thredded/private_topics/show.html.erb
@@ -11,7 +11,9 @@
     <%= view_hooks.posts_common.pagination_top.render(self, posts: @posts) do %>
       <footer class="thredded--pagination-top"><%= paginate @posts %></footer>
     <% end %>
-    <%= render partial: 'thredded/private_posts/private_post', collection: @posts, cached: true %>
+    <%= render_posts @posts,
+                     partial: 'thredded/private_posts/private_post',
+                     content_partial: 'thredded/private_posts/content' %>
     <%= view_hooks.posts_common.pagination_bottom.render(self, posts: @posts) do %>
       <footer class="thredded--pagination-bottom"><%= paginate @posts %></footer>
     <% end %>

--- a/app/views/thredded/topics/show.html.erb
+++ b/app/views/thredded/topics/show.html.erb
@@ -12,7 +12,7 @@
     <%= view_hooks.posts_common.pagination_top.render(self, posts: @posts) do %>
       <footer class="thredded--pagination-top"><%= paginate @posts %></footer>
     <% end %>
-    <%= render partial: 'thredded/posts/post', collection: @posts, cached: true %>
+    <%= render_posts @posts, partial: 'thredded/posts/post', content_partial: 'thredded/posts/content' %>
     <%= view_hooks.posts_common.pagination_bottom.render(self, posts: @posts) do %>
       <footer class="thredded--pagination-bottom"><%= paginate @posts %></footer>
     <% end %>

--- a/app/views/thredded/users/_post.html.erb
+++ b/app/views/thredded/users/_post.html.erb
@@ -1,6 +1,6 @@
-<%# @param post [Thredded::PostView] %>
+<% post, content = post_and_content if local_assigns.key?(:post_and_content) %>
 <%= content_tag :article, id: dom_id(post), class: 'thredded--post' do %>
   <%= render 'thredded/posts_common/header_with_topic', post: post %>
-  <%= render 'thredded/posts_common/content', post: post %>
+  <%= content || render('thredded/posts/content', post: post) %>
   <%= render 'thredded/posts_common/actions', post: post %>
 <% end %>

--- a/app/views/thredded/users/_posts.html.erb
+++ b/app/views/thredded/users/_posts.html.erb
@@ -4,4 +4,4 @@
   TODO: Use a Cell instead. https://github.com/apotonick/cells
 %>
 <%# @param posts [Thredded::PostsPageView] %>
-<%= render partial: 'thredded/users/post', collection: posts %>
+<%= render_posts posts, partial: 'thredded/users/post', content_partial: 'thredded/posts/content' %>

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -39,6 +39,8 @@ require 'thredded/view_hooks/renderer'
 # Require Thredded::ContentFormatter explicitly so that it doesn't need to be required if used in the initializer.
 require 'thredded/content_formatter'
 
+require 'thredded/collection_to_strings_with_cache_renderer'
+
 module Thredded
   mattr_accessor \
     :autocomplete_min_length,

--- a/lib/thredded/collection_to_strings_with_cache_renderer.rb
+++ b/lib/thredded/collection_to_strings_with_cache_renderer.rb
@@ -15,8 +15,8 @@ module Thredded
       instrument(:collection, count: collection.size) do |instrumentation_payload|
         return [] if collection.blank?
         keyed_collection = collection.each_with_object({}) do |item, hash|
-          key = view_context.fragment_cache_key(
-            view_context.cache_fragment_name(item, virtual_path: template.virtual_path)
+          key = ActiveSupport::Cache.expand_cache_key(
+            view_context.cache_fragment_name(item, virtual_path: template.virtual_path), :views
           )
           # #read_multi & #write may require key mutability, Dalli 2.6.0.
           hash[key.frozen? ? key.dup : key] = item

--- a/lib/thredded/collection_to_strings_with_cache_renderer.rb
+++ b/lib/thredded/collection_to_strings_with_cache_renderer.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'action_view/renderer/abstract_renderer'
+module Thredded
+  class CollectionToStringsWithCacheRenderer < ActionView::AbstractRenderer
+    # @param view_context
+    # @param collection [Array<T>]
+    # @param partial [String]
+    # @param expires_in [ActiveSupport::Duration]
+    # @return Array<[T, String]>
+    def render_collection_to_strings_with_cache( # rubocop:disable Metrics/ParameterLists
+        view_context, collection:, partial:, expires_in:, locals: {}, **opts
+    )
+      template = @lookup_context.find_template(partial, [], true, locals, {})
+      collection = collection.to_a
+      instrument(:collection, count: collection.size) do |instrumentation_payload|
+        return [] if collection.blank?
+        keyed_collection = collection.each_with_object({}) do |item, hash|
+          key = view_context.fragment_cache_key(
+            view_context.cache_fragment_name(item, virtual_path: template.virtual_path)
+          )
+          # #read_multi & #write may require key mutability, Dalli 2.6.0.
+          hash[key.frozen? ? key.dup : key] = item
+        end
+        cached_partials = collection_cache.read_multi(*keyed_collection.keys)
+        instrumentation_payload[:cache_hits] = cached_partials.size
+
+        collection_to_render = keyed_collection.reject { |key, _| cached_partials.key?(key) }.values
+        rendered_partials = render_partials(
+          view_context, collection: collection_to_render, partial: partial, locals: locals, **opts
+        ).each
+
+        keyed_collection.map do |cache_key, item|
+          [item, cached_partials[cache_key] || rendered_partials.next.tap do |rendered|
+            collection_cache.write(cache_key, rendered, expires_in: expires_in)
+          end]
+        end
+      end
+    end
+
+    private
+
+    def collection_cache
+      ActionView::PartialRenderer.collection_cache
+    end
+
+    # @return [Array<String>]
+    def render_partials(view_context, collection:, **opts)
+      return [] if collection.empty?
+      partial_renderer = ActionView::PartialRenderer.new(@lookup_context)
+      collection.map do |item|
+        partial_renderer.render(view_context, opts.merge(object: item), nil)
+      end
+    end
+  end
+end

--- a/lib/thredded/collection_to_strings_with_cache_renderer.rb
+++ b/lib/thredded/collection_to_strings_with_cache_renderer.rb
@@ -7,7 +7,7 @@ module Thredded
     # @param partial [String]
     # @param expires_in [ActiveSupport::Duration]
     # @return Array<[T, String]>
-    def render_collection_to_strings_with_cache(# rubocop:disable Metrics/ParameterLists
+    def render_collection_to_strings_with_cache( # rubocop:disable Metrics/ParameterLists
       view_context, collection:, partial:, expires_in:, locals: {}, **opts
     )
       template = @lookup_context.find_template(partial, [], true, locals, {})

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 class HomeController < ApplicationController
-  def show
-  end
+  def show; end
 end

--- a/spec/dummy/app/controllers/sessions_controller.rb
+++ b/spec/dummy/app/controllers/sessions_controller.rb
@@ -2,8 +2,7 @@
 class SessionsController < ApplicationController
   self.store_location_fullpath = false
 
-  def new
-  end
+  def new; end
 
   def create
     user = Thredded.user_class.find_or_initialize_by(name: params[:name])

--- a/spec/features/thredded/user_edits_post_spec.rb
+++ b/spec/features/thredded/user_edits_post_spec.rb
@@ -33,6 +33,7 @@ feature 'User editing posts' do
 
       post = someone_elses_post
       post.visit_post_edit
+      expect(post).to be_editable
       post.submit_new_content('I edited this')
 
       expect(post).to be_authored_by('sal')

--- a/spec/support/features/page_object/post.rb
+++ b/spec/support/features/page_object/post.rb
@@ -35,8 +35,8 @@ module PageObject
     end
 
     def submit_new_content(content)
-      fill_in 'Content', with: content
-      click_on 'Update Post'
+      fill_in I18n.t('thredded.posts.form.content_label'), with: content
+      click_on I18n.t('thredded.posts.form.update_btn')
     end
 
     def css_selector

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -63,7 +63,7 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'rspec-rails', '>= 3.5.0'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'rubocop', '= 0.45.0'
+  s.add_development_dependency 'rubocop', '= 0.46.0'
 
   # dummy app dependencies
   s.add_development_dependency 'rails-i18n'


### PR DESCRIPTION
With this we will multi-get only the post contents, and *not* cache the surrounding post UI.

Advantages:

* Allows state-dependent post UI as there is no need to worry about caching it anymore.
* Less cache load, as only the contents are cached. Different post views, such as a user post vs a post in a topic, re-use the same cached content.
* No need for the complex extension-unfriendly `PostView#cache_key` method.
* Bonus: multi-get caching even on Rails 4.

Disadvantage:

The `render_collection_to_strings_with_cache` implementation is complex.
It does use only the public  API of ActionView though.
Hoping for something like this to be included in ActionView itself
(https://groups.google.com/forum/#!topic/rubyonrails-core/Cx0GXz_k7Dc).

This idea comes from the discussion at
https://github.com/thredded/thredded/pull/533#issuecomment-282907746.