### PR TITLE
Resolved issue where mailer notifier was not autoloading dpendencies

### DIFF
--- a/app/notifiers/thredded/email_notifier.rb
+++ b/app/notifiers/thredded/email_notifier.rb
@@ -11,11 +11,11 @@ module Thredded
     end
 
     def new_post(post, users)
-      PostMailer.post_notification(post.id, users.map(&:email)).deliver_now
+      Thredded::PostMailer.post_notification(post.id, users.map(&:email)).deliver_now
     end
 
     def new_private_post(post, users)
-      PrivateTopicMailer.message_notification(post.id, users.map(&:email)).deliver_now
+      Thredded::PrivateTopicMailer.message_notification(post.id, users.map(&:email)).deliver_now
     end
   end
 end


### PR DESCRIPTION
Resolved errors where email notifier was getting the error: 'A copy of Thredded::EmailNotifier has been removed from the module tree but is still active'. Updated email notifier to reference Thredded.

Error arose after overriding the PrivatePostsController