### PR TITLE
Make @mention dropdown not match when trailing space.

### DIFF
--- a/app/assets/javascripts/thredded/components/mention_autocompletion.es6
+++ b/app/assets/javascripts/thredded/components/mention_autocompletion.es6
@@ -1,7 +1,8 @@
 //= require thredded/components/user_textcomplete
 
 const ThreddedMentionAutocompletion = {
-  MATCH_RE: /(^@|\s@)"?([\w.,\- ()]+)$/,
+  MATCH_RE: /(^@|\s@)"?([\w., \-()]+[\w.,\-()])$/,
+  // the last letter has to not be a space so it doesn't match after replacement
   DROPDOWN_MAX_COUNT: 6,
 
   init(form, textarea) {

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -139,7 +139,7 @@ FactoryBot.define do
 
   factory :user, aliases: %i[email_confirmed_user last_user], class: ::User do
     sequence(:email) { |n| "user#{n}@example.com" }
-    name { Faker::Name.name }
+    name { [true, false].sample ? Faker::Name.name : Faker::Name.first_name }
 
     trait :admin do
       admin true

--- a/spec/features/thredded/user_replies_to_post_spec.rb
+++ b/spec/features/thredded/user_replies_to_post_spec.rb
@@ -32,6 +32,33 @@ feature 'User replying to topic' do
     expect(posts.post_form.content).to(start_with('>').and(end_with("\n\n")))
   end
 
+  describe 'using dropdown', js: true do
+    shared_examples_for 'user can be mentioned' do
+      scenario 'can be mentioned' do
+        expect(page).not_to have_css('.thredded--textcomplete-dropdown')
+        posts.start_reply("Hey @#{other_user.name[0..2]}")
+        expect(page).to have_css('.thredded--textcomplete-dropdown')
+        find('.thredded--textcomplete-dropdown .textcomplete-item.active').click
+        expect(find_field('Content').value).to include(other_user_mention)
+        expect(page).not_to have_css('.thredded--textcomplete-dropdown')
+      end
+    end
+
+    context '(with a user with space in their name)' do
+      it_behaves_like 'user can be mentioned' do
+        let!(:other_user) { create(:user, name: 'Han Solo') }
+        let(:other_user_mention) { '@"Han Solo"' }
+      end
+    end
+
+    context '(with a user without a space)' do
+      it_behaves_like 'user can be mentioned' do
+        let!(:other_user) { create(:user, name: 'Chewie') }
+        let(:other_user_mention) { '@Chewie' }
+      end
+    end
+  end
+
   def user
     user = create(:user)
     PageObject::User.new(user)

--- a/spec/features/thredded/user_replies_to_post_spec.rb
+++ b/spec/features/thredded/user_replies_to_post_spec.rb
@@ -3,25 +3,28 @@
 require 'spec_helper'
 
 feature 'User replying to topic' do
-  let(:posts) { posts_exist_in_a_topic }
+  let!(:posts) { posts_exist_in_a_topic }
   let(:post) { posts.first_post }
-  before do
+  def login_and_visit_posts
     user.log_in
     posts.visit_posts
   end
 
   scenario 'adds a new reply' do
+    login_and_visit_posts
     expect { posts.submit_reply }.to change { posts.posts.size }.by(1)
     expect(posts).to have_new_reply
   end
 
   scenario 'starts a quote-reply (no js)' do
+    login_and_visit_posts
     post.start_quote
     expect(page).to have_current_path(posts.quote_page_for_first_post)
     expect(posts.post_form.content).to(start_with('>').and(end_with("\n\n")))
   end
 
   scenario 'starts a quote-reply (js)', js: true do
+    login_and_visit_posts
     post.start_quote
     # Expect current path to not change because the JS magic takes place
     expect(page).to have_current_path(current_path)
@@ -35,6 +38,7 @@ feature 'User replying to topic' do
   describe 'using dropdown', js: true do
     shared_examples_for 'user can be mentioned' do
       scenario 'can be mentioned' do
+        login_and_visit_posts
         expect(page).not_to have_css('.thredded--textcomplete-dropdown')
         posts.start_reply("Hey @#{other_user.name[0..2]}")
         expect(page).to have_css('.thredded--textcomplete-dropdown')

--- a/spec/features/thredded/user_replies_to_post_spec.rb
+++ b/spec/features/thredded/user_replies_to_post_spec.rb
@@ -60,7 +60,7 @@ feature 'User replying to topic' do
   end
 
   def user
-    user = create(:user, name: "C-3PO")
+    user = create(:user, name: 'C-3PO')
     PageObject::User.new(user)
   end
 

--- a/spec/features/thredded/user_replies_to_post_spec.rb
+++ b/spec/features/thredded/user_replies_to_post_spec.rb
@@ -60,7 +60,7 @@ feature 'User replying to topic' do
   end
 
   def user
-    user = create(:user)
+    user = create(:user, name: "C-3PO")
     PageObject::User.new(user)
   end
 

--- a/spec/support/features/page_object/posts.rb
+++ b/spec/support/features/page_object/posts.rb
@@ -17,9 +17,13 @@ module PageObject
     end
 
     def submit_reply(content = 'I replied')
+      start_reply(content)
+      click_button 'Submit Reply'
+    end
+
+    def start_reply(content)
       self.reply_content = content
       fill_in 'Content', with: reply_content
-      click_button 'Submit Reply'
     end
 
     def posts


### PR DESCRIPTION
Otherwise you don't get rid of the dropdown when you select a user who
doesn't have a space in it. fixes #643
It then prevents tripping into a bug
in textcomplete: https://github.com/yuku-t/textcomplete/issues/115
(because when `@Joe ` is inserted without this patch then it matches again
and then the reinsertion if you select again will be an identical
replacement and then js hangs (haven't found out why).