### PR TITLE
Un-bold breadcrumbs text on desktop

### DIFF
--- a/app/assets/stylesheets/thredded/layout/_main-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_main-navigation.scss
@@ -18,10 +18,13 @@
 
   li {
     display: block;
-    font-weight: bold;
 
     a {
       display: block;
+    }
+
+    @include thredded-media-tablet-and-down {
+      font-weight: bold;
     }
 
     @include thredded-media-mobile {


### PR DESCRIPTION
Makes breadcrumbs consistent with the rest of the navigation

### Screenshots

Desktop:
![nav-desktop](https://cloud.githubusercontent.com/assets/216339/25070508/ba225356-22a0-11e7-8839-3183d9da07fd.png)

---

Mobile and tablet remain the same:

![nav-tablet](https://cloud.githubusercontent.com/assets/216339/25070507/b46f02e2-22a0-11e7-8ef7-cbec45203766.png)

---

![nav-mobile](https://cloud.githubusercontent.com/assets/216339/25070514/ea4478ca-22a0-11e7-855b-5f57c1558acf.png)
