### PR TITLE
Ensure users are notified by all notifiers, not just the first 

### DIFF
--- a/app/commands/thredded/notify_following_users.rb
+++ b/app/commands/thredded/notify_following_users.rb
@@ -11,10 +11,10 @@ module Thredded
     def run
       Thredded.notifiers.each do |notifier|
         notifiable_users = targeted_users(notifier)
-        notifiable_users = notifiable_users.select do |user|
-          # Create a notification for the user.
+        notifiable_users.each do |user|
+          # Record idempotently that the notification happened
           # If a notification was already created (from another thread/process),
-          # this will return false due to the unique constraint on the table
+          # this won't create another notification, but will renotify (too bad)
           # and the user will be excluded.
           Thredded::UserPostNotification.create_from_post_and_user(@post, user)
         end

--- a/app/commands/thredded/notify_following_users.rb
+++ b/app/commands/thredded/notify_following_users.rb
@@ -14,8 +14,7 @@ module Thredded
         notifiable_users.each do |user|
           # Record idempotently that the notification happened
           # If a notification was already created (from another thread/process),
-          # this won't create another notification, but will renotify (too bad)
-          # and the user will be excluded.
+          # this won't create another notification, but will renotify (too bad).
           Thredded::UserPostNotification.create_from_post_and_user(@post, user)
         end
         next if notifiable_users.empty?

--- a/spec/commands/thredded/notify_following_users_spec.rb
+++ b/spec/commands/thredded/notify_following_users_spec.rb
@@ -52,7 +52,7 @@ module Thredded
         end
 
         context 'with the MockNotifier' do
-          let(:notifier) { MockNotifier.new.resetted }
+          let(:notifier) { MockNotifier.new }
           it 'does include that user' do
             expect(subject).to include(follower)
           end
@@ -76,7 +76,7 @@ module Thredded
         end
 
         context 'with the MockNotifier' do
-          let(:notifier) { MockNotifier.new.resetted }
+          let(:notifier) { MockNotifier.new }
           it "doesn't include that user" do
             expect(subject).not_to include(follower)
           end
@@ -99,7 +99,7 @@ module Thredded
         end
 
         context 'with the MockNotifier' do
-          let(:notifier) { MockNotifier.new.resetted }
+          let(:notifier) { MockNotifier.new }
           it "doesn't include that user" do
             expect(subject).not_to include(follower)
           end
@@ -120,13 +120,15 @@ module Thredded
       end
 
       context 'with the MockNotifier', thredded_reset: ['@@notifiers'] do
-        before { Thredded.notifiers = [MockNotifier.new.resetted] }
+        let(:mock_notifier) { MockNotifier.new }
+
+        before { Thredded.notifiers = [mock_notifier] }
         it "doesn't send any emails" do
           expect { command.run }.not_to change { ActionMailer::Base.deliveries.count }
         end
         it 'notifies exactly once' do
-          expect { command.run }.to change { MockNotifier.users_notified_of_new_post }
-          expect { command.run }.to_not change { MockNotifier.users_notified_of_new_post }
+          expect { command.run }.to change { mock_notifier.users_notified_of_new_post }
+          expect { command.run }.to_not change { mock_notifier.users_notified_of_new_post }
         end
       end
     end

--- a/spec/commands/thredded/notify_following_users_spec.rb
+++ b/spec/commands/thredded/notify_following_users_spec.rb
@@ -131,6 +131,26 @@ module Thredded
           expect { command.run }.to_not change { mock_notifier.users_notified_of_new_post }
         end
       end
+
+      context 'with multiple notifiers', thredded_reset: ['@@notifiers'] do
+        let(:mock_notifier1) { MockNotifier.new }
+        let(:mock_notifier2) { MockNotifier.new }
+
+        before { Thredded.notifiers = [mock_notifier1, mock_notifier2] }
+
+        def count_users_for_each_notifier
+          [mock_notifier1.users_notified_of_new_post.length, mock_notifier2.users_notified_of_new_post.length]
+        end
+        it 'notifies via all notifiers' do
+          expect { command.run }
+            .to change { count_users_for_each_notifier }.from([0, 0]).to([1, 1])
+        end
+        it "second run doesn't notify" do
+          command.run
+          expect { command.run }
+            .to_not change { count_users_for_each_notifier }
+        end
+      end
     end
   end
 end

--- a/spec/commands/thredded/notify_private_topic_users_spec.rb
+++ b/spec/commands/thredded/notify_private_topic_users_spec.rb
@@ -34,7 +34,7 @@ module Thredded
 
         context 'but with MockNotifier' do
           it 'includes them' do
-            recipients = NotifyPrivateTopicUsers.new(post).targeted_users(MockNotifier.new.resetted)
+            recipients = NotifyPrivateTopicUsers.new(post).targeted_users(MockNotifier.new)
             expect(recipients).to include(@joel)
           end
         end
@@ -53,12 +53,14 @@ module Thredded
       end
 
       context 'with the MockNotifier', thredded_reset: ['@@notifiers'] do
-        before { Thredded.notifiers = [MockNotifier.new.resetted] }
+        let(:mock_notifier) { MockNotifier.new }
+
+        before { Thredded.notifiers = [mock_notifier] }
         it "doesn't send any emails" do
           expect { command.run }.not_to change { ActionMailer::Base.deliveries.count }
         end
         it 'uses MockNotifier' do
-          expect { command.run }.to change { MockNotifier.users_notified_of_new_private_post }
+          expect { command.run }.to change { mock_notifier.users_notified_of_new_private_post }
         end
       end
     end

--- a/spec/commands/thredded/notify_private_topic_users_spec.rb
+++ b/spec/commands/thredded/notify_private_topic_users_spec.rb
@@ -63,6 +63,29 @@ module Thredded
           expect { command.run }.to change { mock_notifier.users_notified_of_new_private_post }
         end
       end
+
+      context 'with multiple notifiers', thredded_reset: ['@@notifiers'] do
+        let(:mock_notifier1) { MockNotifier.new }
+        let(:mock_notifier2) { MockNotifier.new }
+
+        before { Thredded.notifiers = [mock_notifier1, mock_notifier2] }
+
+        def count_users_for_each_notifier
+          [
+            mock_notifier1.users_notified_of_new_private_post.length,
+            mock_notifier2.users_notified_of_new_private_post.length
+          ]
+        end
+        it 'notifies via all notifiers' do
+          expect { command.run }
+            .to change { count_users_for_each_notifier }.from([0, 0]).to([1, 1])
+        end
+        it "second run doesn't notify" do
+          command.run
+          expect { command.run }
+            .to_not change { count_users_for_each_notifier }
+        end
+      end
     end
   end
 end

--- a/spec/lib/thredded_spec.rb
+++ b/spec/lib/thredded_spec.rb
@@ -64,7 +64,7 @@ describe Thredded, '.notifiers', thredded_reset: [:@@notifiers] do
   end
 
   specify 'can assign to new notifier instance' do
-    mock = MockNotifier.new.resetted
+    mock = MockNotifier.new
     Thredded.notifiers = [mock]
     expect(Thredded.notifiers).to eq([mock])
   end

--- a/spec/support/mock_notifier.rb
+++ b/spec/support/mock_notifier.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
-class MockNotifier
-  mattr_accessor :users_notified_of_new_post, :users_notified_of_new_private_post
+require 'set'
 
-  def key
-    'mock'
+class MockNotifier
+  attr_accessor :users_notified_of_new_post, :users_notified_of_new_private_post
+
+  def initialize(key = 'mock')
+    @users_notified_of_new_post = Set.new
+    @users_notified_of_new_private_post = Set.new
+    @key = key
   end
 
+  attr_reader :key
+
   def human_name
-    'By mock'
+    "By #{key}"
   end
 
   def new_post(_post, users)
-    self.users_notified_of_new_post = users
+    users_notified_of_new_post.merge(users)
   end
 
   def new_private_post(_post, users)
-    self.users_notified_of_new_private_post = users
-  end
-
-  def resetted
-    self.users_notified_of_new_post = []
-    self.users_notified_of_new_private_post = []
-    self
+    users_notified_of_new_private_post.merge(users)
   end
 end


### PR DESCRIPTION
fixes #540.

Note that in rare cases (I think only when background jobs are misconfigured or have an unreliable lock) this implementation might result in double notification.