### PR TITLE
UI: Show search on the left, user nav on the right

### DIFF
--- a/app/assets/stylesheets/thredded/layout/_search-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_search-navigation.scss
@@ -1,9 +1,10 @@
 .thredded--navigation--search {
-  margin-right: 0;
+  $input-padding-x: 0.75rem;
+
+  margin: 0;
   padding: 0;
   position: absolute;
   top: 0;
-  right: 0;
 
   @include thredded-media-tablet-and-down {
     position: initial;
@@ -20,16 +21,15 @@
 
     @include thredded-media-desktop-and-up {
       $line-height: 1rem;
-      $padding-x: 0.75rem;
       background: transparent;
       border-color: transparent;
       font-size: $thredded-font-size-small;
       line-height: $line-height;
       min-width: 13rem;
-      text-align: right;
       width: auto;
-      padding: 0.9375rem 0.75rem 0.875rem 0.75rem;
-      margin: -1px (-$padding-x) 0 0;
+      padding: 0.9375rem $input-padding-x 0.875rem $input-padding-x;
+      margin-top: -1px;
+      margin-bottom: 0;
 
       &, &:focus {
         transition: background, border-color, box-shadow, min-width 0.15s ease-out 0s;
@@ -39,6 +39,7 @@
         background: $thredded-background-color;
         box-shadow: none;
         margin-right: 0;
+        margin-left: 0;
         min-width: 16rem;
         text-align: left;
       }
@@ -97,5 +98,29 @@
 
   @media print {
     display: none;
+  }
+
+  // On the left:
+  right: auto;
+  left: 0;
+  @include thredded-media-desktop-and-up {
+    input[type="search"] {
+      text-align: left;
+      margin-right: 0;
+      margin-left: -$input-padding-x;
+    }
+  }
+
+  // On the right:
+  &--right {
+    right: 0;
+    left: auto;
+    @include thredded-media-desktop-and-up {
+      input[type="search"] {
+        text-align: right;
+        margin-right: -$input-padding-x;
+        margin-left: 0;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/thredded/layout/_user-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_user-navigation.scss
@@ -1,5 +1,6 @@
 .thredded--user-navigation {
   @extend %thredded--nav-tabs;
+  text-align: right;
   @media print {
     display: none;
   }

--- a/app/views/thredded/moderation/_users_search_form.html.erb
+++ b/app/views/thredded/moderation/_users_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag users_moderation_path,
              method: 'get',
-             class: 'thredded--form thredded--navigation--search',
+             class: 'thredded--form thredded--navigation--search thredded--navigation--search--right',
              'data-thredded-turboform' => true do %>
   <%= label_tag :q, t('thredded.moderation.search_users.form_label') %>
   <%= text_field_tag :q, @query,


### PR DESCRIPTION
The username / profile link is usually rendered on top right, so it makes sense to keep user nav (notification settings, private messages) close.

![thredded-nav-flip](https://cloud.githubusercontent.com/assets/216339/24448751/018016d0-146d-11e7-9d79-5a3d487a38bf.png)

Fixes #561 