### PR TITLE
A divider line between sticky & non-sticky topics

### DIFF
--- a/app/assets/stylesheets/thredded/base/_variables.scss
+++ b/app/assets/stylesheets/thredded/base/_variables.scss
@@ -87,6 +87,8 @@ $thredded-badge-inactive-color: $thredded-button-color !default;
 $thredded-badge-inactive-background: rgba($thredded-text-color, 0.3) !default;
 
 // Layout features
+
+// Messageboards grid
 // Whether to display messageboards as a grid on the desktop screen sizes.
 $thredded-messageboards-grid: true !default;
 // Paddings within a grid item
@@ -107,3 +109,6 @@ $thredded-messageboards-grid-item-border-color:
        $thredded-base-border-color) !default;
 // Minimum width of a grid item
 $thredded-messageboards-grid-item-flex-basis: 21.5rem !default;
+
+// Topics list
+$thredded-topics-list-gutter-y: $thredded-base-spacing !default;

--- a/app/assets/stylesheets/thredded/components/_topics.scss
+++ b/app/assets/stylesheets/thredded/components/_topics.scss
@@ -1,5 +1,5 @@
 .thredded--topics--topic {
-  margin-bottom: $thredded-base-spacing;
+  margin-bottom: $thredded-topics-list-gutter-y;
   position: relative;
 
   @media (max-width: $thredded-grid-container-max-width) {
@@ -8,7 +8,13 @@
   @include thredded-media-mobile {
     margin-right: 2rem;
   }
+}
 
+.thredded--topics--sticky-topics-divider {
+  margin-top: -$thredded-topics-list-gutter-y / 2;
+  margin-bottom: $thredded-topics-list-gutter-y / 2;
+  border: 0;
+  border-top: $thredded-base-border;
 }
 
 .thredded--topics--title {

--- a/app/view_models/thredded/topic_view.rb
+++ b/app/view_models/thredded/topic_view.rb
@@ -2,7 +2,7 @@
 module Thredded
   # A view model for Topic.
   class TopicView < Thredded::BaseTopicView
-    delegate :categories, :id, :blocked?, :last_moderation_record, :followers,
+    delegate :sticky?, :locked?, :categories, :id, :blocked?, :last_moderation_record, :followers,
              :last_post, :messageboard_id, :messageboard_name,
              to: :@topic
 

--- a/app/view_models/thredded/topics_page_view.rb
+++ b/app/view_models/thredded/topics_page_view.rb
@@ -6,6 +6,7 @@ module Thredded
              :to_ary,
              :blank?,
              :empty?,
+             :[],
              to: :@topic_views
     delegate :total_pages,
              :current_page,

--- a/app/views/thredded/topics/_sticky_topics_divider.html.erb
+++ b/app/views/thredded/topics/_sticky_topics_divider.html.erb
@@ -1,0 +1,1 @@
+<hr class="thredded--topics--sticky-topics-divider">

--- a/app/views/thredded/topics/_topic.html.erb
+++ b/app/views/thredded/topics/_topic.html.erb
@@ -40,3 +40,7 @@
     </span>
   <% end %>
 <% end %>
+
+<% if !topic_iteration.last? && topic.sticky? && !topics[topic_counter + 1].sticky? %>
+  <%= render 'thredded/topics/sticky_topics_divider' %>
+<% end %>

--- a/app/views/thredded/topics/index.html.erb
+++ b/app/views/thredded/topics/index.html.erb
@@ -15,7 +15,7 @@
                css_class: 'thredded--is-compact',
                preview_url: preview_new_messageboard_topic_path(messageboard),
                placeholder: t('thredded.topics.form.title_placeholder_start') if @new_topic %>
-    <%= render @topics %>
+    <%= render partial: 'thredded/topics/topic', collection: @topics, locals: {topics: @topics} %>
   <% end %>
 
   <footer class="thredded--pagination-bottom">

--- a/spec/controllers/thredded/topics_controller_spec.rb
+++ b/spec/controllers/thredded/topics_controller_spec.rb
@@ -12,7 +12,6 @@ module Thredded
       @post         = create(:post, postable: @topic, content: 'hi')
       allow(controller).to receive_messages(
         topics:        [@topic],
-        sticky_topics: [],
         cannot?:       false,
         the_current_user:  user,
         messageboard:  @messageboard

--- a/spec/features/thredded/user_views_topics_spec.rb
+++ b/spec/features/thredded/user_views_topics_spec.rb
@@ -23,6 +23,7 @@ feature 'User viewing topics' do
 
     expect(topics.stuck_topics.size).to eq(1)
     expect(topics.normal_topics.size).to eq(2)
+    expect(topics).to have_sticky_divider
   end
 
   def three_topics

--- a/spec/support/features/page_object/topics.rb
+++ b/spec/support/features/page_object/topics.rb
@@ -69,6 +69,10 @@ module PageObject
       has_content?(topic_title)
     end
 
+    def has_sticky_divider?
+      has_css?('.thredded--topics--sticky-topics-divider')
+    end
+
     def preview_html
       # Wait for debounced preview to trigger
       Timeout.timeout(1) do


### PR DESCRIPTION
Currently there is no way to easily tell which topics are sticky.

I'm not sure what the best way to do it is, but for now I've added a subtle divider line between the sticky and non-sticky topics. It looks like this:

![sticky-divider](https://cloud.githubusercontent.com/assets/216339/23591852/1f13468a-01ef-11e7-8289-5dfccf66dd40.png)
