### PR TITLE
Settings messageboards nav

### DIFF
--- a/app/assets/stylesheets/thredded/_email.scss
+++ b/app/assets/stylesheets/thredded/_email.scss
@@ -21,14 +21,13 @@
   margin: 0;
 
   &--author {
-    margin-bottom: 1em;
+    margin-bottom: 2px;
   }
 
   .thredded--post--content {
     font-size: inherit;
-    border-left: solid 5px $thredded-blockquote-border-color;
     margin: 0 0 0.75rem;
-    padding: ($thredded-small-spacing / 2) $thredded-small-spacing;
+    padding-left: 6px;
 
     .onebox-wrapper-table {
       width: 100%;

--- a/app/assets/stylesheets/thredded/components/_preferences.scss
+++ b/app/assets/stylesheets/thredded/components/_preferences.scss
@@ -1,6 +1,19 @@
-.thredded--preferences-header {
-  &--title {
-    @extend %thredded--heading;
-    font-size: 1.5rem; // 24px
+.thredded--preferences--title {
+  @extend %thredded--heading;
+  font-size: 1.5rem; // 24px
+}
+
+.thredded--preferences--form {
+  padding-bottom: $thredded-base-spacing;
+}
+
+.thredded--preferences--messageboards-nav {
+  border-top: $thredded-base-border;
+  padding-top: $thredded-base-spacing;
+}
+
+.thredded--preferences--messageboards-nav--item {
+  &.thredded--messageboard {
+    padding: $thredded-small-spacing;
   }
 }

--- a/app/controllers/thredded/preferences_controller.rb
+++ b/app/controllers/thredded/preferences_controller.rb
@@ -21,6 +21,7 @@ module Thredded
       @preferences = UserPreferencesForm.new(
         user:         thredded_current_user,
         messageboard: messageboard_or_nil,
+        messageboards: policy_scope(Messageboard.all),
         params: preferences_params
       )
     end

--- a/app/forms/thredded/user_preferences_form.rb
+++ b/app/forms/thredded/user_preferences_form.rb
@@ -22,9 +22,11 @@ module Thredded
 
     # @param user [Thredded.user_class]
     # @param messageboard [Thredded::Messageboard, nil]
-    def initialize(user:, messageboard: nil, params: {})
+    # @param messageboards [ActiveRecord::Relation<Thredded::Messageboard>]
+    def initialize(user:, messageboard: nil, messageboards: nil, params: {})
       @user = user
       @messageboard = messageboard
+      @messageboards = messageboards
       super(params)
     end
 
@@ -44,6 +46,10 @@ module Thredded
         user_messageboard_preference.save! if messageboard
       end
       true
+    end
+
+    def messageboard_groups
+      @messageboard_groups ||= MessageboardGroupView.grouped(@messageboards)
     end
 
     def notifications_for_private_topics

--- a/app/view_models/thredded/messageboard_group_view.rb
+++ b/app/view_models/thredded/messageboard_group_view.rb
@@ -5,7 +5,7 @@ module Thredded
     delegate :name, to: :@group, allow_nil: true
     attr_reader :group, :messageboards
 
-    # @param messageboard_scope [ActiveRecord::Relation]
+    # @param messageboard_scope [ActiveRecord::Relation<Thredded::Messageboard>]
     # @return [Array<MessageboardGroupView>]
     def self.grouped(messageboard_scope)
       messageboard_scope.preload(last_topic: [:last_user])

--- a/app/views/thredded/preferences/_form.html.erb
+++ b/app/views/thredded/preferences/_form.html.erb
@@ -3,8 +3,6 @@
     class: 'thredded--form thredded--notification-preferences-form',
     'data-thredded-user-preferences-form' => true
 }) do |f| %>
-
-  <h3><%= t 'thredded.preferences.form.global_preferences_label' %></h3>
   <ul class="thredded--form-list">
     <li>
       <%= f.label :auto_follow_topics do %>
@@ -52,9 +50,9 @@
     <% end %>
   </ul>
   <% if preferences.messageboard %>
-    <h3>
-      <%= t 'thredded.preferences.form.messageboard_preferences_label_html', messageboard: messageboard.name %>
-    </h3>
+    <h2 class="thredded--preferences--title">
+      <%= t 'thredded.preferences.messageboard_preferences_title_html', messageboard: messageboard.name %>
+    </h2>
     <ul class="thredded--form-list" data-thredded-user-preferences-form-messageboard-fields>
       <li>
         <%= f.label :messageboard_auto_follow_topics do %>

--- a/app/views/thredded/preferences/_header.html.erb
+++ b/app/views/thredded/preferences/_header.html.erb
@@ -1,1 +1,0 @@
-<h1 class="thredded--preferences-header--title"><%= t 'thredded.preferences.form.title' %></h1>

--- a/app/views/thredded/preferences/_messageboards_nav.html.erb
+++ b/app/views/thredded/preferences/_messageboards_nav.html.erb
@@ -1,0 +1,8 @@
+<% preferences.messageboard_groups.each do |group| %>
+  <h3 class="thredded--messageboards-group--title"><%= group.name %></h3>
+  <div class="thredded--messageboards-group">
+    <%= render partial: 'thredded/preferences/messageboards_nav_item',
+               collection: group.messageboards,
+               as: :messageboard %>
+  </div>
+<% end %>

--- a/app/views/thredded/preferences/_messageboards_nav_item.html.erb
+++ b/app/views/thredded/preferences/_messageboards_nav_item.html.erb
@@ -1,0 +1,2 @@
+<%= link_to messageboard.name, edit_messageboard_preferences_path(messageboard),
+            class: 'thredded--preferences--messageboards-nav--item thredded--messageboard' %>

--- a/app/views/thredded/preferences/edit.html.erb
+++ b/app/views/thredded/preferences/edit.html.erb
@@ -3,8 +3,18 @@
 <% content_for :thredded_breadcrumbs, render('thredded/shared/breadcrumbs') %>
 
 <%= thredded_page do %>
-  <section class="thredded--main-section preferences">
-    <%= render 'thredded/preferences/header' %>
-    <%= render 'thredded/preferences/form', preferences: @preferences %>
+  <section class="thredded--main-section thredded--preferences">
+    <section class="thredded--preferences--form">
+      <h2 class="thredded--preferences--title"><%= t 'thredded.preferences.global_preferences_title' %></h2>
+      <%= render 'thredded/preferences/form', preferences: @preferences %>
+    </section>
+    <% unless preferences.messageboard %>
+      <section class="thredded--preferences--messageboards-nav">
+        <h2 class="thredded--preferences--title">
+          <%= t 'thredded.preferences.messageboard_preferences_nav_title' %>
+        </h2>
+        <%= render 'thredded/preferences/messageboards_nav', preferences: @preferences %>
+      </section>
+    <% end %>
   </section>
 <% end %>

--- a/app/views/thredded/theme_previews/show.html.erb
+++ b/app/views/thredded/theme_previews/show.html.erb
@@ -103,7 +103,7 @@
 
   <%= render 'section_title', label: 'preferences#edit', href: edit_messageboard_preferences_path(@messageboard) %>
   <%= content_tag :section, class: 'thredded--thredded--main-section preferences' do %>
-    <%= render 'thredded/preferences/header' %>
+    <h2 class="thredded--preferences-header--title"><%= t 'thredded.preferences.global_preferences_title' %></h2>
     <%= render 'thredded/preferences/form', preferences: @preferences %>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,7 +92,6 @@ en:
         follow_topics_on_mention:
           hint: 'When someone mentions you by your username (eg: @sam) you will follow the topic.'
           label: Follow topics you are mentioned in
-        global_preferences_label: Global Settings
         messageboard_auto_follow_topics:
           hint: Automatically follow all new topics in this messageboard. This overrides the respective setting
             above.
@@ -103,14 +102,15 @@ en:
           label: :thredded.preferences.form.follow_topics_on_mention.label
         messageboard_notifications_for_followed_topics:
           label: :thredded.preferences.form.notifications_for_followed_topics.label
-        messageboard_preferences_label_html: Notification Settings for <em>%{messageboard}</em>
         notifications_for_followed_topics:
           label: Notifications for followed topics
         notifications_for_private_topics:
           label: Notifications for private messages
         submit_btn: Update Settings
-        title: Settings
         update_btn_submitting: :thredded.form.update_btn_submitting
+      global_preferences_title: Global Settings
+      messageboard_preferences_nav_title: Messageboard Settings
+      messageboard_preferences_title_html: Settings for <em>%{messageboard}</em>
       updated_notice: Your settings have been updated.
     private_posts:
       form:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -93,7 +93,6 @@ es:
         follow_topics_on_mention:
           hint: 'Cuando alguien te menciona usando tu nombre de usuario (por ejemplo: @sam), seguirás el tema.'
           label: Sigue temas en los que seas mencionado
-        global_preferences_label: Ajustes Generales
         messageboard_auto_follow_topics:
           hint: >-
             Sigue automáticamente todos los nuevos temas en este tablero de mensajes. Esto anula la configuración
@@ -105,14 +104,15 @@ es:
           label: :thredded.preferences.form.follow_topics_on_mention.label
         messageboard_notifications_for_followed_topics:
           label: :thredded.preferences.form.notifications_for_followed_topics.label
-        messageboard_preferences_label_html: Ajustes de Notificaciones para <em>%{messageboard}</em>
         notifications_for_followed_topics:
           label: Notificaciones de temas seguidos
         notifications_for_private_topics:
           label: Notificaciones de mensajes privados
         submit_btn: Actualizar Ajustes
-        title: Ajustes
         update_btn_submitting: :thredded.form.update_btn_submitting
+      global_preferences_title: Ajustes Generales
+      messageboard_preferences_nav_title: Ajustes por foro
+      messageboard_preferences_title_html: Ajustes de Notificaciones para <em>%{messageboard}</em>
       updated_notice: Tus ajustes han sido actualizados.
     private_posts:
       form:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -93,7 +93,6 @@ pl:
         follow_topics_on_mention:
           hint: 'Gdy ktoś w temacie wspomni o Tobie (np.: @sam) zaczniesz obserwować ten temat.'
           label: Obserwuj tematy, w których zostałeś wspomiany
-        global_preferences_label: Ustawienia powiadomień
         messageboard_auto_follow_topics:
           hint: Automatycznie śledzić wszystkie nowe tematy na tym messageboard. To zastępuje odpowiednie ustawienie
             powyżej.
@@ -103,14 +102,15 @@ pl:
           label: :thredded.preferences.form.follow_topics_on_mention.label
         messageboard_notifications_for_followed_topics:
           label: :thredded.preferences.form.notifications_for_followed_topics.label
-        messageboard_preferences_label_html: Notification Settings for <em>%{messageboard}</em>
         notifications_for_followed_topics:
           label: Powiadomienia z obserwowanych tematów
         notifications_for_private_topics:
           label: Powiadomienia z prywatnych wiadomości
         submit_btn: Zaktualizuj ustawienia
-        title: Ustawienia
         update_btn_submitting: :thredded.form.update_btn_submitting
+      global_preferences_title: Ustawienia powiadomień
+      messageboard_preferences_nav_title: Ustawienia na tablicę
+      messageboard_preferences_title_html: Notification Settings for <em>%{messageboard}</em>
       updated_notice: Twoje ustawienia zostały zaktualizowane.
     private_posts:
       form:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -94,7 +94,6 @@ pt-BR:
             Quando alguém mencionar você através do seu usuário (ex.: @sam) você irá receber um e-mail com o conteúdo
             deste post.
           label: Siga os tópicos que são mencionados na
-        global_preferences_label: Configurações Globais
         messageboard_auto_follow_topics:
           hint: siga automaticamente todos os novos tópicos neste messageboard. Isso substitui a respectiva definição
             acima.
@@ -106,14 +105,15 @@ pt-BR:
           label: :thredded.preferences.form.follow_topics_on_mention.label
         messageboard_notifications_for_followed_topics:
           label: :thredded.preferences.form.notifications_for_followed_topics.label
-        messageboard_preferences_label_html: Configurações de Notificação para <em>%{messageboard}</em>
         notifications_for_followed_topics:
           label: Notificações para tópicos seguido
         notifications_for_private_topics:
           label: Notificações de mensagens privadas
         submit_btn: Atualizar Configurações
-        title: Configurações
         update_btn_submitting: :thredded.form.update_btn_submitting
+      global_preferences_title: Configurações Globais
+      messageboard_preferences_nav_title: Configurações por Fórum de Mensagem
+      messageboard_preferences_title_html: Configurações de Notificação para <em>%{messageboard}</em>
       updated_notice: Suas configurações foram atualizadas.
     private_posts:
       form:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -188,16 +188,16 @@ ru:
       last_active_html: Последняя активность %{time_ago}
       posted_in_topic_html: Сделан пост в %{topic_link}
       posts_count:
-        one: Сделан %{count} пост
         few: Сделано %{count} поста
         many: Сделано %{count} постов
+        one: Сделан %{count} пост
         other: Сделано %{count} постов
       recent_activity: :thredded.recent_activity
       started_topic_html: Начато %{topic_link}
       started_topics_count:
-        one: Начата %{count} тема
         few: Начато %{count} темы
         many: Начато %{count} тем
+        one: Начата %{count} тема
         other: Начато %{count} тем
       user_posted_in_topic_html: "%{user_link} сделал запись в %{topic_link}"
       user_since_html: Пользователь был %{time_ago}

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -66,7 +66,7 @@ ru:
       moderation_pending: В ожидании
       moderation_users: Пользователи
       private_topics: Личное
-      settings: Уведомления
+      settings: Настройки
     null_user_name: Пользователь удален
     posts:
       delete: Удалить пост
@@ -92,7 +92,6 @@ ru:
         follow_topics_on_mention:
           hint: 'Когда кто-то упоминает вас на форуме (например: @sam), Вы будете наблюдать за этой темой.'
           label: Наблюдать за темой, в которой Вы упомянуты
-        global_preferences_label: Настройки форума
         messageboard_auto_follow_topics:
           hint: Автоматически следовать все новые темы в этом ОБЪЯВЛЕНИЯ. Это отменяет соответствующую настройку
             выше.
@@ -102,14 +101,15 @@ ru:
           label: :thredded.preferences.form.follow_topics_on_mention.label
         messageboard_notifications_for_followed_topics:
           label: :thredded.preferences.form.notifications_for_followed_topics.label
-        messageboard_preferences_label_html: Настройки уведомлений для <em>%{messageboard}</em>
         notifications_for_followed_topics:
           label: Уведомления для отслеживаемых тем
         notifications_for_private_topics:
           label: Уведомления для личных сообщений
         submit_btn: Сохранить настройки
-        title: Настройки
         update_btn_submitting: :thredded.form.update_btn_submitting
+      global_preferences_title: Общие настройки
+      messageboard_preferences_nav_title: Настройки форума
+      messageboard_preferences_title_html: Настройки уведомлений для <em>%{messageboard}</em>
       updated_notice: Ваши настройки были обновлены.
     private_posts:
       form:


### PR DESCRIPTION
On https://plforums.org a few users asked me to add per-messageboard notification settings.
While explaining that this is possible I realized that it is not easily discoverable from the global settings page.

I'm not sure what the best UI for this is. Here is my first take:

![messageboard-settings](https://cloud.githubusercontent.com/assets/216339/25506853/a410ba36-2ba0-11e7-9013-5bece56421e1.png)