### PR TITLE
Fix index creation in v013_to_v14 update migration

### DIFF
--- a/db/upgrade_migrations/20170811090735_upgrade_thredded_v0_13_to_v_014.rb
+++ b/db/upgrade_migrations/20170811090735_upgrade_thredded_v0_13_to_v_014.rb
@@ -8,11 +8,13 @@ class UpgradeThreddedV013ToV014 < Thredded::BaseMigration
     remove_index :thredded_user_details,
                  name: :index_thredded_user_details_on_user_id
     add_index :thredded_user_details,
+              :user_id,
               name: :index_thredded_user_details_on_user_id,
               unique: true
     remove_index :thredded_user_preferences,
                  name: :index_thredded_user_preferences_on_user_id
     add_index :thredded_user_preferences,
+              :user_id,
               name: :index_thredded_user_preferences_on_user_id,
               unique: true
   end


### PR DESCRIPTION
The add_index calls are missing the column names