### PR TITLE
Basic "Quote" reply

### DIFF
--- a/app/assets/javascripts/thredded/components/quote_post.es6
+++ b/app/assets/javascripts/thredded/components/quote_post.es6
@@ -1,0 +1,45 @@
+(function() {
+  window.Thredded.onPageLoad(() => {
+    Array.prototype.forEach.call(document.querySelectorAll('[data-thredded-quote-post]'), (el) => {
+      el.addEventListener('click', onClick);
+    });
+  });
+
+  function onClick(evt) {
+    // Handle only left clicks with no modifier keys
+    if (evt.button !== 0 || evt.ctrlKey || evt.altKey || evt.metaKey || evt.shiftKey) return;
+    evt.preventDefault();
+    const target = document.getElementById('post_content');
+    target.scrollIntoView();
+    target.value = '...';
+    fetchReply(evt.target.getAttribute('data-thredded-quote-post'), (replyText) => {
+      if (!target.ownerDocument.body.contains(target)) return;
+      target.focus();
+      target.value = replyText;
+
+      const autosizeUpdateEvent = document.createEvent('Event');
+      autosizeUpdateEvent.initEvent('autosize:update', true, false);
+      target.dispatchEvent(autosizeUpdateEvent);
+      // Scroll into view again as the size might have changed.
+      target.scrollIntoView();
+    }, (errorMessage) => {
+      target.value = errorMessage;
+    });
+  }
+
+  function fetchReply(url, onSuccess, onError) {
+    const request = new XMLHttpRequest();
+    request.open('GET', url, /* async */ true);
+    request.onload = () => {
+      if (request.status >= 200 && request.status < 400) {
+        onSuccess(request.responseText);
+      } else {
+        onError(`Error (${request.status}): ${request.statusText} ${request.responseText}`);
+      }
+    };
+    request.onerror = () => {
+      onError('Network Error');
+    };
+    request.send();
+  }
+})();

--- a/app/controllers/concerns/thredded/new_post_params.rb
+++ b/app/controllers/concerns/thredded/new_post_params.rb
@@ -6,8 +6,15 @@ module Thredded
 
     def new_post_params
       params.fetch(:post, {})
-        .permit(:content)
-        .merge(ip: request.remote_ip)
+        .permit(:content, :quote_post_id)
+        .merge(ip: request.remote_ip).tap do |p|
+        quote_id = p.delete(:quote_post_id)
+        if quote_id
+          post = Post.find(quote_id)
+          authorize_reading post
+          p[:quote_post] = post
+        end
+      end
     end
   end
 end

--- a/app/controllers/concerns/thredded/new_private_post_params.rb
+++ b/app/controllers/concerns/thredded/new_private_post_params.rb
@@ -6,8 +6,15 @@ module Thredded
 
     def new_private_post_params
       params.fetch(:post, {})
-        .permit(:content)
-        .merge(ip: request.remote_ip)
+        .permit(:content, :quote_private_post_id)
+        .merge(ip: request.remote_ip).tap do |p|
+        quote_id = p.delete(:quote_private_post_id)
+        if quote_id
+          post = PrivatePost.find(quote_id)
+          authorize_reading post
+          p[:quote_post] = post
+        end
+      end
     end
   end
 end

--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -55,6 +55,11 @@ module Thredded
       after_mark_as_unread # customization hook
     end
 
+    def quote
+      authorize_reading post
+      render plain: Thredded::ContentFormatter.quote_content(post.content)
+    end
+
     private
 
     def canonical_topic_params

--- a/app/controllers/thredded/private_posts_controller.rb
+++ b/app/controllers/thredded/private_posts_controller.rb
@@ -58,6 +58,11 @@ module Thredded
       after_mark_as_unread # customization hook
     end
 
+    def quote
+      authorize_reading post
+      render plain: Thredded::ContentFormatter.quote_content(post.content)
+    end
+
     private
 
     def canonical_topic_params

--- a/app/forms/thredded/post_form.rb
+++ b/app/forms/thredded/post_form.rb
@@ -16,6 +16,11 @@ module Thredded
       @messageboard = topic.messageboard
       @topic = topic
       @post = post ? post : topic.posts.build
+
+      if post_params.include?(:quote_post)
+        post_params[:content] =
+          Thredded::ContentFormatter.quote_content(post_params.delete(:quote_post).content)
+      end
       @post.attributes = post_params.merge(
         user: (user unless user.thredded_anonymous?),
         messageboard: topic.messageboard

--- a/app/forms/thredded/private_post_form.rb
+++ b/app/forms/thredded/private_post_form.rb
@@ -15,6 +15,11 @@ module Thredded
     def initialize(user:, topic:, post: nil, post_params: {})
       @topic = topic
       @post = post ? post : topic.posts.build
+
+      if post_params.include?(:quote_post)
+        post_params[:content] =
+          Thredded::ContentFormatter.quote_content(post_params.delete(:quote_post).content)
+      end
       @post.attributes = post_params.merge(user: (user unless user.thredded_anonymous?))
     end
 

--- a/app/helpers/thredded/urls_helper.rb
+++ b/app/helpers/thredded/urls_helper.rb
@@ -104,6 +104,14 @@ module Thredded
       end
     end
 
+    def quote_post_path(post)
+      if post.private_topic_post?
+        quote_private_topic_private_post_path(post.postable, post)
+      else
+        quote_messageboard_topic_post_path(post.messageboard, post.postable, post)
+      end
+    end
+
     def mark_unread_path(post, _params = {})
       if post.private_topic_post?
         mark_as_unread_private_topic_private_post_path(post.postable, post)

--- a/app/policies/thredded/private_topic_policy.rb
+++ b/app/policies/thredded/private_topic_policy.rb
@@ -17,7 +17,7 @@ module Thredded
     end
 
     def update?
-      @user.id == @private_topic.user_id
+      !@user.thredded_anonymous? && @user.id == @private_topic.user_id
     end
   end
 end

--- a/app/view_models/thredded/post_view.rb
+++ b/app/view_models/thredded/post_view.rb
@@ -14,12 +14,16 @@ module Thredded
              to: :@post
 
     # @param post [Thredded::PostCommon]
-    # @param policy [#update? #destroy?]
-    # @param policy [Thredded::TopicView]
+    # @param policy [#create? #update? #destroy? #moderate?]
+    # @param topic_view [Thredded::TopicView]
     def initialize(post, policy, topic_view: nil)
       @post   = post
       @policy = policy
       @topic_view = topic_view
+    end
+
+    def can_reply?
+      @can_reply ||= @policy.create?
     end
 
     def can_update?
@@ -32,6 +36,18 @@ module Thredded
 
     def can_moderate?
       @can_moderate ||= @policy.moderate?
+    end
+
+    def quote_url_params
+      if @post.private_topic_post?
+        { post: { quote_private_post_id: @post.id } }
+      else
+        { post: { quote_post_id: @post.id } }
+      end.update(anchor: 'post_content')
+    end
+
+    def quote_path
+      Thredded::UrlsHelper.quote_post_path(@post)
     end
 
     def edit_path

--- a/app/views/thredded/posts_common/_actions.html.erb
+++ b/app/views/thredded/posts_common/_actions.html.erb
@@ -1,5 +1,8 @@
 <% actions = capture do %>
   <%= view_hooks.post_common.actions.render self, post: post do %>
+    <% if post.can_reply? %>
+      <%= render 'thredded/posts_common/actions/quote', post: post %>
+    <% end  %>
     <% if post.can_update? %>
       <%= render 'thredded/posts_common/actions/edit', post: post %>
     <% end %>

--- a/app/views/thredded/posts_common/actions/_quote.html.erb
+++ b/app/views/thredded/posts_common/actions/_quote.html.erb
@@ -1,0 +1,4 @@
+<%= link_to t('thredded.posts.quote_btn'), url_for(post.quote_url_params),
+            'data-thredded-quote-post' => post.quote_path,
+            class: 'thredded--post--quote thredded--post--dropdown--actions--item',
+            rel: 'nofollow' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
         update_btn: Update Post
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Your post will be published when it has been reviewed by a moderator.
+      quote_btn: Quote
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -82,6 +82,7 @@ es:
         update_btn: Actualizar Mensaje
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Tu post será publicado cuando haya sido revisado por un moderador.
+      quote_btn: Citar
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -82,6 +82,7 @@ pl:
         update_btn: Zaktualizuj post
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Twój post zostanie zamieszczony po zweryfikowaniu go przez moderatora.
+      quote_btn: Zacytować
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -82,6 +82,7 @@ pt-BR:
         update_btn: Atualizar Post
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: O envio da mensagem será publicada quando foi revisado por um moderador.
+      quote_btn: Citar
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -81,6 +81,7 @@ ru:
         update_btn: Обновить пост
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Ваш пост будет опубликован, когда будет одобрен модератором.
+      quote_btn: Цитировать
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
         post :preview, on: :new, controller: 'private_post_previews'
         resource :preview, only: [:update], controller: 'private_post_previews'
         member do
+          get 'quote'
           post 'mark_as_unread'
         end
       end
@@ -74,6 +75,7 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
         post :preview, on: :new, controller: 'post_previews'
         resource :preview, only: [:update], controller: 'post_previews'
         member do
+          get 'quote'
           post 'mark_as_unread'
         end
       end

--- a/lib/thredded/content_formatter.rb
+++ b/lib/thredded/content_formatter.rb
@@ -99,6 +99,17 @@ module Thredded
       # rubocop:enable Rails/OutputSafety
     end
 
+    # @param content [String]
+    # @return [String] a quote containing the formatted content
+    def self.quote_content(content)
+      result = String.new(content)
+      result.gsub!(/^(?!$)/, '> ')
+      result.gsub!(/^$/, '>')
+      result << "\n" unless result.end_with?("\n")
+      result << "\n"
+      result
+    end
+
     protected
 
     # @return [Array<HTML::Pipeline::Filter]>]

--- a/spec/features/thredded/user_replies_to_post_spec.rb
+++ b/spec/features/thredded/user_replies_to_post_spec.rb
@@ -2,16 +2,33 @@
 require 'spec_helper'
 
 feature 'User replying to topic' do
-  scenario 'adds a new reply' do
+  let(:posts) { posts_exist_in_a_topic }
+  let(:post) { posts.first_post }
+  before do
     user.log_in
-
-    posts = posts_exist_in_a_topic
     posts.visit_posts
-    expect(posts.posts.size).to eq(2)
+  end
 
-    posts.submit_reply
-    expect(posts.posts.size).to eq(3)
+  scenario 'adds a new reply' do
+    expect { posts.submit_reply }.to change { posts.posts.size }.by(1)
     expect(posts).to have_new_reply
+  end
+
+  scenario 'starts a quote-reply (no js)' do
+    post.start_quote
+    expect(page).to have_current_path(posts.quote_page_for_first_post)
+    expect(posts.post_form.content).to(start_with('>').and(end_with("\n\n")))
+  end
+
+  scenario 'starts a quote-reply (js)', js: true do
+    post.start_quote
+    # Expect current path to not change because the JS magic takes place
+    expect(page).to have_current_path(current_path)
+    # Wait for the async quote content fetch completion
+    Timeout.timeout(1) do
+      loop { break if posts.post_form.content != '...' }
+    end
+    expect(posts.post_form.content).to(start_with('>').and(end_with("\n\n")))
   end
 
   def user

--- a/spec/lib/thredded/content_formatter_spec.rb
+++ b/spec/lib/thredded/content_formatter_spec.rb
@@ -112,4 +112,10 @@ Hello
       expect { format_content(FakeContent::ONEBOXES.join("\n")) }.to_not raise_error
     end
   end
+
+  context '.quote_content' do
+    it 'quotes as markdown' do
+      expect(Thredded::ContentFormatter.quote_content('Hello')).to eq "> Hello\n\n"
+    end
+  end
 end

--- a/spec/support/features/page_object/post.rb
+++ b/spec/support/features/page_object/post.rb
@@ -39,6 +39,19 @@ module PageObject
       click_on I18n.t('thredded.posts.form.update_btn')
     end
 
+    def start_quote
+      open_post_actions
+      within css_selector do
+        click_on I18n.t('thredded.posts.quote_btn')
+      end
+    end
+
+    def open_post_actions
+      within css_selector do
+        find('.thredded--post--dropdown').click
+      end
+    end
+
     def css_selector
       "article#post_#{post.id}"
     end

--- a/spec/support/features/page_object/post_form.rb
+++ b/spec/support/features/page_object/post_form.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'support/features/page_object/base'
+
+module PageObject
+  class PostForm < Base
+    def content
+      find('#post_content')[:value]
+    end
+  end
+end

--- a/spec/support/features/page_object/posts.rb
+++ b/spec/support/features/page_object/posts.rb
@@ -33,6 +33,28 @@ module PageObject
       has_css?('strong', text: content)
     end
 
+    def first_post
+      PageObject::Post.new(@posts.first)
+    end
+
+    def post_form
+      PageObject::PostForm.new
+    end
+
+    def quote_page_for_post(post)
+      messageboard_topic_path(
+        topic.messageboard.slug,
+        topic.slug,
+        post: {
+          quote_post_id: post.id
+        }
+      )
+    end
+
+    def quote_page_for_first_post
+      quote_page_for_post(@posts.first)
+    end
+
     private
 
     attr_reader :messageboard, :topic


### PR DESCRIPTION
Adds a "Quote" button that populates the post form with the quoted
content.

The quote can be customized by overriding a method in Thredded::ContentFormatter,
though the API will likely need to be enhanced in the future (e.g. to
support adding a link to the original post).

![opt2](https://cloud.githubusercontent.com/assets/216339/25644337/36926f80-2f9d-11e7-808e-9105bddbad84.gif)
