### PR TITLE
Fix for module qualified user class

### DIFF
--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -143,7 +143,7 @@ module Thredded
     unless user_class_name.is_a?(String)
       fail "Thredded.user_class must be set to a String, got #{user_class_name.inspect}"
     end
-    @@user_class_name = user_class_name # rubocop:disable Style/ClassVars
+    @@user_class_name = user_class_name.demodulize # rubocop:disable Style/ClassVars
   end
 
   # @return [Class<Thredded::UserExtender>] the user class from the host application.


### PR DESCRIPTION
While trying to integrate Thredded with Spree I set Thredded.user_class to "Spree::User" which caused Thredded.user_class_name to be "spree/user" instead of "user" breaking most methods. This was the fix that seems to be working for me. I'm pretty new to Ruby/Rails so not sure if this is the best way to fix it.