### PR TITLE
Gitignore all RVM configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .agignore
-.ruby-version
 db/schema*.rb
 Gemfile.lock
 *.gemfile.lock
@@ -24,3 +23,11 @@ tmp/
 /doc/
 /.yardoc/
 .idea/
+.rvmrc
+.versions.conf
+.ruby-gemset
+.ruby-version
+.ruby-env
+.rbenv-version
+.rbenv-vars
+.rbfu-version


### PR DESCRIPTION
Previously, only `.ruby-version` was ignored, but I personally use the `.ruby-gemset` file, so I wanted to ignore that file as well.

I figured while I'm at it, I might as well ignore all other RVM configuration files, listed in the [Typical RVM Project Workflow](https://rvm.io/workflow/projects) document.

In order of precedence, the files are:

- .rvmrc
- .versions.conf
- .ruby-version
  + .ruby-gemset
  + .ruby-env
  + .rbenv-version
  + .rbenv-vars
  + .rbfu-version
- _Gemfile_ <sup>1</sup>

---

<sup>1</sup> _Will not be ignored_