### PR TITLE
A simple message for depicting if a topic is locked

### DIFF
--- a/app/assets/stylesheets/thredded/components/_topics.scss
+++ b/app/assets/stylesheets/thredded/components/_topics.scss
@@ -172,3 +172,10 @@
     display: none;
   }
 }
+
+.thredded--topic-locked { 
+  .thredded--topics--posts-count {
+    border: 1px solid red;
+    background-color: darkred;
+  }
+}

--- a/app/views/thredded/topics/show.html.erb
+++ b/app/views/thredded/topics/show.html.erb
@@ -28,6 +28,8 @@
                    button_text: t('thredded.posts.form.create_btn'),
                    button_submitting_text: t('thredded.posts.form.create_btn_submitting') %>
       </div>
+    <% else %>
+    <h3><%= t 'thredded.topics.locked.message'%></h3>
     <% end %>
 
     <% if topic.can_destroy? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,6 +210,7 @@ en:
         update_btn: Update Topic
       locked:
         label: Locked
+        message: This topic has been locked by a moderator.
       mark_as_unread: Mark unread from here
       not_following: You are not following this topic.
       search:


### PR DESCRIPTION
I'd first of all like to thank you for this amazing project. It must be my lucky day to have come across it. I love how the code base is so neat and clean.

While exploring, I noticed that it wouldn't let a user know if a topic is locked or not and just simply doesn't render a form. I added this- 
![image](https://user-images.githubusercontent.com/19175526/31493954-f8ff23d2-af6e-11e7-9894-de6f0739610b.png)
