### PR TITLE
Remove "from %{user}" from post notification email

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
           email_sent_reason_html: 'This email was sent to you because you are following this topic: “<a href="%{post_url}">%{topic_title}</a>”.'
           post_lead_html: '%{user} <a href="%{post_url}">said in “%{topic_title}”</a>:'
           unsubscribe_instructions_html: To unsubscribe from these emails, update your <a href="%{preferences_url}">preferences</a>.
-        subject: A new post in “%{topic_title}” by %{user}
+        subject: A new post in “%{topic_title}”
         text:
           email_sent_reason: |-
             This email was sent to you because you are following

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -30,7 +30,7 @@ es:
           post_lead_html: '%{user} <a href="%{post_url}">dijo en "%{topic_title}"</a>:'
           unsubscribe_instructions_html: >-
             Para cancelar la suscripción a estos correos electrónicos, actualice sus <a href="%{preferences_url}">preferencias</a>.
-        subject: Un nuevo mensaje en "%{topic_title}" de %{user}
+        subject: Un nuevo mensaje en "%{topic_title}"
         text:
           email_sent_reason: |-
             Este correo electrónico se te envió porque estás siguiendo

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -28,7 +28,7 @@ fr:
           email_sent_reason_html: 'Ce courriel vous a été envoyé car vous suivez ce sujet: "<a href="%{post_url}">%{topic_title}</a>".'
           post_lead_html: '%{user} a <a href="%{post_url}">déclaré dans "%{topic_title}"</a>:'
           unsubscribe_instructions_html: Pour vous désabonner de ces courriels, mettez à jour vos <a href="%{preferences_url}">préférences</a>.
-        subject: Une nouvelle publication dans "%{topic_title}" par %{user}
+        subject: Une nouvelle publication dans "%{topic_title}"
         text:
           email_sent_reason: |-
             Ce courriel vous a été envoyé parce que vous suivez

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -28,7 +28,7 @@ pl:
           email_sent_reason_html: 'Ten e-mail został wysłany do Ciebie, ponieważ śledzisz ten temat: "<a href="%{post_url}">%{topic_title}</a>".'
           post_lead_html: '%{user} <a href="%{post_url}">powiedział w "%{topic_title}"</a>:'
           unsubscribe_instructions_html: Aby wypisać się z tych e-maili, zaktualizuj swoje <a href="%{preferences_url}">preferencje</a>.
-        subject: Nowy post w "%{topic_title}" przez %{user}
+        subject: Nowy post w "%{topic_title}"
         text:
           email_sent_reason: |-
             Ten e-mail został wysłany do Ciebie, ponieważ śledzisz

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -29,7 +29,7 @@ pt-BR:
             Este e-mail foi enviado para você porque você está seguindo este tópico: "<a href="%{post_url}">%{topic_title}</a>".
           post_lead_html: '%{user} <a href="%{post_url}">disse em "%{topic_title}"</a>:'
           unsubscribe_instructions_html: Para cancelar a inscrição desses e-mails, atualize suas <a href="%{preferences_url}">preferências</a>.
-        subject: Uma nova postagem em "%{topic_title}" por %{user}
+        subject: Uma nova postagem em "%{topic_title}"
         text:
           email_sent_reason: |-
             Este e-mail foi enviado para você porque você está seguindo

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -28,7 +28,7 @@ ru:
           email_sent_reason_html: 'Это письмо было отправлено вам, потому что вы подписаны на тему: «<a href="%{post_url}">%{topic_title}</a>».'
           post_lead_html: '%{user} в <a href="%{post_url}">«%{topic_title}»</a>:'
           unsubscribe_instructions_html: Чтобы отписаться от этих писем, обновите свои <a href="%{preferences_url}">настройки</a>.
-        subject: Новое сообщение в «%{topic_title}» от %{user}
+        subject: Новое сообщение в «%{topic_title}»
         text:
           email_sent_reason: |-
             Это письмо было отправлено вам, потому что вы подписаны на тему «%{topic_title}».


### PR DESCRIPTION
This enables email clients like GMail to group the notification emails
together into a thread.