### PR TITLE
Always return 404 for missing messageboards

### DIFF
--- a/app/controllers/thredded/application_controller.rb
+++ b/app/controllers/thredded/application_controller.rb
@@ -20,7 +20,7 @@ module Thredded
                 Thredded::Errors::UserNotFound do |exception|
       @error   = exception
       @message = exception.message
-      render template: 'thredded/error_pages/not_found', status: :not_found
+      render template: 'thredded/error_pages/not_found', status: :not_found, formats: [:html]
     end
 
     rescue_from Pundit::NotAuthorizedError,

--- a/spec/controllers/thredded/topics_controller_spec.rb
+++ b/spec/controllers/thredded/topics_controller_spec.rb
@@ -13,8 +13,7 @@ module Thredded
       allow(controller).to receive_messages(
         topics:        [@topic],
         cannot?:       false,
-        the_current_user:  user,
-        messageboard:  @messageboard
+        the_current_user:  user
       )
     end
 
@@ -29,6 +28,18 @@ module Thredded
       it 'performs canonical redirect' do
         get :index, params: { messageboard_id: @messageboard.id }
         expect(response).to redirect_to(action: :index, messageboard_id: @messageboard.slug)
+      end
+
+      context 'with missing messageboard' do
+        it 'returns a 404 for HTML requests' do
+          get :index, params: { messageboard_id: 'notfound' }
+          expect(response.status).to eq(404)
+        end
+
+        it 'returns a 404 for JSON requests' do
+          get :index, params: { messageboard_id: 'notfound', format: :json }
+          expect(response.status).to eq(404)
+        end
       end
     end
 


### PR DESCRIPTION
Always return a 404 in `TopicsController#index` when the `messageboard` isn't found, regardless of request format (HTML, JSON, etc).

Fixes #557 