### PR TITLE
Make topic slugs unique across messageboards

### DIFF
--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -5,6 +5,10 @@ module Thredded
 
     before_action :thredded_require_login!,
                   only: %i(edit new update create destroy follow unfollow)
+
+    before_action :use_topic_messageboard,
+                  only: %i(show edit update destroy follow unfollow)
+
     after_action :update_user_activity
 
     after_action :verify_authorized, except: %i(search)
@@ -172,7 +176,13 @@ module Thredded
     # @return [Thredded::Topic]
     # @raise [Thredded::Errors::TopicNotFound] if the topic with the given slug does not exist.
     def topic
-      @topic ||= messageboard.topics.friendly_find!(params[:id])
+      @topic ||= Thredded::Topic.friendly_find!(params[:id])
+    end
+
+    # Use the topic's messageboard instead of the one specified in the URL,
+    # to account for `params[:messageboard_id]` pointing to the wrong messageboard
+    def use_topic_messageboard
+      @messageboard = topic.messageboard
     end
 
     def topic_params

--- a/app/models/thredded/topic.rb
+++ b/app/models/thredded/topic.rb
@@ -22,8 +22,7 @@ module Thredded
 
     extend FriendlyId
     friendly_id :slug_candidates,
-                use:            [:history, :reserved, :scoped],
-                scope:          :messageboard,
+                use: %i(history reserved),
                 # Avoid route conflicts
                 reserved_words: ::Thredded::FriendlyIdReservedWordsAndPagination.new(%w(topics))
 
@@ -153,7 +152,8 @@ module Thredded
     def slug_candidates
       [
         :title,
-        [:title, '-topic'],
+        [:title, '-', messageboard.try(:name)],
+        [:title, '-', messageboard.try(:name), '-topic']
       ]
     end
 

--- a/db/migrate/20160329231848_create_thredded.rb
+++ b/db/migrate/20160329231848_create_thredded.rb
@@ -118,7 +118,7 @@ class CreateThredded < ActiveRecord::Migration
               order: { sticky: :desc, updated_at: :desc },
               name:  :index_thredded_topics_for_display
       t.index [:hash_id], name: :index_thredded_topics_on_hash_id
-      t.index [:messageboard_id, :slug], name: :index_thredded_topics_on_messageboard_id_and_slug, unique: true
+      t.index [:slug], name: :index_thredded_topics_on_slug, unique: true
       t.index [:messageboard_id], name: :index_thredded_topics_on_messageboard_id
       t.index [:user_id], name: :index_thredded_topics_on_user_id
     end

--- a/db/upgrade_migrations/20170420163138_upgrade_thredded_v0_11_to_v0_12.rb
+++ b/db/upgrade_migrations/20170420163138_upgrade_thredded_v0_11_to_v0_12.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+class UpgradeThreddedV011ToV012 < ActiveRecord::Migration
+  def up
+    FriendlyId::Slug.transaction do
+      FriendlyId::Slug.where(sluggable_type: 'Thredded::Topic').where(
+        slug: FriendlyId::Slug.group(:slug).having('count(id) > 1').select(:slug)
+      ).group_by(&:slug).each_value do |slugs|
+        slugs.from(1).each(&:delete)
+      end
+      FriendlyId::Slug.where(sluggable_type: 'Thredded::Topic')
+        .update_all(scope: nil)
+    end
+    Thredded::Topic.all.find_each do |topic|
+      # re-generate the slug
+      topic.title_will_change!
+      topic.save!
+    end
+    remove_index :thredded_topics, name: :index_thredded_topics_on_messageboard_id_and_slug
+    add_index :thredded_topics, [:slug], name: :index_thredded_topics_on_slug, unique: true
+  end
+
+  def down
+    fail ActiveRecord::MigrationError::IrreversibleMigration
+  end
+end

--- a/lib/thredded/version.rb
+++ b/lib/thredded/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Thredded
-  VERSION = '0.11.1'
+  VERSION = '0.12.0'
 end


### PR DESCRIPTION
This allows us to correctly redirect to the new topic URL when the topic's messageboard has changed.

Resolves #573

Needs code review!