### PR TITLE
Localize the emails

### DIFF
--- a/app/mailer_previews/thredded/private_topic_mailer_preview.rb
+++ b/app/mailer_previews/thredded/private_topic_mailer_preview.rb
@@ -4,12 +4,8 @@ module Thredded
   # Previews for the PrivateTopicMailer
   class PrivateTopicMailerPreview < BaseMailerPreview
     def message_notification
-      post = mock_private_post(content: mock_content(mention_users: ['glebm']))
       PrivateTopicMailer.message_notification(
-        mock_private_topic(posts: [
-                             post
-                           ]),
-        post,
+        mock_private_post(content: mock_content(mention_users: ['glebm'])),
         %w[glebm@test.com joel@test.com]
       )
     end

--- a/app/mailers/thredded/post_mailer.rb
+++ b/app/mailers/thredded/post_mailer.rb
@@ -3,14 +3,19 @@
 module Thredded
   class PostMailer < Thredded::BaseMailer
     def post_notification(post_id, emails)
-      @post                = find_record Thredded::Post, post_id
-      email_details        = Thredded::TopicEmailView.new(@post.postable)
+      @post = find_record Thredded::Post, post_id
+      email_details = Thredded::TopicEmailView.new(@post.postable)
       headers['X-SMTPAPI'] = email_details.smtp_api_tag('post_notification')
 
-      mail from:     email_details.no_reply,
-           to:       email_details.no_reply,
-           bcc:      emails,
-           subject:  email_details.subject
+      mail from: email_details.no_reply,
+           to: email_details.no_reply,
+           bcc: emails,
+           subject: [
+             Thredded.email_outgoing_prefix,
+             t('thredded.emails.post_notification.subject',
+               user: @post.user.thredded_display_name,
+               topic_title: @post.postable.title)
+           ].compact.join
     end
   end
 end

--- a/app/mailers/thredded/private_topic_mailer.rb
+++ b/app/mailers/thredded/private_topic_mailer.rb
@@ -2,16 +2,20 @@
 
 module Thredded
   class PrivateTopicMailer < Thredded::BaseMailer
-    def message_notification(private_topic_id, post_id, emails)
-      @topic               = find_record Thredded::PrivateTopic, private_topic_id
-      @post                = find_record Thredded::PrivatePost, post_id
-      email_details        = Thredded::TopicEmailView.new(@topic)
+    def message_notification(post_id, emails)
+      @post = find_record Thredded::PrivatePost, post_id
+      email_details = Thredded::TopicEmailView.new(@post.postable)
       headers['X-SMTPAPI'] = email_details.smtp_api_tag('private_topic_mailer')
 
-      mail from:     email_details.no_reply,
-           to:       email_details.no_reply,
-           bcc:      emails,
-           subject:  email_details.subject
+      mail from: email_details.no_reply,
+           to: email_details.no_reply,
+           bcc: emails,
+           subject: [
+             Thredded.email_outgoing_prefix,
+             t('thredded.emails.message_notification.subject',
+               user: @post.user.thredded_display_name,
+               topic_title: @post.postable.title)
+           ].compact.join
     end
   end
 end

--- a/app/notifiers/thredded/email_notifier.rb
+++ b/app/notifiers/thredded/email_notifier.rb
@@ -15,7 +15,7 @@ module Thredded
     end
 
     def new_private_post(post, users)
-      PrivateTopicMailer.message_notification(post.postable.id, post.id, users.map(&:email)).deliver_now
+      PrivateTopicMailer.message_notification(post.id, users.map(&:email)).deliver_now
     end
   end
 end

--- a/app/view_models/thredded/topic_email_view.rb
+++ b/app/view_models/thredded/topic_email_view.rb
@@ -11,10 +11,6 @@ module Thredded
       %({"category": ["thredded_#{@topic.private? ? 'private_topic' : @topic.messageboard.name}","#{tag}"]})
     end
 
-    def subject
-      "#{Thredded.email_outgoing_prefix} #{@topic.title}"
-    end
-
     def no_reply
       Thredded.email_from
     end

--- a/app/views/thredded/post_mailer/post_notification.html.erb
+++ b/app/views/thredded/post_mailer/post_notification.html.erb
@@ -1,7 +1,10 @@
 <div class="thredded--email">
   <figure class="thredded--email-post">
     <figcaption class="thredded--email-post--author">
-      <%= @post.user.thredded_display_name %> <%= link_to 'said', post_permalink_url(@post) %>:
+      <%= t 'thredded.emails.post_notification.html.post_lead_html',
+            user: @post.user.thredded_display_name,
+            post_url: post_permalink_url(@post.id),
+            topic_title: @post.postable.title %>
     </figcaption>
     <% cache [@post, 'content-onebox-placeholders'] do %>
       <%= render partial: 'thredded/posts/content',
@@ -11,13 +14,13 @@
   <hr/>
 
   <p>
-    This email was sent to you because you are following this topic
-    "<%= link_to @post.postable.title, post_permalink_url(@post.id) %>".
-    <%= link_to 'View the conversation here', topic_url(@post.postable) %>.
+    <%= t 'thredded.emails.post_notification.html.email_sent_reason_html',
+          post_url: post_permalink_url(@post.id),
+          topic_title: @post.postable.title %>
   </p>
 
   <p>
-    To unsubscribe from these emails, update your
-    <%= link_to 'preferences', edit_messageboard_preferences_url(@post.messageboard) %>.
+    <%= t 'thredded.emails.post_notification.html.unsubscribe_instructions_html',
+          preferences_url: edit_messageboard_preferences_url(@post.messageboard) %>
   </p>
 </div>

--- a/app/views/thredded/post_mailer/post_notification.text.erb
+++ b/app/views/thredded/post_mailer/post_notification.text.erb
@@ -1,10 +1,14 @@
+<%= t 'thredded.emails.post_notification.text.post_lead',
+      user: @post.user.thredded_display_name,
+      topic_title: @post.postable.title %>
+
 <%= @post.content %>
 
 ---
 
-This email was sent to you because you are following this topic
-"<%= @post.postable.title %>". Go here to view the conversation:
-<%= post_permalink_url @post %>
+<%= t 'thredded.emails.post_notification.text.email_sent_reason',
+      topic_title: @post.postable.title,
+      post_url: post_permalink_url(@post.id) %>
 
-To unsubscribe from these emails, update your preferences here:
-  <%= edit_messageboard_preferences_url @post.messageboard %>
+<%= t 'thredded.emails.post_notification.text.unsubscribe_instructions',
+      unsubscribe_url: edit_messageboard_preferences_url(@post.messageboard) %>

--- a/app/views/thredded/private_topic_mailer/message_notification.html.erb
+++ b/app/views/thredded/private_topic_mailer/message_notification.html.erb
@@ -1,7 +1,10 @@
 <div class="thredded--email">
   <figure class="thredded--email-post">
     <figcaption class="thredded--email-post--author">
-      <%= @post.user.thredded_display_name %> <%= link_to 'said', private_post_permalink_url(@post) %>:
+      <%= t 'thredded.emails.message_notification.html.post_lead_html',
+            user: @post.user.thredded_display_name,
+            post_url: private_post_permalink_url(@post.id),
+            topic_title: @post.postable.title %>
     </figcaption>
     <% cache [@post, 'content-onebox-placeholders'] do %>
       <%= render partial: 'thredded/private_posts/content',
@@ -10,11 +13,14 @@
   </figure>
   <hr/>
   <p>
-    This email was sent to you because <%= @topic.user.thredded_display_name %> included you in a
-    private topic, "<%= link_to @topic.title, private_topic_url(@topic) %>".
+    <%= t 'thredded.emails.message_notification.html.email_sent_reason_html',
+          user: @post.postable.user.thredded_display_name,
+          post_url: private_post_permalink_url(@post.id),
+          topic_title: @post.postable.title %>
   </p>
 
   <p>
-    To unsubscribe from these emails, update your <%= link_to 'preferences', edit_preferences_url %>.
+    <%= t 'thredded.emails.message_notification.html.unsubscribe_instructions_html',
+          preferences_url: edit_preferences_url %>
   </p>
 </div>

--- a/app/views/thredded/private_topic_mailer/message_notification.text.erb
+++ b/app/views/thredded/private_topic_mailer/message_notification.text.erb
@@ -1,12 +1,15 @@
-<%= @post.user.thredded_display_name %> said:
+<%= t 'thredded.emails.message_notification.text.post_lead',
+      user: @post.user.thredded_display_name,
+      topic_title: @post.postable.title %>
+
 <%= @post.content %>
+
 ---
 
-This email was sent to you because <%= @topic.user.thredded_display_name %>
-included you in the private topic "<%= @topic.title %>".
+<%= t 'thredded.emails.message_notification.text.email_sent_reason',
+      user: @post.postable.user.thredded_display_name,
+      topic_title: @post.postable.title,
+      post_url: private_post_permalink_url(@post.id) %>
 
-Go here to view the conversation:
-  <%= private_post_permalink_url(@post) %>
-
-To unsubscribe from these emails, update your preferences here:
-  <%= edit_preferences_url %>
+<%= t 'thredded.emails.message_notification.text.unsubscribe_instructions',
+      unsubscribe_url: edit_preferences_url %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,40 @@ en:
       content_blocked_notice_with_record_html: Blocked by %{moderator} %{time_ago}
     email_notifier:
       by_email: by email
+    emails:
+      message_notification:
+        html:
+          email_sent_reason_html: >-
+            This email was sent to you because %{user} included you in a private topic, “<a href="%{post_url}">%{topic_title}</a>”.
+          post_lead_html: 'A new message from %{user} in <a href="%{post_url}">“%{topic_title}”</a>:'
+          unsubscribe_instructions_html: :thredded.emails.post_notification.html.unsubscribe_instructions_html
+        subject: A new message from %{user} in “%{topic_title}”
+        text:
+          email_sent_reason: |-
+            This email was sent to you because %{user} included you in
+            the private topic “%{topic_title}”.
+
+            Go here to view the conversation:
+            %{post_url}
+          post_lead: 'A new message from %{user} in “%{topic_title}”:'
+          unsubscribe_instructions: :thredded.emails.post_notification.text.unsubscribe_instructions
+      post_notification:
+        html:
+          email_sent_reason_html: 'This email was sent to you because you are following this topic: “<a href="%{post_url}">%{topic_title}</a>”.'
+          post_lead_html: '%{user} <a href="%{post_url}">said in “%{topic_title}”</a>:'
+          unsubscribe_instructions_html: To unsubscribe from these emails, update your <a href="%{preferences_url}">preferences</a>.
+        subject: A new post in “%{topic_title}” by %{user}
+        text:
+          email_sent_reason: |-
+            This email was sent to you because you are following
+            the topic “%{topic_title}”.
+
+            Go here to view the conversation:
+            %{post_url}
+          post_lead: "%{user} said in “%{topic_title}”:"
+          unsubscribe_instructions: |-
+            To unsubscribe from these emails, update your preferences here:
+            %{unsubscribe_url}
     errors:
       login_required: Please sign in first.
       not_authorized: You are not authorized to access this page.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -6,6 +6,42 @@ es:
       content_blocked_notice_with_record_html: Censurado por %{moderator} hace %{time_ago}
     email_notifier:
       by_email: vía email
+    emails:
+      message_notification:
+        html:
+          email_sent_reason_html: >-
+            Este correo electrónico se te envió porque %{user} te incluyó en un tema privado, "<a href="%{post_url}">%{topic_title}</a>".
+          post_lead_html: 'Un nuevo mensaje de %{user} en <a href="%{post_url}">"%{topic_title}"</a>:'
+          unsubscribe_instructions_html: :thredded.emails.post_notification.html.unsubscribe_instructions_html
+        subject: Un nuevo mensaje de %{user} en "%{topic_title}"
+        text:
+          email_sent_reason: |-
+            Este correo electrónico se te envió porque %{user} te incluyó en
+            el tema privado "%{topic_title}".
+
+            Ve aquí para ver la conversación:
+            %{post_url}
+          post_lead: 'Un nuevo mensaje de %{user} en "%{topic_title}":'
+          unsubscribe_instructions: :thredded.emails.post_notification.text.unsubscribe_instructions
+      post_notification:
+        html:
+          email_sent_reason_html: >-
+            Este correo electrónico se le envió porque está siguiendo este tema: "<a href="%{post_url}">%{topic_title}</a>".
+          post_lead_html: '%{user} <a href="%{post_url}">dijo en "%{topic_title}"</a>:'
+          unsubscribe_instructions_html: >-
+            Para cancelar la suscripción a estos correos electrónicos, actualice sus <a href="%{preferences_url}">preferencias</a>.
+        subject: Un nuevo mensaje en "%{topic_title}" de %{user}
+        text:
+          email_sent_reason: |-
+            Este correo electrónico se te envió porque estás siguiendo
+            el tema "%{topic_title}".
+
+            Ve aquí para ver la conversación:
+            %{post_url}
+          post_lead: '%{user} dijo en "%{topic_title}":'
+          unsubscribe_instructions: |-
+            Para anular la suscripción de estos correos electrónicos, actualice sus preferencias aquí:
+            %{unsubscribe_url}
     errors:
       login_required: Por favor, inicia sesión.
       not_authorized: No estás autorizado para ver esta página.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -6,6 +6,40 @@ fr:
       content_blocked_notice_with_record_html: Bloqué par %{moderator} %{time_ago}
     email_notifier:
       by_email: via email
+    emails:
+      message_notification:
+        html:
+          email_sent_reason_html: >-
+            Ce courriel vous a été envoyé parce que %{user} vous a inclus dans un sujet privé, "<a href="%{post_url}">%{topic_title}</a>".
+          post_lead_html: 'Un nouveau message de %{user} dans <a href="%{post_url}">"%{topic_title}"</a>:'
+          unsubscribe_instructions_html: :thredded.emails.post_notification.html.unsubscribe_instructions_html
+        subject: Un nouveau message de %{user} dans "%{topic_title}"
+        text:
+          email_sent_reason: |-
+            Ce courriel vous a été envoyé parce que %{user} vous a inclus
+            le sujet privé "%{topic_title}".
+
+            Allez ici pour voir la conversation:
+            %{post_url}
+          post_lead: 'Un nouveau message de %{user} dans "%{topic_title}":'
+          unsubscribe_instructions: :thredded.emails.post_notification.text.unsubscribe_instructions
+      post_notification:
+        html:
+          email_sent_reason_html: 'Ce courriel vous a été envoyé car vous suivez ce sujet: "<a href="%{post_url}">%{topic_title}</a>".'
+          post_lead_html: '%{user} a <a href="%{post_url}">déclaré dans "%{topic_title}"</a>:'
+          unsubscribe_instructions_html: Pour vous désabonner de ces courriels, mettez à jour vos <a href="%{preferences_url}">préférences</a>.
+        subject: Une nouvelle publication dans "%{topic_title}" par %{user}
+        text:
+          email_sent_reason: |-
+            Ce courriel vous a été envoyé parce que vous suivez
+            le sujet "%{topic_title}".
+
+            Allez ici pour voir la conversation:
+            %{post_url}
+          post_lead: '%{user} a déclaré dans "%{topic_title}":'
+          unsubscribe_instructions: |-
+            Pour vous désabonner de ces courriels, mettez à jour vos préférences ici:
+            %{unsubscribe_url}
     errors:
       login_required: Connectez vous s'il vous plait
       not_authorized: Vous n'êtes pas authorisé à accéder à cette page.
@@ -47,8 +81,8 @@ fr:
       post_blocked_html: Commentaire bloqué par %{moderator} %{time_ago}.
       post_deleted_notice: Ce commentaire a été effacé.
       posts_content_changed_since_moderation_html: >-
-        Le <a href="%{post_url}">commentaire</a> a changé depuis qu'il a été modéré.
-        La date de modération est affiché en dessous.
+        Le <a href="%{post_url}">commentaire</a> a changé depuis qu'il a été modéré. La date de modération est affiché
+        en dessous.
       search_users:
         form_label: Rechercher des utilisateurs
         form_placeholder: :thredded.moderation.search_users.form_label
@@ -91,15 +125,16 @@ fr:
           hint: Suivre automatiquement les nouveaux sujets. Changer ce paramètre affectera aussi toutes les catégories.
           label: Suivre tout les nouveaux sujets
         follow_topics_on_mention:
-          hint: "Suivre un sujet lorsqu'on est mentionné par son nom (exemple: @marc)"
+          hint: 'Suivre un sujet lorsqu''on est mentionné par son nom (exemple: @marc)'
           label: Suivre un sujet dans lequel vous êtes mentionné
         messageboard_auto_follow_topics:
-          hint: Suivre automatiquement tout les nouveaux sujets dans cette catégorie.
-            Ce paramètre outrepasse le paramètre relatif au dessus.
+          hint: >-
+            Suivre automatiquement tout les nouveaux sujets dans cette catégorie. Ce paramètre outrepasse le paramètre
+            relatif au dessus.
           label: Suivre tout les nouveaux sujets
         messageboard_follow_topics_on_mention:
-          hint: "Quand quelqu'un mentionnera votre nom (exemple: @marc) dans cette catégorie, vous serez abonné au
-            sujet."
+          hint: 'Quand quelqu''un mentionnera votre nom (exemple: @marc) dans cette catégorie, vous serez abonné
+            au sujet.'
           label: :thredded.preferences.form.follow_topics_on_mention.label
         messageboard_notifications_for_followed_topics:
           label: :thredded.preferences.form.notifications_for_followed_topics.label
@@ -144,7 +179,7 @@ fr:
         btn_submit: :thredded.search.form.label
         label: Recherche
         placeholder: Rechercher un Sujet ou un Commentaire
-    time_ago: "il y a %{time}"
+    time_ago: il y a %{time}
     topics:
       delete_confirm: Êtes-vous sur de vouloir supprimer ce sujet ? Cette action est irréversible.
       delete_topic: Supprimer le Sujet
@@ -173,7 +208,8 @@ fr:
       mark_as_unread: Marquer comme non lu à partir d'ici
       not_following: Vous ne suivez pas ce sujet.
       search:
-        no_results_in_messageboard_message_html: Il n'y a aucun résultat pour votre recherche <q>%{query}</q> dans %{messageboard}
+        no_results_in_messageboard_message_html: Il n'y a aucun résultat pour votre recherche <q>%{query}</q> dans
+          %{messageboard}
         no_results_message_html: Il n'y a aucun résultat pour votre recherche <q>%{query}</q>
         page_title: Résultat de la Recherche de Sujet
         results_in_messageboard_message_html: Recherche pour <q>%{query}</q> dans %{messageboard}

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -6,6 +6,41 @@ pl:
       content_blocked_notice_with_record_html: Zablokowany przez %{moderator} %{time_ago}
     email_notifier:
       by_email: przez e-mail
+    emails:
+      message_notification:
+        html:
+          email_sent_reason_html: >-
+            Ten e-mail został wysłany do Ciebie, ponieważ %{user} włącza Cię do prywatnego tematu "<a href="%{post_url}">%{topic_title}</a>".
+          post_lead_html: 'Nowa wiadomość z %{user} w <a href="%{post_url}">"%{topic_title}"</a>:'
+          unsubscribe_instructions_html: :thredded.emails.post_notification.html.unsubscribe_instructions_html
+        subject: Nowa wiadomość z %{user} w "%{topic_title}"
+        text:
+          email_sent_reason: |-
+            Ten e-mail został wysłany do Ciebie, ponieważ %{user} Cię włączyło
+            Prywatny temat "%{topic_title}".
+
+            Przejdź tutaj, aby wyświetlić rozmowę:
+            %{post_url}
+          post_lead: 'Nowa wiadomość z %{user} w "%{topic_title}":'
+          unsubscribe_instructions: :thredded.emails.post_notification.text.unsubscribe_instructions
+      post_notification:
+        html:
+          email_sent_reason_html: >-
+            Ten e-mail został wysłany do Ciebie, ponieważ śledzisz ten temat: "<a href="%{post_url}">%{topic_title}</a>".
+          post_lead_html: '%{user} <a href="%{post_url}">powiedział w "%{topic_title}"</a>:'
+          unsubscribe_instructions_html: Aby wypisać się z tych e-maili, zaktualizuj swoje <a href="%{preferences_url}">preferencje</a>.
+        subject: Nowy post w "%{topic_title}" przez %{user}
+        text:
+          email_sent_reason: |-
+            Ten e-mail został wysłany do Ciebie, ponieważ śledzisz
+            Temat "%{topic_title}".
+
+            Przejdź tutaj, aby wyświetlić rozmowę:
+            %{post_url}
+          post_lead: '%{user} powiedział w "%{topic_title}":'
+          unsubscribe_instructions: |-
+            Aby wypisać się z tych e-maili, zaktualizuj swoje preferencje:
+            %{unsubscribe_url}
     errors:
       login_required: Proszę się najpierw zalogować.
       not_authorized: Nie masz uprawnień aby zobaczyć tę stronę.

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -6,6 +6,41 @@ pt-BR:
       content_blocked_notice_with_record_html: Bloqueados por %{moderator} %{time_ago}
     email_notifier:
       by_email: de e-mail
+    emails:
+      message_notification:
+        html:
+          email_sent_reason_html: >-
+            Este e-mail foi enviado para você porque %{user} incluiu você em um tópico privado, "<a href="%{post_url}">%{topic_title}</a>".
+          post_lead_html: 'Uma nova mensagem de %{user} em <a href="%{post_url}">"%{topic_title}"</a>:'
+          unsubscribe_instructions_html: :thredded.emails.post_notification.html.unsubscribe_instructions_html
+        subject: Uma nova mensagem de %{user} em "%{topic_title}"
+        text:
+          email_sent_reason: |-
+            Este e-mail foi enviado para você porque %{user} incluiu você em
+            o tópico privado "%{topic_title}".
+
+            Vá aqui para ver a conversa:
+            %{post_url}
+          post_lead: 'Uma nova mensagem de %{user} em "%{topic_title}":'
+          unsubscribe_instructions: :thredded.emails.post_notification.text.unsubscribe_instructions
+      post_notification:
+        html:
+          email_sent_reason_html: >-
+            Este e-mail foi enviado para você porque você está seguindo este tópico: "<a href="%{post_url}">%{topic_title}</a>".
+          post_lead_html: '%{user} <a href="%{post_url}">disse em "%{topic_title}"</a>:'
+          unsubscribe_instructions_html: Para cancelar a inscrição desses e-mails, atualize suas <a href="%{preferences_url}">preferências</a>.
+        subject: Uma nova postagem em "%{topic_title}" por %{user}
+        text:
+          email_sent_reason: |-
+            Este e-mail foi enviado para você porque você está seguindo
+            o tópico "%{topic_title}".
+
+            Vá aqui para ver a conversa:
+            %{post_url}
+          post_lead: '%{user} disse em "%{topic_title}":'
+          unsubscribe_instructions: |-
+            Para cancelar a inscrição desses e-mails, atualize suas preferências aqui:
+            %{unsubscribe_url}
     errors:
       login_required: Por favor, autentique-se primeiro.
       not_authorized: Você não está autorizado a acessar esta página.

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -6,6 +6,40 @@ ru:
       content_blocked_notice_with_record_html: Блокировано %{moderator} %{time_ago}
     email_notifier:
       by_email: email
+    emails:
+      message_notification:
+        html:
+          email_sent_reason_html: >-
+            Это письмо было отправлено вам, потому что %{user} добавил вас в приватную тему «<a href="%{post_url}">%{topic_title}</a>».
+          post_lead_html: 'Новое сообщение от %{user} в <a href="%{post_url}">«%{topic_title}»</a>:'
+          unsubscribe_instructions_html: :thredded.emails.post_notification.html.unsubscribe_instructions_html
+        subject: Новое сообщение от %{user} в «%{topic_title}»
+        text:
+          email_sent_reason: |-
+            Это письмо было отправлено вам, потому что %{user} добавил вас в
+            приватную тему «%{topic_title}».
+
+            Перейдите сюда, чтобы просмотреть разговор:
+            %{post_url}
+          post_lead: 'Новое сообщение от %{user} в «%{topic_title}»:'
+          unsubscribe_instructions: :thredded.emails.post_notification.text.unsubscribe_instructions
+      post_notification:
+        html:
+          email_sent_reason_html: >-
+            Это письмо было отправлено вам, потому что вы подписаны на тему: «<a href="%{post_url}">%{topic_title}</a>».
+          post_lead_html: '%{user} в <a href="%{post_url}">«%{topic_title}»</a>:'
+          unsubscribe_instructions_html: Чтобы отписаться от этих писем, обновите свои <a href="%{preferences_url}">настройки</a>.
+        subject: Новое сообщение в «%{topic_title}» от %{user}
+        text:
+          email_sent_reason: |-
+            Это письмо было отправлено вам, потому что вы подписаны на тему «%{topic_title}».
+
+            Перейдите сюда, чтобы просмотреть разговор:
+            %{post_url}
+          post_lead: "%{user} указан в «%{topic_title}»:"
+          unsubscribe_instructions: |-
+            Чтобы отписаться от этих писем, обновите свои настройки здесь:
+            %{unsubscribe_url}
     errors:
       login_required: Необходимо зайти на форум.
       not_authorized: Вы не авторизованы.


### PR DESCRIPTION
Fixes #603

@tiii, I've noticed you're working on the German translations in https://github.com/AppCamps/thredded/commit/cc5dcf767fc33049946b207152de5c3604e80149, including the mailers.

This PR updates the mailers to use i18n, making their localization a lot easier.

@matsumonkie This also translates the emails French using Google-translate, so you might have to send a PR fixing Google's mistakes.