### PR TITLE
Incorporate user_display_name_method into autocomplete search results

### DIFF
--- a/app/controllers/thredded/autocomplete_users_controller.rb
+++ b/app/controllers/thredded/autocomplete_users_controller.rb
@@ -6,10 +6,11 @@ module Thredded
     def index
       authorize_creating PrivateTopicForm.new(user: thredded_current_user).private_topic
       users = params.key?(:q) ? users_by_prefix : users_by_ids
+
       render json: {
         results: users.map do |user|
           { id:         user.id,
-            name:       user.send(Thredded.user_name_column),
+            name:       Thredded.display_name.call(user),
             avatar_url: Thredded.avatar_url.call(user) }
         end
       }

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -46,6 +46,7 @@ module Thredded
     :autocomplete_min_length,
     :active_user_threshold,
     :avatar_url,
+    :display_name,
     :email_from,
     :email_outgoing_prefix,
     :layout,
@@ -113,6 +114,10 @@ module Thredded
   def self.notifiers=(notifiers)
     notifiers.each { |notifier| BaseNotifier.validate_notifier(notifier) }
     @@notifiers = notifiers # rubocop:disable Style/ClassVars
+  end
+
+  def self.display_name(user)
+    [user.send(Thredded.user_name_column), user.send(Thredded.user_display_name_method)].uniq.join(' - ')
   end
 
   def self.user_display_name_method

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -98,6 +98,10 @@ module Thredded
   self.autocomplete_min_length = 2
   self.routes_id_constraint = /[1-9]\d*/
 
+  self.display_name = ->(user) do
+    [user.send(Thredded.user_name_column), user.send(Thredded.user_display_name_method)].uniq.join(' - ')
+  end
+
   # @return [Thredded::AllViewHooks] View hooks configuration.
   def self.view_hooks
     instance = Thredded::AllViewHooks.instance
@@ -114,10 +118,6 @@ module Thredded
   def self.notifiers=(notifiers)
     notifiers.each { |notifier| BaseNotifier.validate_notifier(notifier) }
     @@notifiers = notifiers # rubocop:disable Style/ClassVars
-  end
-
-  def self.display_name(user)
-    [user.send(Thredded.user_name_column), user.send(Thredded.user_display_name_method)].uniq.join(' - ')
   end
 
   def self.user_display_name_method


### PR DESCRIPTION
Allows for custom user_display_name's to be visible in the drop down when autocomplete searches for users. Default functionality remains unchanged, however when a user has specified a user_display_name_method, it will append the output to the search drop down for friendly user identification.