### PR TITLE
Improve formatting of "notifications" settings when multiple.

### DIFF
--- a/app/assets/stylesheets/thredded/components/_form-list.scss
+++ b/app/assets/stylesheets/thredded/components/_form-list.scss
@@ -14,9 +14,10 @@
     transition: all 0.15s ease-out 0s;
   }
 
-  label + label {
+  label ~ label {
     display: inline-block;
     font-weight: normal;
+    margin-right: 15px;
   }
 }
 


### PR DESCRIPTION
# Before:
![before](https://user-images.githubusercontent.com/18395/30025410-5b68b532-9170-11e7-92d1-1e2f61abe077.png)
(NB: automatically created hidden input is sometimes hoiked outside of label)

# After:
![after](https://user-images.githubusercontent.com/18395/30025421-645c39c0-9170-11e7-826e-02c7b1523004.png)
