### PR TITLE
Add Thredded.routes_id_constraint configuration option

### DIFF
--- a/app/controllers/thredded/moderation_controller.rb
+++ b/app/controllers/thredded/moderation_controller.rb
@@ -76,7 +76,7 @@ module Thredded
 
     def maybe_set_last_moderated_record_flash
       return unless flash[:last_moderated_record_id]
-      @last_moderated_record = accessible_post_moderation_records.find(flash[:last_moderated_record_id].to_i)
+      @last_moderated_record = accessible_post_moderation_records.find(flash[:last_moderated_record_id])
     end
 
     def moderatable_posts

--- a/app/forms/thredded/private_topic_form.rb
+++ b/app/forms/thredded/private_topic_form.rb
@@ -64,7 +64,7 @@ module Thredded
 
     def topic_categories
       if category_ids
-        ids = category_ids.reject(&:empty?).map(&:to_i)
+        ids = category_ids.reject(&:empty?)
         Category.where(id: ids)
       else
         []
@@ -82,8 +82,8 @@ module Thredded
     def normalized_user_ids
       user_ids
         .reject(&:empty?)
-        .map(&:to_i)
-        .push(user.id)
+        .map(&:to_s)
+        .push(user.id.to_s)
         .uniq
     end
 

--- a/app/forms/thredded/topic_form.rb
+++ b/app/forms/thredded/topic_form.rb
@@ -65,7 +65,7 @@ module Thredded
 
     def topic_categories
       if category_ids
-        ids = category_ids.reject(&:empty?).map(&:to_i)
+        ids = category_ids.reject(&:empty?)
         Category.where(id: ids)
       else
         []

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,7 @@
 Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
   resource :theme_preview, only: [:show], path: 'theme-preview' if %w(development test).include? Rails.env
 
-  positive_int = /[1-9]\d*/
-  page_constraint = { page: positive_int }
+  page_constraint = { page: /[1-9]\d*/ }
 
   scope path: 'private-topics' do
     resource :read_state, only: [:update], as: :mark_all_private_topics_read
@@ -24,7 +23,7 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  scope only: [:show], constraints: { id: positive_int } do
+  scope only: [:show], constraints: { id: Thredded.routes_id_constraint } do
     resources :private_post_permalinks, path: 'private-posts'
     resources :post_permalinks, path: 'posts'
   end

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -29,6 +29,13 @@ Thredded.current_user_method = :"current_#{Thredded.user_class.name.underscore}"
 # User avatar URL. rb-gravatar gem is used by default:
 Thredded.avatar_url = ->(user) { Gravatar.src(user.email, 128, 'mm') }
 
+# ==> Database Configuration
+# By default, thredded uses integers for record ID route constraints.
+# For integer based IDs (default):
+# Thredded.routes_id_constraint = /[1-9]\d*/
+# For UUID based IDs (example):
+# Thredded.routes_id_constraint = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+
 # ==> Permissions Configuration
 # By default, thredded uses a simple permission model, where all the users can post to all message boards,
 # and admins and moderators are determined by a flag on the users table.

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -48,6 +48,7 @@ module Thredded
     :email_outgoing_prefix,
     :layout,
     :messageboards_order,
+    :routes_id_constraint,
     :user_class,
     :user_display_name_method,
     :user_name_column,
@@ -92,6 +93,7 @@ module Thredded
   self.show_topic_followers = false
   self.messageboards_order = :position
   self.autocomplete_min_length = 2
+  self.routes_id_constraint = /[1-9]\d*/
 
   # @return [Thredded::AllViewHooks] View hooks configuration.
   def self.view_hooks


### PR DESCRIPTION
Added Thredded.routes_id_contraint option to allow the user to specify the page constraint ID in lieu of forcing positive integers. Useful in cases where the underlying database is using a different ID type such as UUID. Default remains a positive integer. Additionally changed Thredded::PrivateTopicForm#normalized_user_ids to map to the string value of the user ID to support UUIDs (however this may not be the best option). I was unable to replicate your test environment, so I am unable to fully test these changes, however they are working without issue within my application.