### PR TITLE
Auto-follow messageboard preference follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,16 @@ To disable moderation, e.g. if you run internal forums that do not need moderati
 change_column_default :thredded_user_details, :moderation_state, 1 # approved
 ```
 
+### Enabling auto-follow
+
+In some cases, you'll want all users to auto-follow new messageboard topics by default. This might be useful
+for a team messageboard or a company announcements board, for example. To enable user auto-follow of new topics,
+run the following migration(s):
+
+```ruby
+change_column_default :thredded_user_preferences, :auto_follow_topics, 1
+```
+
 ## Plugins
 
 The following official plugins are available for Thredded:

--- a/app/assets/javascripts/thredded/components/user_preferences_form.es6
+++ b/app/assets/javascripts/thredded/components/user_preferences_form.es6
@@ -1,6 +1,7 @@
 (($) => {
   const COMPONENT_SELECTOR = '[data-thredded-user-preferences-form]';
   const BOUND_MESSAGEBOARD_NAME = 'data-thredded-bound-messageboard-pref';
+  const UPDATE_ON_CHANGE_NAME = 'data-thredded-update-checkbox-on-change';
 
   class MessageboardPreferenceBinding {
     constructor($form, genericCheckboxName, messageboardCheckboxName) {
@@ -26,15 +27,29 @@
         .prop('disabled', !enabled)
         .filter(':checkbox').prop('checked', enabled ? this.messageboardCheckedWas : false);
     }
-
   }
+
+  class UpdateOnChange {
+    constructor($form, $sourceElement, targetName) {
+      const $target = $form.find(`:checkbox[name="${targetName}"]`);
+      if (!$target.length) return;
+      $sourceElement.on('change', () => {
+        $target.prop('checked', $sourceElement.prop('checked'));
+      });
+    }
+  }
+
   class UserPreferencesForm {
     constructor(form) {
       const $form = $(form);
       $form.find(`input[${BOUND_MESSAGEBOARD_NAME}]`).each((index, element) => {
         const $elem = $(element);
         new MessageboardPreferenceBinding($form, $elem.attr('name'), $elem.attr(BOUND_MESSAGEBOARD_NAME));
-      })
+      });
+      $form.find(`input[${UPDATE_ON_CHANGE_NAME}]`).each((index, element) => {
+        const $elem = $(element);
+        new UpdateOnChange($form, $elem, $elem.attr(UPDATE_ON_CHANGE_NAME))
+      });
     }
   }
 

--- a/app/commands/thredded/autofollow_users.rb
+++ b/app/commands/thredded/autofollow_users.rb
@@ -1,18 +1,23 @@
 # frozen_string_literal: true
 module Thredded
-  class AutofollowMentionedUsers
+  class AutofollowUsers
     def initialize(post)
       @post = post
     end
 
     def run
       autofollowers.each do |user|
-        Thredded::UserTopicFollow.create_unless_exists(user.id, post.postable_id, :mentioned)
+        reason = mentioned_users.include?(user) ? :mentioned : :auto
+        Thredded::UserTopicFollow.create_unless_exists(user.id, post.postable_id, reason)
       end
     end
 
+    def mentioned_users
+      @mentioned_users ||= Thredded::AtNotificationExtractor.new(post).run
+    end
+
     def autofollowers
-      autofollowers = Thredded::AtNotificationExtractor.new(post).run
+      autofollowers = (include_auto_followers + mentioned_users).uniq
       autofollowers.delete(post.user)
       exclude_those_opting_out_of_at_notifications autofollowers
     end
@@ -20,6 +25,10 @@ module Thredded
     private
 
     attr_reader :post
+
+    def include_auto_followers
+      post.messageboard.user_messageboard_preferences.auto_followers.map(&:user)
+    end
 
     def exclude_those_opting_out_of_at_notifications(members)
       members.select do |member|

--- a/app/commands/thredded/autofollow_users.rb
+++ b/app/commands/thredded/autofollow_users.rb
@@ -37,7 +37,9 @@ module Thredded
       user_board_prefs = post.messageboard.user_messageboard_preferences.each_with_object({}) do |ump, h|
         h[ump.user] = ump
       end
-      User.includes(:thredded_user_preference).all.select do |user|
+      Thredded.user_class.includes(:thredded_user_preference)
+        .select(Thredded.user_class.primary_key)
+        .find_each(batch_size: 50_000).select do |user|
         (user_board_prefs[user] ||
             Thredded::UserMessageboardPreference.new(messageboard: post.messageboard, user: user)).auto_follow_topics?
       end

--- a/app/controllers/thredded/preferences_controller.rb
+++ b/app/controllers/thredded/preferences_controller.rb
@@ -27,6 +27,8 @@ module Thredded
 
     def preferences_params
       params.fetch(:user_preferences_form, {}).permit(
+        :auto_follow_topics,
+        :messageboard_auto_follow_topics,
         :follow_topics_on_mention,
         :messageboard_follow_topics_on_mention,
         messageboard_notifications_for_followed_topics_attributes: %i(notifier_key id messageboard_id enabled),

--- a/app/forms/thredded/user_preferences_form.rb
+++ b/app/forms/thredded/user_preferences_form.rb
@@ -9,12 +9,14 @@ module Thredded
     validate :validate_children
 
     delegate :follow_topics_on_mention, :follow_topics_on_mention=,
+             :auto_follow_topics, :auto_follow_topics=,
              :messageboard_notifications_for_followed_topics_attributes=,
              :notifications_for_followed_topics_attributes=,
              :notifications_for_private_topics_attributes=,
              to: :user_preference
 
     delegate :follow_topics_on_mention, :follow_topics_on_mention=,
+             :auto_follow_topics, :auto_follow_topics=,
              to: :user_messageboard_preference,
              prefix: :messageboard
 

--- a/app/forms/thredded/user_preferences_form.rb
+++ b/app/forms/thredded/user_preferences_form.rb
@@ -33,6 +33,14 @@ module Thredded
       return false unless valid?
       Thredded::UserPreference.transaction do
         user_preference.save!
+
+        # Update all of the messageboards' auto_follow_topics if the global preference has changed.
+        if user_preference.previous_changes.include?('auto_follow_topics')
+          UserMessageboardPreference.where(user: @user)
+            .update_all(auto_follow_topics: user_preference.auto_follow_topics)
+          user_messageboard_preference.auto_follow_topics_will_change! if messageboard
+        end
+
         user_messageboard_preference.save! if messageboard
       end
       true
@@ -54,6 +62,14 @@ module Thredded
     def for_every_notifier(prefs)
       Thredded.notifiers.map do |notifier|
         prefs.find { |n| n.notifier_key == notifier.key } || prefs.build(notifier_key: notifier.key)
+      end
+    end
+
+    def update_path
+      if @messageboard
+        Thredded::UrlsHelper.messageboard_preferences_path(@messageboard)
+      else
+        Thredded::UrlsHelper.global_preferences_path
       end
     end
 

--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -93,11 +93,11 @@ module Thredded
       ]
     end
 
-    # @param follow_reason ['manual', 'posted', 'mentioned', nil]
+    # @param follow_reason ['manual', 'posted', 'mentioned', 'auto', nil]
     def topic_follow_reason_text(follow_reason)
       if follow_reason
         # rubocop:disable Metrics/LineLength
-        # i18n-tasks-use t('thredded.topics.following.manual') t('thredded.topics.following.posted') t('thredded.topics.following.mentioned')
+        # i18n-tasks-use t('thredded.topics.following.manual') t('thredded.topics.following.posted') t('thredded.topics.following.mentioned') t('thredded.topics.following.auto')
         # rubocop:enable Metrics/LineLength
         t("thredded.topics.following.#{follow_reason}")
       else

--- a/app/jobs/thredded/auto_follow_and_notify_job.rb
+++ b/app/jobs/thredded/auto_follow_and_notify_job.rb
@@ -6,7 +6,7 @@ module Thredded
     def perform(post_id)
       post = Post.find(post_id)
 
-      AutofollowMentionedUsers.new(post).run
+      AutofollowUsers.new(post).run
       NotifyFollowingUsers.new(post).run
     end
   end

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -27,6 +27,14 @@ module Thredded
       self.position ||= (created_at || Time.zone.now).to_i
     end
 
+    after_save :set_autofollow, on: :create
+
+    def set_autofollow
+      UserPreference.auto_followers.each do |user_preference|
+        user_messageboard_preferences.create(user_preference: user_preference, auto_follow_topics: true)
+      end
+    end
+
     has_many :categories, dependent: :destroy
     has_many :user_messageboard_preferences, dependent: :destroy
     has_many :posts, dependent: :destroy

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -27,14 +27,6 @@ module Thredded
       self.position ||= (created_at || Time.zone.now).to_i
     end
 
-    after_save :set_autofollow, on: :create
-
-    def set_autofollow
-      UserPreference.auto_followers.each do |user_preference|
-        user_messageboard_preferences.create(user_preference: user_preference, auto_follow_topics: true)
-      end
-    end
-
     has_many :categories, dependent: :destroy
     has_many :user_messageboard_preferences, dependent: :destroy
     has_many :posts, dependent: :destroy

--- a/app/models/thredded/user_messageboard_preference.rb
+++ b/app/models/thredded/user_messageboard_preference.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency 'app/models/thredded/user_preference'
 module Thredded
   class UserMessageboardPreference < ActiveRecord::Base
     belongs_to :user_preference,
@@ -14,11 +13,7 @@ module Thredded
     validates :user_id, presence: true
     validates :messageboard_id, presence: true
 
-    # If we're migrating from a version that doesn't have the column, this check will fail.
-    if Thredded::UserPreference.new.respond_to?(:auto_follow_topics?)
-      attribute :auto_follow_topics, ActiveRecord::Type::Boolean.new,
-                default: Thredded::UserPreference.new.auto_follow_topics?
-    end
+    after_initialize :set_auto_follow_from_user_preference, unless: :persisted?
 
     scope :auto_followers, -> { where(auto_follow_topics: true) }
 
@@ -28,6 +23,12 @@ module Thredded
 
     def user_preference
       super || build_user_preference
+    end
+
+    private
+
+    def set_auto_follow_from_user_preference
+      self.auto_follow_topics = user_preference.auto_follow_topics
     end
   end
 end

--- a/app/models/thredded/user_messageboard_preference.rb
+++ b/app/models/thredded/user_messageboard_preference.rb
@@ -25,10 +25,20 @@ module Thredded
       super || build_user_preference
     end
 
+    def user_id=(value)
+      super
+      set_auto_follow_from_user_preference
+    end
+
+    def user=(value)
+      super
+      set_auto_follow_from_user_preference
+    end
+
     private
 
     def set_auto_follow_from_user_preference
-      self.auto_follow_topics = user_preference.auto_follow_topics
+      self.auto_follow_topics = user_preference.auto_follow_topics if user_id && !id
     end
   end
 end

--- a/app/models/thredded/user_messageboard_preference.rb
+++ b/app/models/thredded/user_messageboard_preference.rb
@@ -13,6 +13,8 @@ module Thredded
     validates :user_id, presence: true
     validates :messageboard_id, presence: true
 
+    scope :auto_followers, -> { where(auto_follow_topics: true) }
+
     def self.in(messageboard)
       find_or_initialize_by(messageboard_id: messageboard.id)
     end

--- a/app/models/thredded/user_messageboard_preference.rb
+++ b/app/models/thredded/user_messageboard_preference.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_dependency 'app/models/thredded/user_preference'
 module Thredded
   class UserMessageboardPreference < ActiveRecord::Base
     belongs_to :user_preference,
@@ -13,10 +14,20 @@ module Thredded
     validates :user_id, presence: true
     validates :messageboard_id, presence: true
 
+    # If we're migrating from a version that doesn't have the column, this check will fail.
+    if Thredded::UserPreference.new.respond_to?(:auto_follow_topics?)
+      attribute :auto_follow_topics, ActiveRecord::Type::Boolean.new,
+                default: Thredded::UserPreference.new.auto_follow_topics?
+    end
+
     scope :auto_followers, -> { where(auto_follow_topics: true) }
 
     def self.in(messageboard)
       find_or_initialize_by(messageboard_id: messageboard.id)
+    end
+
+    def user_preference
+      super || build_user_preference
     end
   end
 end

--- a/app/models/thredded/user_preference.rb
+++ b/app/models/thredded/user_preference.rb
@@ -16,6 +16,8 @@ module Thredded
     end
     validates :user_id, presence: true
 
+    scope :auto_followers, -> { where(auto_follow_topics: true) }
+
     accepts_nested_attributes_for :notifications_for_followed_topics,
                                   :notifications_for_private_topics,
                                   :messageboard_notifications_for_followed_topics

--- a/app/models/thredded/user_topic_follow.rb
+++ b/app/models/thredded/user_topic_follow.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Thredded
   class UserTopicFollow < ActiveRecord::Base
-    enum reason: [:manual, :posted, :mentioned]
+    enum reason: [:manual, :posted, :mentioned, :auto]
 
     belongs_to :user, inverse_of: :thredded_topic_follows, class_name: Thredded.user_class
     belongs_to :topic, inverse_of: :user_follows

--- a/app/views/thredded/preferences/_form.html.erb
+++ b/app/views/thredded/preferences/_form.html.erb
@@ -1,17 +1,16 @@
-<%= form_for(
-        preferences,
-        method: :patch,
-        url:    (preferences.messageboard ? messageboard_preferences_path(preferences.messageboard) : global_preferences_path),
-        html:   {
-            class:                                'thredded--form thredded--notification-preferences-form',
-            'data-thredded-user-preferences-form' => true
-        }) do |f| %>
+<%# @type preferences [Thredded::UserPreferencesForm] %>
+<%= form_for(preferences, method: :patch, url: preferences.update_path, html: {
+    class: 'thredded--form thredded--notification-preferences-form',
+    'data-thredded-user-preferences-form' => true
+}) do |f| %>
 
   <h3><%= t 'thredded.preferences.form.global_preferences_label' %></h3>
   <ul class="thredded--form-list">
     <li>
       <%= f.label :auto_follow_topics do %>
-        <%= f.check_box :auto_follow_topics, 'data-thredded-bound-messageboard-pref' => 'user_preferences_form[messageboard_auto_follow_topics]' %>
+        <%= f.check_box :auto_follow_topics,
+                        'data-thredded-update-checkbox-on-change' =>
+                            'user_preferences_form[messageboard_auto_follow_topics]' %>
         <%= t 'thredded.preferences.form.auto_follow_topics.label' %>
         <p class="thredded--form-list--hint">
           <%= t 'thredded.preferences.form.auto_follow_topics.hint' %>

--- a/app/views/thredded/preferences/_form.html.erb
+++ b/app/views/thredded/preferences/_form.html.erb
@@ -10,6 +10,15 @@
   <h3><%= t 'thredded.preferences.form.global_preferences_label' %></h3>
   <ul class="thredded--form-list">
     <li>
+      <%= f.label :auto_follow_topics do %>
+        <%= f.check_box :auto_follow_topics, 'data-thredded-bound-messageboard-pref' => 'user_preferences_form[messageboard_auto_follow_topics]' %>
+        <%= t 'thredded.preferences.form.auto_follow_topics.label' %>
+        <p class="thredded--form-list--hint">
+          <%= t 'thredded.preferences.form.auto_follow_topics.hint' %>
+        </p>
+      <% end %>
+    </li>
+    <li>
       <%= f.label :follow_topics_on_mention do %>
         <%= f.check_box :follow_topics_on_mention, 'data-thredded-bound-messageboard-pref' => 'user_preferences_form[messageboard_follow_topics_on_mention]' %>
         <%= t 'thredded.preferences.form.follow_topics_on_mention.label' %>
@@ -48,6 +57,15 @@
       <%= t 'thredded.preferences.form.messageboard_preferences_label_html', messageboard: messageboard.name %>
     </h3>
     <ul class="thredded--form-list" data-thredded-user-preferences-form-messageboard-fields>
+      <li>
+        <%= f.label :messageboard_auto_follow_topics do %>
+          <%= f.check_box :messageboard_auto_follow_topics %>
+          <%= t 'thredded.preferences.form.messageboard_auto_follow_topics.label' %>
+          <p class="thredded--form-list--hint">
+            <%= t 'thredded.preferences.form.messageboard_auto_follow_topics.hint' %>
+          </p>
+        <% end %>
+      </li>
       <li>
         <%= f.label :messageboard_follow_topics_on_mention do %>
           <%= f.check_box :messageboard_follow_topics_on_mention %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,14 +83,14 @@ en:
         page_title: :thredded.nav.settings
       form:
         auto_follow_topics:
-          hint: 'You will automatically follow all new topics.'
+          hint: 'You will automatically follow all new topics. Changing this setting will change it for all messageboards.'
           label: 'Automatically follow new topics'
         follow_topics_on_mention:
           hint: 'When someone mentions you by your username (eg: @sam) you will follow the topic.'
           label: Follow topics you are mentioned in
         global_preferences_label: Global Settings
         messageboard_auto_follow_topics:
-          hint: 'Automatically follow all new topics in this messageboard.'
+          hint: 'Automatically follow all new topics in this messageboard. This overrides the respective setting above.'
           label: 'Automatically follow new topics'
         messageboard_follow_topics_on_mention:
           hint: 'When someone mentions you by your username (eg: @sam) in this messageboard you will follow the

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,10 +82,16 @@ en:
       edit:
         page_title: :thredded.nav.settings
       form:
+        auto_follow_topics:
+          hint: 'You will automatically follow all new topics.'
+          label: 'Automatically follow new topics'
         follow_topics_on_mention:
           hint: 'When someone mentions you by your username (eg: @sam) you will follow the topic.'
           label: Follow topics you are mentioned in
         global_preferences_label: Global Settings
+        messageboard_auto_follow_topics:
+          hint: 'Automatically follow all new topics in this messageboard.'
+          label: 'Automatically follow new topics'
         messageboard_follow_topics_on_mention:
           hint: 'When someone mentions you by your username (eg: @sam) in this messageboard you will follow the
             topic.'
@@ -146,6 +152,7 @@ en:
         manual: You are following this topic.
         mentioned: You are following this topic because you were mentioned on it.
         posted: You are following this topic because you posted to it.
+        auto: You are following this topic because auto-follow is enabled.
       form:
         categories_placeholder: Categories
         content_label: :thredded.posts.form.content_label

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,15 +83,15 @@ en:
         page_title: :thredded.nav.settings
       form:
         auto_follow_topics:
-          hint: 'You will automatically follow all new topics. Changing this setting will change it for all messageboards.'
-          label: 'Automatically follow new topics'
+          hint: 'Automatically follow all new topics. Changing this setting will change it for all messageboards.'
+          label: 'Follow all new topics'
         follow_topics_on_mention:
           hint: 'When someone mentions you by your username (eg: @sam) you will follow the topic.'
           label: Follow topics you are mentioned in
         global_preferences_label: Global Settings
         messageboard_auto_follow_topics:
           hint: 'Automatically follow all new topics in this messageboard. This overrides the respective setting above.'
-          label: 'Automatically follow new topics'
+          label: 'Follow all new topics'
         messageboard_follow_topics_on_mention:
           hint: 'When someone mentions you by your username (eg: @sam) in this messageboard you will follow the
             topic.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -83,15 +83,19 @@ es:
         page_title: :thredded.nav.settings
       form:
         auto_follow_topics:
-          hint: 'Seguirá automáticamente todos los temas nuevos.'
-          label: 'Seguir automáticamente nuevos temas'
+          hint: >-
+            Usted seguirá automáticamente todos los temas nuevos. El cambio de este ajuste se cambiará en todos
+            los messageboards.
+          label: Sigue automáticamente nuevos temas
         follow_topics_on_mention:
           hint: 'Cuando alguien te menciona usando tu nombre de usuario (por ejemplo: @sam), seguirás el tema.'
           label: Sigue temas en los que seas mencionado
         global_preferences_label: Ajustes Generales
         messageboard_auto_follow_topics:
-          hint: :thredded.preferences.form.auto_follow_topics.label
-          label: :thredded.preferences.form.auto_follow_topics.label
+          hint: >-
+            Sigue automáticamente todos los nuevos temas en este tablero de mensajes. Esto anula la configuración
+            respectiva anteriormente.
+          label: Sigue automáticamente nuevos temas
         messageboard_follow_topics_on_mention:
           hint: 'Cuando alguien te menciona usando tu nombre de usuario (por ejemplo: @sam) en este foro, seguirás
             el tema.'
@@ -149,10 +153,10 @@ es:
       followed_by_noone: Nadie está siguiendo este tema
       followed_notice: Estás siguiendo este tema
       following:
+        auto: Estás siguiendo este tema porque seguimiento automático está activado.
         manual: Estás siguiendo este tema.
         mentioned: Estás siguiendo este tema porque alguien te ha mencionado en él.
         posted: Estás siguiendo este tema porque has escrito en él.
-        auto: Estás siguiendo este tema porque seguimiento automático está activado.
       form:
         categories_placeholder: Categorías
         content_label: :thredded.posts.form.content_label

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -83,10 +83,9 @@ es:
         page_title: :thredded.nav.settings
       form:
         auto_follow_topics:
-          hint: >-
-            Usted seguirá automáticamente todos los temas nuevos. El cambio de este ajuste se cambiará en todos
-            los messageboards.
-          label: Sigue automáticamente nuevos temas
+          hint: Sigue automáticamente todos los temas nuevos. El cambio de este ajuste se cambiará en todos los
+            messageboards.
+          label: Siga todos los temas nuevos
         follow_topics_on_mention:
           hint: 'Cuando alguien te menciona usando tu nombre de usuario (por ejemplo: @sam), seguirás el tema.'
           label: Sigue temas en los que seas mencionado
@@ -95,7 +94,7 @@ es:
           hint: >-
             Sigue automáticamente todos los nuevos temas en este tablero de mensajes. Esto anula la configuración
             respectiva anteriormente.
-          label: Sigue automáticamente nuevos temas
+          label: Siga todos los temas nuevos
         messageboard_follow_topics_on_mention:
           hint: 'Cuando alguien te menciona usando tu nombre de usuario (por ejemplo: @sam) en este foro, seguirás
             el tema.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -82,10 +82,16 @@ es:
       edit:
         page_title: :thredded.nav.settings
       form:
+        auto_follow_topics:
+          hint: 'Seguirá automáticamente todos los temas nuevos.'
+          label: 'Seguir automáticamente nuevos temas'
         follow_topics_on_mention:
           hint: 'Cuando alguien te menciona usando tu nombre de usuario (por ejemplo: @sam), seguirás el tema.'
           label: Sigue temas en los que seas mencionado
         global_preferences_label: Ajustes Generales
+        messageboard_auto_follow_topics:
+          hint: :thredded.preferences.form.auto_follow_topics.label
+          label: :thredded.preferences.form.auto_follow_topics.label
         messageboard_follow_topics_on_mention:
           hint: 'Cuando alguien te menciona usando tu nombre de usuario (por ejemplo: @sam) en este foro, seguirás
             el tema.'
@@ -146,6 +152,7 @@ es:
         manual: Estás siguiendo este tema.
         mentioned: Estás siguiendo este tema porque alguien te ha mencionado en él.
         posted: Estás siguiendo este tema porque has escrito en él.
+        auto: Estás siguiendo este tema porque seguimiento automático está activado.
       form:
         categories_placeholder: Categorías
         content_label: :thredded.posts.form.content_label

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -82,10 +82,16 @@ pl:
       edit:
         page_title: :thredded.nav.settings
       form:
+        auto_follow_topics:
+          hint: Będziesz na bieżąco śledzić wszystkie nowe tematy.
+          label: Automatycznie wykonaj nowych tematów
         follow_topics_on_mention:
           hint: 'Gdy ktoś w temacie wspomni o Tobie (np.: @sam) zaczniesz obserwować ten temat.'
           label: Obserwuj tematy, w których zostałeś wspomiany
         global_preferences_label: Ustawienia powiadomień
+        messageboard_auto_follow_topics:
+          hint: Automatycznie przestrzegać wszystkich nowych tematów na tym messageboard.
+          label: Automatycznie wykonaj nowych tematów
         messageboard_follow_topics_on_mention:
           hint: 'Gdy ktoś w temacie wspomni o Tobie (np.: @sam) zaczniesz obserwować ten temat.'
           label: :thredded.preferences.form.follow_topics_on_mention.label
@@ -142,6 +148,7 @@ pl:
       followed_by_noone: Nikt nie obserwuje tego tematu
       followed_notice: Obserwujesz ten temat
       following:
+        auto: Osoby stosujące ten temat, ponieważ auto naśladowania jest włączony.
         manual: Obserwujesz ten temat.
         mentioned: Obserwujesz ten temat, ponieważ ktoś wspomniał w nim o tobie.
         posted: Obserwujesz ten temat, ponieważ w nim napisałeś.

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -83,15 +83,18 @@ pl:
         page_title: :thredded.nav.settings
       form:
         auto_follow_topics:
-          hint: Będziesz na bieżąco śledzić wszystkie nowe tematy.
-          label: Automatycznie wykonaj nowych tematów
+          hint: >-
+            Będziesz na bieżąco śledzić wszystkie nowe tematy. Zmiana tego ustawienia powoduje zmianę dla wszystkich
+            messageboards.
+          label: Automatycznie śledzić nowych tematów
         follow_topics_on_mention:
           hint: 'Gdy ktoś w temacie wspomni o Tobie (np.: @sam) zaczniesz obserwować ten temat.'
           label: Obserwuj tematy, w których zostałeś wspomiany
         global_preferences_label: Ustawienia powiadomień
         messageboard_auto_follow_topics:
-          hint: Automatycznie przestrzegać wszystkich nowych tematów na tym messageboard.
-          label: Automatycznie wykonaj nowych tematów
+          hint: Automatycznie śledzić wszystkie nowe tematy na tym messageboard. To zastępuje odpowiednie ustawienie
+            powyżej.
+          label: Automatycznie śledzić nowych tematów
         messageboard_follow_topics_on_mention:
           hint: 'Gdy ktoś w temacie wspomni o Tobie (np.: @sam) zaczniesz obserwować ten temat.'
           label: :thredded.preferences.form.follow_topics_on_mention.label

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -84,9 +84,8 @@ pl:
       form:
         auto_follow_topics:
           hint: >-
-            Będziesz na bieżąco śledzić wszystkie nowe tematy. Zmiana tego ustawienia powoduje zmianę dla wszystkich
-            messageboards.
-          label: Automatycznie śledzić nowych tematów
+            Automatycznie śledzić wszystkie nowe tematy. Zmiana tego ustawienia powoduje zmianę dla wszystkich messageboards.
+          label: Śledź wszystkie nowe tematy
         follow_topics_on_mention:
           hint: 'Gdy ktoś w temacie wspomni o Tobie (np.: @sam) zaczniesz obserwować ten temat.'
           label: Obserwuj tematy, w których zostałeś wspomiany
@@ -94,7 +93,7 @@ pl:
         messageboard_auto_follow_topics:
           hint: Automatycznie śledzić wszystkie nowe tematy na tym messageboard. To zastępuje odpowiednie ustawienie
             powyżej.
-          label: Automatycznie śledzić nowych tematów
+          label: Śledź wszystkie nowe tematy
         messageboard_follow_topics_on_mention:
           hint: 'Gdy ktoś w temacie wspomni o Tobie (np.: @sam) zaczniesz obserwować ten temat.'
           label: :thredded.preferences.form.follow_topics_on_mention.label

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -83,10 +83,8 @@ pt-BR:
         page_title: :thredded.nav.settings
       form:
         auto_follow_topics:
-          hint: >-
-            Você seguirá automaticamente todos os novos temas. Alterar essa configuração vai mudá-lo para todos
-            os messageboards.
-          label: siga automaticamente novos tópicos
+          hint: siga automaticamente todos os novos temas. Alterar essa configuração vai mudá-lo para todos os messageboards.
+          label: Siga todos os novos temas
         follow_topics_on_mention:
           hint: >-
             Quando alguém mencionar você através do seu usuário (ex.: @sam) você irá receber um e-mail com o conteúdo
@@ -96,7 +94,7 @@ pt-BR:
         messageboard_auto_follow_topics:
           hint: siga automaticamente todos os novos tópicos neste messageboard. Isso substitui a respectiva definição
             acima.
-          label: siga automaticamente novos tópicos
+          label: Siga todos os novos temas
         messageboard_follow_topics_on_mention:
           hint: >-
             Quando alguém mencionar você através do seu usuário (ex.: @sam) neste fórum de mensagens, você irá receber

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -83,8 +83,10 @@ pt-BR:
         page_title: :thredded.nav.settings
       form:
         auto_follow_topics:
-          hint: 'Você seguirá automaticamente todos os novos tópicos.'
-          label: 'Seguir automaticamente novos tópicos'
+          hint: >-
+            Você seguirá automaticamente todos os novos temas. Alterar essa configuração vai mudá-lo para todos
+            os messageboards.
+          label: siga automaticamente novos tópicos
         follow_topics_on_mention:
           hint: >-
             Quando alguém mencionar você através do seu usuário (ex.: @sam) você irá receber um e-mail com o conteúdo
@@ -92,8 +94,9 @@ pt-BR:
           label: Siga os tópicos que são mencionados na
         global_preferences_label: Configurações Globais
         messageboard_auto_follow_topics:
-          hint: :thredded.preferences.form.auto_follow_topics.label
-          label: :thredded.preferences.form.auto_follow_topics.label
+          hint: siga automaticamente todos os novos tópicos neste messageboard. Isso substitui a respectiva definição
+            acima.
+          label: siga automaticamente novos tópicos
         messageboard_follow_topics_on_mention:
           hint: >-
             Quando alguém mencionar você através do seu usuário (ex.: @sam) neste fórum de mensagens, você irá receber
@@ -152,10 +155,10 @@ pt-BR:
       followed_by_noone: Ninguém está seguindo este tópico
       followed_notice: Você agora está seguindo este tópico
       following:
+        auto: Você está seguindo este tópico porque o auto-follow está ativado.
         manual: Você está seguindo este tópico.
         mentioned: Você está seguindo este tópico porque você foi mencionado nele.
         posted: Você está seguindo este tópico porque foi você que o publicou.
-        auto: Você está seguindo este tópico porque o auto-follow está ativado.
       form:
         categories_placeholder: Categorias
         content_label: :thredded.posts.form.content_label

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -82,12 +82,18 @@ pt-BR:
       edit:
         page_title: :thredded.nav.settings
       form:
+        auto_follow_topics:
+          hint: 'Você seguirá automaticamente todos os novos tópicos.'
+          label: 'Seguir automaticamente novos tópicos'
         follow_topics_on_mention:
           hint: >-
             Quando alguém mencionar você através do seu usuário (ex.: @sam) você irá receber um e-mail com o conteúdo
             deste post.
           label: Siga os tópicos que são mencionados na
         global_preferences_label: Configurações Globais
+        messageboard_auto_follow_topics:
+          hint: :thredded.preferences.form.auto_follow_topics.label
+          label: :thredded.preferences.form.auto_follow_topics.label
         messageboard_follow_topics_on_mention:
           hint: >-
             Quando alguém mencionar você através do seu usuário (ex.: @sam) neste fórum de mensagens, você irá receber
@@ -149,6 +155,7 @@ pt-BR:
         manual: Você está seguindo este tópico.
         mentioned: Você está seguindo este tópico porque você foi mencionado nele.
         posted: Você está seguindo este tópico porque foi você que o publicou.
+        auto: Você está seguindo este tópico porque o auto-follow está ativado.
       form:
         categories_placeholder: Categorias
         content_label: :thredded.posts.form.content_label

--- a/db/migrate/20160329231848_create_thredded.rb
+++ b/db/migrate/20160329231848_create_thredded.rb
@@ -153,6 +153,7 @@ class CreateThredded < ActiveRecord::Migration
     create_table :thredded_user_preferences do |t|
       t.references :user, null: false
       t.boolean :follow_topics_on_mention, default: true, null: false
+      t.boolean :auto_follow_topics, default: false, null: false
       t.timestamps null: false
       t.index [:user_id], name: :index_thredded_user_preferences_on_user_id
     end
@@ -161,6 +162,7 @@ class CreateThredded < ActiveRecord::Migration
       t.references :user, null: false
       t.references :messageboard, null: false
       t.boolean :follow_topics_on_mention, default: true, null: false
+      t.boolean :auto_follow_topics, default: false, null: false
       t.timestamps null: false
       t.index [:user_id, :messageboard_id],
               name: :thredded_user_messageboard_preferences_user_id_messageboard_id,

--- a/db/upgrade_migrations/20161113161801_upgrade_v0_8_to_v0_9.rb
+++ b/db/upgrade_migrations/20161113161801_upgrade_v0_8_to_v0_9.rb
@@ -25,16 +25,17 @@ class UpgradeV08ToV09 < ActiveRecord::Migration
               name: 'thredded_messageboard_notifications_for_followed_topics_unique', unique: true
     end
 
-    Thredded::UserPreference.includes(:user).each do |pref|
+    Thredded::UserPreference.all.each do |pref|
       pref.notifications_for_private_topics.create(notifier_key: 'email', enabled: pref.notify_on_message)
       pref.notifications_for_followed_topics.create(notifier_key: 'email', enabled: pref.followed_topic_emails)
     end
-    Thredded::UserMessageboardPreference.includes(:user).each do |pref|
+    Thredded::UserMessageboardPreference.pluck(:user_id, :messageboard_id, :followed_topic_emails)
+      .each do |user_id, messageboard_id, emails|
       Thredded::MessageboardNotificationsForFollowedTopics.create(
-        user_id: pref.user_id,
-        messageboard_id: pref.messageboard_id,
+        user_id: user_id,
+        messageboard_id: messageboard_id,
         notifier_key: 'email',
-        enabled: pref.followed_topic_emails
+        enabled: emails
       )
     end
 

--- a/db/upgrade_migrations/20170312131417_upgrade_thredded_v0_10_to_v0_11.rb
+++ b/db/upgrade_migrations/20170312131417_upgrade_thredded_v0_10_to_v0_11.rb
@@ -2,9 +2,13 @@
 class UpgradeThreddedV010ToV011 < ActiveRecord::Migration
   def up
     drop_table :thredded_post_notifications
+    add_column :thredded_user_preferences, :auto_follow_topics, :boolean, default: false, null: false
+    add_column :thredded_user_messageboard_preferences, :auto_follow_topics, :boolean, default: false, null: false
   end
 
   def down
+    remove_column :thredded_user_messageboard_preferences, :auto_follow_topics
+    remove_column :thredded_user_preferences, :auto_follow_topics
     create_table :thredded_post_notifications do |t|
       t.string :email, limit: 191, null: false
       t.references :post, null: false

--- a/spec/forms/thredded/user_preferences_form_spec.rb
+++ b/spec/forms/thredded/user_preferences_form_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+module Thredded
+  describe UserPreferencesForm do
+    let(:user) { create(:user) }
+
+    context 'autofollow' do
+      let(:default_auto_follow) { UserPreference.new.auto_follow_topics }
+
+      it 'changed: updates messageboard preferences' do
+        messageboard_preference = create(:user_messageboard_preference, user: user)
+        expect(messageboard_preference.auto_follow_topics).to eq default_auto_follow
+        new_value = !default_auto_follow
+        UserPreferencesForm.new(user: user, params: { auto_follow_topics: new_value }).save
+        expect(messageboard_preference.reload.auto_follow_topics).to eq new_value
+      end
+
+      it 'not changed: messageboard preferences intact' do
+        board_value = !default_auto_follow
+        messageboard_preference = create(:user_messageboard_preference, user: user, auto_follow_topics: board_value)
+        expect(messageboard_preference.auto_follow_topics).to eq board_value
+        expect(user.thredded_user_preference.auto_follow_topics).to_not eq board_value
+        UserPreferencesForm.new(user: user).save
+        expect(messageboard_preference.reload.auto_follow_topics).to eq board_value
+        expect(user.thredded_user_preference.reload.auto_follow_topics).to_not eq board_value
+      end
+    end
+  end
+end

--- a/spec/models/thredded/messageboard_spec.rb
+++ b/spec/models/thredded/messageboard_spec.rb
@@ -156,16 +156,4 @@ module Thredded
       expect(messageboard.position).to eq(12)
     end
   end
-
-  describe '#set_autofollow' do
-    it 'creates messageboard preferences for each auto-following user' do
-      no_follow_user_preference = create(:user_preference, auto_follow_topics: false)
-      auto_follow_preference = create(:user_preference, auto_follow_topics: true)
-
-      expect {
-        messageboard = create(:messageboard)
-        expect(messageboard.user_messageboard_preferences.last.user_preference).to eq(auto_follow_preference)
-      }.to change(UserMessageboardPreference, :count).by(1)
-    end
-  end
 end

--- a/spec/models/thredded/messageboard_spec.rb
+++ b/spec/models/thredded/messageboard_spec.rb
@@ -156,4 +156,16 @@ module Thredded
       expect(messageboard.position).to eq(12)
     end
   end
+
+  describe '#set_autofollow' do
+    it 'creates messageboard preferences for each auto-following user' do
+      no_follow_user_preference = create(:user_preference, auto_follow_topics: false)
+      auto_follow_preference = create(:user_preference, auto_follow_topics: true)
+
+      expect {
+        messageboard = create(:messageboard)
+        expect(messageboard.user_messageboard_preferences.last.user_preference).to eq(auto_follow_preference)
+      }.to change(UserMessageboardPreference, :count).by(1)
+    end
+  end
 end

--- a/spec/models/thredded/user_messageboard_preference_spec.rb
+++ b/spec/models/thredded/user_messageboard_preference_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+module Thredded
+  describe UserMessageboardPreference do
+    let(:user) { create(:user) }
+
+    describe 'autofollow' do
+      it 'inherits `auto_follow_topics: true` from user_preference for a new record' do
+        user.thredded_user_preference.update(auto_follow_topics: true)
+        expect(UserMessageboardPreference.new(user: user, messageboard: create(:messageboard)).auto_follow_topics)
+          .to eq true
+      end
+
+      it 'inherits `auto_follow_topics: false` from user_preference for a new record' do
+        user.thredded_user_preference.update(auto_follow_topics: false)
+        expect(UserMessageboardPreference.new(user: user, messageboard: create(:messageboard)).auto_follow_topics)
+          .to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
See #488 - by changing the column default specified in the README, users
will (by default) auto-follow topics in all newly created messageboards.
You can also togggle individual messageboard auto-follows (like an
'important notices' board) for specific message boards by running a data
migration targeting the ThreddedUserMessageboardPreference model. Users
can turn this functionality off at the global level or for particular
boards.