### PR TITLE
Fix race of multiple background jobs + notifiers

### DIFF
--- a/app/commands/thredded/notify_following_users.rb
+++ b/app/commands/thredded/notify_following_users.rb
@@ -9,46 +9,65 @@ module Thredded
     end
 
     def run
+      subscribed_users.select! do |user|
+        # Record idempotently that the notification happened.
+        # If a notification was already created (e.g. from another thread/process),
+        # this will return false due to the unique constraint on the table
+        # and the user will be excluded.
+        subscribed_via_any_notifier?(user) && record_as_notified_successful?(user)
+      end
       Thredded.notifiers.each do |notifier|
         notifiable_users = targeted_users(notifier)
-        notifiable_users.each do |user|
-          # Record idempotently that the notification happened
-          # If a notification was already created (from another thread/process),
-          # this won't create another notification, but will renotify (too bad).
-          Thredded::UserPostNotification.create_from_post_and_user(@post, user)
-        end
         next if notifiable_users.empty?
         notifier.new_post(@post, notifiable_users)
       end
     end
 
     def targeted_users(notifier)
-      users_subscribed_via(notifier).reject do |user|
-        already_notified_user_ids.include?(user.id)
-      end
-    end
-
-    def users_subscribed_via(notifier)
       subscribed_users.select do |user|
-        Thredded::NotificationsForFollowedTopics
-          .detect_or_default(user.thredded_notifications_for_followed_topics, notifier).enabled? &&
-          Thredded::MessageboardNotificationsForFollowedTopics
-            .detect_or_default(messageboard_notifier_prefs_by_user_id[user.id], notifier).enabled?
+        user_subscribed_via?(user, notifier)
       end
     end
 
+    def user_subscribed_via?(user, notifier)
+      Thredded::NotificationsForFollowedTopics
+        .detect_or_default(user.thredded_notifications_for_followed_topics, notifier).enabled? &&
+        Thredded::MessageboardNotificationsForFollowedTopics
+          .detect_or_default(messageboard_notifier_prefs_by_user_id[user.id], notifier).enabled?
+    end
+
+    # @return [Array<User>]
     def subscribed_users
       @subscribed_users ||=
-        @post.postable.followers.includes(:thredded_notifications_for_followed_topics).reject do |user|
-          user == @post.user || !Thredded::PostPolicy.new(user, @post).read?
+        @post.postable.followers.includes(:thredded_notifications_for_followed_topics).select do |user|
+          !already_notified?(user) && !originator?(user) && can_read_post?(user)
         end
     end
 
-    def already_notified_user_ids
-      @notified_user_ids ||= Set.new Thredded::UserPostNotification.notified_user_ids(@post)
+    private
+
+    def originator?(user)
+      user == @post.user
     end
 
-    private
+    def can_read_post?(user)
+      Thredded::PostPolicy.new(user, @post).read?
+    end
+
+    def already_notified?(user)
+      # We memoize the set so that records created during this task do not affect the result,
+      # so that a user can receive notifications via multiple notifiers.
+      @already_notified_user_ids ||= Set.new Thredded::UserPostNotification.notified_user_ids(@post)
+      @already_notified_user_ids.include?(user.id)
+    end
+
+    def subscribed_via_any_notifier?(user)
+      Thredded.notifiers.any? { |notifier| user_subscribed_via?(user, notifier) }
+    end
+
+    def record_as_notified_successful?(user)
+      Thredded::UserPostNotification.create_from_post_and_user(@post, user)
+    end
 
     def messageboard_notifier_prefs_by_user_id
       @messageboard_notifier_prefs_by_user_id ||= Thredded::MessageboardNotificationsForFollowedTopics


### PR DESCRIPTION
Refs #615 #540

It is actually pretty common for background queues to not guarantee that
a task is executed exactly once.

For example, resque (and I think sidekiq on redis) require background
jobs to be idempotent.