### PR TITLE
Perform canonical redirects from old/invalid slugs

### DIFF
--- a/app/controllers/thredded/application_controller.rb
+++ b/app/controllers/thredded/application_controller.rb
@@ -60,6 +60,12 @@ module Thredded
       end
     end
 
+    # @param given [Hash]
+    # @return [Boolean] whether the given params are a subset of the controller's {#params}.
+    def params_match?(given = {})
+      given.all? { |k, v| v == params[k] }
+    end
+
     private
 
     def thredded_layout

--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -19,7 +19,7 @@ module Thredded
 
     def edit
       authorize post, :update?
-      return if redirect_to_canonical_topic!
+      return redirect_to(canonical_topic_params) unless params_match?(canonical_topic_params)
       render
     end
 
@@ -47,9 +47,8 @@ module Thredded
 
     private
 
-    def redirect_to_canonical_topic!
-      return if params[:messageboard_id].to_s == messageboard.slug && params[:topic_id].to_s == topic.slug
-      redirect_to messageboard_id: messageboard.slug, topic_id: topic.slug
+    def canonical_topic_params
+      { messageboard_id: messageboard.slug, topic_id: topic.slug }
     end
 
     def after_mark_as_unread

--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -19,6 +19,8 @@ module Thredded
 
     def edit
       authorize post, :update?
+      return if redirect_to_canonical_topic!
+      render
     end
 
     def update
@@ -44,6 +46,11 @@ module Thredded
     end
 
     private
+
+    def redirect_to_canonical_topic!
+      return if params[:messageboard_id].to_s == messageboard.slug && params[:topic_id].to_s == topic.slug
+      redirect_to messageboard_id: messageboard.slug, topic_id: topic.slug
+    end
 
     def after_mark_as_unread
       redirect_to messageboard_topics_path(messageboard)

--- a/app/controllers/thredded/private_posts_controller.rb
+++ b/app/controllers/thredded/private_posts_controller.rb
@@ -19,6 +19,8 @@ module Thredded
 
     def edit
       authorize post, :update?
+      return if redirect_to_canonical_topic!
+      render
     end
 
     def update
@@ -44,6 +46,11 @@ module Thredded
     end
 
     private
+
+    def redirect_to_canonical_topic!
+      return if params[:private_topic_id].to_s == topic.slug
+      redirect_to private_topic_id: topic.slug
+    end
 
     def after_mark_as_unread
       redirect_to private_topics_path

--- a/app/controllers/thredded/private_posts_controller.rb
+++ b/app/controllers/thredded/private_posts_controller.rb
@@ -19,7 +19,7 @@ module Thredded
 
     def edit
       authorize post, :update?
-      return if redirect_to_canonical_topic!
+      return redirect_to(canonical_topic_params) unless params_match?(canonical_topic_params)
       render
     end
 
@@ -47,9 +47,8 @@ module Thredded
 
     private
 
-    def redirect_to_canonical_topic!
-      return if params[:private_topic_id].to_s == topic.slug
-      redirect_to private_topic_id: topic.slug
+    def canonical_topic_params
+      { private_topic_id: topic.slug }
     end
 
     def after_mark_as_unread

--- a/app/controllers/thredded/private_topics_controller.rb
+++ b/app/controllers/thredded/private_topics_controller.rb
@@ -22,6 +22,7 @@ module Thredded
 
     def show
       authorize private_topic, :read?
+      return if redirect_to_canonical_topic!
 
       page_scope = private_topic
         .posts
@@ -55,6 +56,8 @@ module Thredded
 
     def edit
       authorize private_topic, :update?
+      return if redirect_to_canonical_topic!
+      render
     end
 
     def update
@@ -68,6 +71,11 @@ module Thredded
     end
 
     private
+
+    def redirect_to_canonical_topic!
+      return if params[:id].to_s == private_topic.slug
+      redirect_to id: private_topic.slug
+    end
 
     def current_page
       (params[:page] || 1).to_i

--- a/app/controllers/thredded/private_topics_controller.rb
+++ b/app/controllers/thredded/private_topics_controller.rb
@@ -22,7 +22,7 @@ module Thredded
 
     def show
       authorize private_topic, :read?
-      return if redirect_to_canonical_topic!
+      return redirect_to(canonical_topic_params) unless params_match?(canonical_topic_params)
 
       page_scope = private_topic
         .posts
@@ -56,7 +56,7 @@ module Thredded
 
     def edit
       authorize private_topic, :update?
-      return if redirect_to_canonical_topic!
+      return redirect_to(canonical_topic_params) unless params_match?(canonical_topic_params)
       render
     end
 
@@ -72,9 +72,8 @@ module Thredded
 
     private
 
-    def redirect_to_canonical_topic!
-      return if params[:id].to_s == private_topic.slug
-      redirect_to id: private_topic.slug
+    def canonical_topic_params
+      { id: private_topic.slug }
     end
 
     def current_page

--- a/spec/controllers/thredded/topics_controller_spec.rb
+++ b/spec/controllers/thredded/topics_controller_spec.rb
@@ -18,17 +18,24 @@ module Thredded
       )
     end
 
-    it 'renders GET index' do
-      get :index, params: { messageboard_id: @messageboard.id }
+    describe 'GET index' do
+      it 'renders' do
+        get :index, params: { messageboard_id: @messageboard.slug }
 
-      expect(response).to be_successful
-      expect(response).to render_template('index')
+        expect(response).to be_successful
+        expect(response).to render_template('index')
+      end
+
+      it 'performs canonical redirect' do
+        get :index, params: { messageboard_id: @messageboard.id }
+        expect(response).to redirect_to(action: :index, messageboard_id: @messageboard.slug)
+      end
     end
 
     describe 'GET search' do
       it 'renders search' do
         allow(Topic).to receive_messages(search_query: Topic.where(id: @topic.id))
-        get :search, params: { messageboard_id: @messageboard.id, q: 'hi' }
+        get :search, params: { messageboard_id: @messageboard.slug, q: 'hi' }
 
         expect(response).to be_successful
         expect(response).to render_template('search')
@@ -36,38 +43,49 @@ module Thredded
 
       it 'is successful with spaces around search term(s)' do
         allow(Topic).to receive_messages(search_query: Topic.where(id: @topic.id))
-        get :search, params: { messageboard_id: @messageboard.id, q: '  hi  ' }
+        get :search, params: { messageboard_id: @messageboard.slug, q: '  hi  ' }
 
         expect(response).to be_successful
       end
 
+      it 'performs canonical redirect' do
+        get :search, params: { messageboard_id: @messageboard.id }
+        expect(response).to redirect_to(action: :search, messageboard_id: @messageboard.slug)
+      end
+
       context 'renders' do
         render_views
-
         it 'a No Results message' do
           allow(Topic).to receive_messages(search_query: Topic.none)
-          get :search, params: { messageboard_id: @messageboard.id, q: 'hi' }
+          get :search, params: { messageboard_id: @messageboard.slug, q: 'hi' }
 
           expect(response.body).to have_content "There are no results for your search - 'hi'"
         end
       end
     end
+
     describe 'GET new' do
       it 'works with no extra parameters' do
-        get :new, params: { messageboard_id: @messageboard.id }
+        get :new, params: { messageboard_id: @messageboard.slug }
         expect(response).to be_successful
         expect(response).to render_template('new')
         expect(assigns(:new_topic).title).to be_blank
         expect(assigns(:new_topic).content).to be_blank
       end
+
       it 'assigns extra parameters' do
         get :new, params: {
-          messageboard_id: @messageboard.id, topic: { title: 'given title', content: 'preset content' }
+          messageboard_id: @messageboard.slug, topic: { title: 'given title', content: 'preset content' }
         }
         expect(response).to be_successful
         expect(response).to render_template('new')
         expect(assigns(:new_topic).title).to eq 'given title'
         expect(assigns(:new_topic).content).to eq 'preset content'
+      end
+
+      it 'performs canonical redirect' do
+        get :new, params: { messageboard_id: @messageboard.id }
+        expect(response).to redirect_to(action: :new, messageboard_id: @messageboard.slug)
       end
     end
 


### PR DESCRIPTION
Always perform policy checks first to avoid leaking new slugs.

Fixes #562