### PR TITLE
Allow development with bundler 1.16.0

### DIFF
--- a/spec/gemfiles/rails_4_2.gemfile
+++ b/spec/gemfiles/rails_4_2.gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 gemspec path: '../../'
-eval_gemfile './shared.gemfile'
+eval_gemfile '../../shared.gemfile'
 gem 'rails', '~> 4.2.5'
 gem 'rails-ujs'

--- a/spec/gemfiles/rails_5_0.gemfile
+++ b/spec/gemfiles/rails_5_0.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 gemspec path: '../../'
-eval_gemfile './shared.gemfile'
+eval_gemfile '../../shared.gemfile'
 gem 'rails', '~> 5.0.1'
 gem 'rails-ujs'
 gem 'rails-controller-testing'

--- a/spec/gemfiles/rails_5_1.gemfile
+++ b/spec/gemfiles/rails_5_1.gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 gemspec path: '../../'
-eval_gemfile './shared.gemfile'
+eval_gemfile '../../shared.gemfile'
 gem 'rails', '~> 5.1.0'
 gem 'rails-controller-testing'


### PR DESCRIPTION
Before v1.16.0, eval_gemfile used path relative to Bundler root.
Now it seems to be using the path relative to the gemfile.