### PR TITLE
Use timeago.js instead of jquery.timeago

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,27 @@ echo '//= require rails-ujs' > app/assets/javascripts/thredded/dependencies/ujs.
 
 The default UJS framework will change from `jquery_ujs` to `rails-ujs` in the upcoming Thredded v0.13.0 release.
 
+##### Timeago version
+
+By default, thredded loads `timeago.js`.
+
+If you'd like to use `jquery.timeago` or `rails-timeago` instead, run this command from your app directory:
+
+```bash
+mkdir -p app/assets/javascripts/thredded/dependencies/
+echo '//= require jquery.timeago' > app/assets/javascripts/thredded/dependencies/timeago.js
+```
+
+You will also need to adjust the `//= require` statements for timeago locales if your site is translated into multiple
+languages. For `jquery.timeago`, these need to be require after `thredded/dependencies` but before `thredded/thredded`.
+E.g. for Brazilian Portuguese:
+
+ ```js
+ //= require thredded/dependencies
+ //= require locales/jquery.timeago.pt-br
+ //= require thredded/thredded
+ ```
+
 #### Thredded page title and ID
 
 Thredded views also provide two `content_tag`s available to yield - `:thredded_page_title` and `:thredded_page_id`.
@@ -384,13 +405,10 @@ Here are the steps to ensure the best support for your language if it isn't Engl
 
 1. Add `rails-i18n` and `kaminari-i18n` to your Gemfile.
 
-2. Require the translations for rails-timeago in your JavaScript before `thredded` but after `jquery.timeago`
-   (included in `thredded/dependencies`). E.g. for Brazilian Portuguese:
+2. Require the translations for timeago.js in your JavaScript. E.g. for Brazilian Portuguese:
 
    ```js
-   //= require thredded/dependencies
-   //= require locales/jquery.timeago.pt-br
-   //= require thredded/thredded
+   //= require timeago/locales/pt_BR
    ```
 
 3. To generate URL slugs for messageboards, categories, and topics with support for more language than English,

--- a/app/assets/javascripts/thredded/components/time_stamps.es6
+++ b/app/assets/javascripts/thredded/components/time_stamps.es6
@@ -1,10 +1,25 @@
-(($) => {
+(() => {
   const COMPONENT_SELECTOR = '#thredded--container [data-time-ago]';
-
-  window.Thredded.onPageLoad(() => {
-    const allowFutureWas = jQuery.timeago.settings.allowFuture;
-    $.timeago.settings.allowFuture = true;
-    $(COMPONENT_SELECTOR).timeago();
-    $.timeago.settings.allowFuture = allowFutureWas;
-  });
-})(jQuery);
+  const Thredded = window.Thredded;
+  if ('timeago' in window) {
+    const timeago = window.timeago;
+    Thredded.onPageLoad(() => {
+      const threddedContainer = document.querySelector('#thredded--container');
+      if (!threddedContainer) return;
+      timeago().render(
+        document.querySelectorAll(COMPONENT_SELECTOR),
+        threddedContainer.getAttribute('data-thredded-locale'));
+    });
+    document.addEventListener('turbolinks:before-cache', () => {
+      timeago.cancel();
+    });
+  } else if ('jQuery' in window && 'timeago' in jQuery.fn) {
+    const $ = window.jQuery;
+    Thredded.onPageLoad(() => {
+      const allowFutureWas = $.timeago.settings.allowFuture;
+      $.timeago.settings.allowFuture = true;
+      $(COMPONENT_SELECTOR).timeago();
+      $.timeago.settings.allowFuture = allowFutureWas;
+    });
+  }
+})();

--- a/app/assets/javascripts/thredded/dependencies.js
+++ b/app/assets/javascripts/thredded/dependencies.js
@@ -1,6 +1,5 @@
 //= require thredded/dependencies/jquery
-// Require jquery.timeago instead of rails-timeago so that we can control the initialization.
-//= require jquery.timeago
+//= require thredded/dependencies/timeago
 //= require thredded/dependencies/ujs
 //= require autosize
 //= require jquery.textcomplete

--- a/app/assets/javascripts/thredded/dependencies/timeago.js
+++ b/app/assets/javascripts/thredded/dependencies/timeago.js
@@ -1,0 +1,1 @@
+//= require timeago

--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -13,6 +13,7 @@ module Thredded
 
     def thredded_container_data
       {
+        'thredded-locale' => I18n.locale,
         'thredded-page-id' => content_for(:thredded_page_id),
         'thredded-root-url' => thredded.root_path
       }
@@ -52,22 +53,19 @@ module Thredded
     # @param datetime [DateTime]
     # @param default [String] a string to return if time is nil.
     # @return [String] html_safe datetime presentation
-    def time_ago(datetime, default: '-')
-      timeago_tag datetime,
-                  lang: I18n.locale.to_s.downcase,
-                  format: ->(t, _opts) { t.year == Time.current.year ? :short : :long },
-                  nojs: true,
-                  date_only: false,
-                  default: default
-    end
-
-    # Override the default timeago_tag_content from rails-timeago
-    def timeago_tag_content(time, time_options = {})
-      if time_options[:nojs] && (time_options[:limit].nil? || time_options[:limit] < time)
-        t 'thredded.time_ago', time: time_ago_in_words(time)
+    def time_ago(datetime, default: '-', html_options: {})
+      return content_tag :time, default if datetime.nil?
+      html_options = html_options.dup
+      is_current_year = datetime.year == Time.current.year
+      if datetime > 4.days.ago
+        content = t 'thredded.time_ago', time: time_ago_in_words(datetime)
+        html_options['data-time-ago'] = true unless html_options.key?('data-time-ago')
       else
-        I18n.l time.to_date, format: time_options[:format]
+        content = I18n.l(datetime.to_date,
+                         format: (is_current_year ? :short : :long))
       end
+      html_options[:title] = I18n.l(datetime) unless html_options.key?(:title)
+      time_tag datetime, content, html_options
     end
 
     # @param posts [Thredded::PostsPageView, Array<Thredded::PostView>]

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -25,7 +25,7 @@ require 'thredded/html_pipeline/wrap_iframes_filter'
 # Asset compilation
 require 'autoprefixer-rails'
 require 'jquery/rails'
-require 'rails-timeago'
+require 'timeago_js'
 require 'select2-rails'
 require 'sprockets/es6'
 

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -1,10 +1,9 @@
 //= require jquery3
 //= require jquery_ujs
 //= require turbolinks
-//= require thredded/dependencies
-//= require locales/jquery.timeago.es
-//= require locales/jquery.timeago.pl
-//= require locales/jquery.timeago.pt-br
-//= require locales/jquery.timeago.ru
-//= require thredded/thredded
+//= require thredded
+//= require timeago/locales/es
+//= require timeago/locales/pl
+//= require timeago/locales/pt_BR
+//= require timeago/locales/ru
 //= require_tree ./app

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -48,7 +48,7 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
   # frontend
   s.add_dependency 'sass', '>= 3.4.21'
   s.add_dependency 'autoprefixer-rails'
-  s.add_dependency 'rails-timeago'
+  s.add_dependency 'timeago_js'
   s.add_dependency 'select2-rails', '~> 3.5'
   s.add_dependency 'sprockets-es6'
   s.add_dependency 'jquery-rails', '>= 4.2.1'


### PR DESCRIPTION
Benefits:

1. Smaller and faster.
2. Does not depend on jQuery.
3. Simpler i18n instructions (does not require a specific order of `//= require`s).
4. Translations are closer to the Rails ones, resulting in fewer changes to the page as the JavaScript initializes.

This keeps the support for jquery.timeago, so main_apps that already use it do not have to switch.

Links: [timeago.js](https://github.com/hustcc/timeago.js), [rubygem](https://github.com/glebm/timeago_js-rubygem).

To be merged close to the v0.13.0 release.

Refs #593 