### PR TITLE
Allow customizing first messageboard post

### DIFF
--- a/app/commands/thredded/create_messageboard.rb
+++ b/app/commands/thredded/create_messageboard.rb
@@ -23,19 +23,19 @@ module Thredded
           messageboard: @messageboard,
           user: @user,
           postable: topic,
-          content: first_post_content
+          content: first_topic_content
         )
         true
       end
     end
 
     def first_topic_title
-      I18n.t('thredded.topics.first_of_messageboard.title')
+      I18n.t('thredded.messageboard_first_topic.title')
     end
 
-    def first_post_content
+    def first_topic_content
       <<-MARKDOWN
-#{I18n.t('thredded.posts.first_of_messageboard.content', thredded_version: Thredded::VERSION)}
+#{I18n.t('thredded.messageboard_first_topic.content', thredded_version: Thredded::VERSION)}
       MARKDOWN
     end
   end

--- a/app/commands/thredded/create_messageboard.rb
+++ b/app/commands/thredded/create_messageboard.rb
@@ -30,16 +30,12 @@ module Thredded
     end
 
     def first_topic_title
-      "Welcome to your messageboard's very first thread"
+      I18n.t('thredded.topics.first_of_messageboard.title')
     end
 
     def first_post_content
       <<-MARKDOWN
-There's not a whole lot here for now.
-
-These forums are powered by [Thredded](https://github.com/thredded/thredded) v#{Thredded::VERSION}.
-You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
-Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
+#{I18n.t('thredded.posts.first_of_messageboard.content', thredded_version: Thredded::VERSION)}
       MARKDOWN
     end
   end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -115,6 +115,13 @@ de:
       delete_confirm: Bist du sicher, dass du diesen Beitrag löschen willst?
       deleted_notice: Dein Beitrag wurde gelöscht
       edit: :thredded.nav.edit_post
+      first_of_messageboard:
+        content: |-
+          There's not a whole lot here for now.
+
+          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Inhalt
         create_btn: Beitrag erstellen
@@ -195,6 +202,8 @@ de:
       delete_topic: Diskussion löschen
       deleted_notice: Diskussion gelöscht
       edit: Diskussion bearbeiten
+      first_of_messageboard:
+        title: Welcome to your messageboard's very first thread
       follow: Folge dieser Diskussion
       followed_by: 'gefolgt von:'
       followed_by_noone: Die Diskussion wird von Niemandem verfolgt

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -68,6 +68,14 @@ de:
       topics_and_posts_counts: "%{topics_count} Diskussionen / %{posts_count} Beiträge"
       update: :thredded.form.update
       updated_notice: Das Forum wurde aktualisiert
+    messageboard_first_topic:
+      content: |-
+        There's not a whole lot here for now.
+
+        These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+        You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+        Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
+      title: Welcome to your messageboard's very first thread
     messageboard_group:
       create: Erstelle eine neue Gruppe
       form:
@@ -115,13 +123,6 @@ de:
       delete_confirm: Bist du sicher, dass du diesen Beitrag löschen willst?
       deleted_notice: Dein Beitrag wurde gelöscht
       edit: :thredded.nav.edit_post
-      first_of_messageboard:
-        content: |-
-          There's not a whole lot here for now.
-
-          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
-          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
-          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Inhalt
         create_btn: Beitrag erstellen
@@ -202,8 +203,6 @@ de:
       delete_topic: Diskussion löschen
       deleted_notice: Diskussion gelöscht
       edit: Diskussion bearbeiten
-      first_of_messageboard:
-        title: Welcome to your messageboard's very first thread
       follow: Folge dieser Diskussion
       followed_by: 'gefolgt von:'
       followed_by_noone: Die Diskussion wird von Niemandem verfolgt

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,14 @@ en:
       topics_and_posts_counts: "%{topics_count} topics / %{posts_count} posts"
       update: :thredded.form.update
       updated_notice: Messageboard has been updated
+    messageboard_first_topic:
+      content: |-
+        There's not a whole lot here for now.
+
+        These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+        You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+        Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
+      title: Welcome to your messageboard's very first thread
     messageboard_group:
       create: Create a New Messageboard Group
       form:
@@ -114,13 +122,6 @@ en:
       delete_confirm: Are you sure you want to delete this post?
       deleted_notice: Your post has been deleted.
       edit: :thredded.nav.edit_post
-      first_of_messageboard:
-        content: |-
-          There's not a whole lot here for now.
-
-          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
-          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
-          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Content
         create_btn: Submit Reply
@@ -199,8 +200,6 @@ en:
       delete_topic: Delete Topic
       deleted_notice: Topic deleted
       edit: Edit Topic
-      first_of_messageboard:
-        title: Welcome to your messageboard's very first thread
       follow: Follow this topic
       followed_by: 'Followed by:'
       followed_by_noone: No one is following this topic

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,6 +114,13 @@ en:
       delete_confirm: Are you sure you want to delete this post?
       deleted_notice: Your post has been deleted.
       edit: :thredded.nav.edit_post
+      first_of_messageboard:
+        content: |-
+          There's not a whole lot here for now.
+
+          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Content
         create_btn: Submit Reply
@@ -192,6 +199,8 @@ en:
       delete_topic: Delete Topic
       deleted_notice: Topic deleted
       edit: Edit Topic
+      first_of_messageboard:
+        title: Welcome to your messageboard's very first thread
       follow: Follow this topic
       followed_by: 'Followed by:'
       followed_by_noone: No one is following this topic

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -69,6 +69,14 @@ es:
       topics_and_posts_counts: "%{topics_count} temas / %{posts_count} mensajes"
       update: :thredded.form.update
       updated_notice: Foro actualizado
+    messageboard_first_topic:
+      content: |-
+        There's not a whole lot here for now.
+
+        These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+        You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+        Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
+      title: Welcome to your messageboard's very first thread
     messageboard_group:
       create: Crear una Nueva Sección
       form:
@@ -116,13 +124,6 @@ es:
       delete_confirm: "¿Estás seguro de que quieres eliminar este mensaje?"
       deleted_notice: Tu mensaje ha sido eliminado.
       edit: :thredded.nav.edit_post
-      first_of_messageboard:
-        content: |-
-          There's not a whole lot here for now.
-
-          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
-          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
-          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Contenido
         create_btn: Responder
@@ -203,8 +204,6 @@ es:
       delete_topic: Eliminar Tema
       deleted_notice: Tema eliminado
       edit: Editar Tema
-      first_of_messageboard:
-        title: Welcome to your messageboard's very first thread
       follow: Seguir este tema
       followed_by: 'Seguido por:'
       followed_by_noone: Nadie está siguiendo este tema

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -116,6 +116,13 @@ es:
       delete_confirm: "¿Estás seguro de que quieres eliminar este mensaje?"
       deleted_notice: Tu mensaje ha sido eliminado.
       edit: :thredded.nav.edit_post
+      first_of_messageboard:
+        content: |-
+          There's not a whole lot here for now.
+
+          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Contenido
         create_btn: Responder
@@ -196,6 +203,8 @@ es:
       delete_topic: Eliminar Tema
       deleted_notice: Tema eliminado
       edit: Editar Tema
+      first_of_messageboard:
+        title: Welcome to your messageboard's very first thread
       follow: Seguir este tema
       followed_by: 'Seguido por:'
       followed_by_noone: Nadie está siguiendo este tema

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -114,6 +114,13 @@ fr:
       delete_confirm: Êtes-vous sure de vouloir effacé ce commentaire ?
       deleted_notice: Votre commentaire a été effacé.
       edit: :thredded.nav.edit_post
+      first_of_messageboard:
+        content: |-
+          There's not a whole lot here for now.
+
+          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Contenu
         create_btn: Soumettre la réponse
@@ -193,6 +200,8 @@ fr:
       delete_topic: Supprimer le Sujet
       deleted_notice: Sujet supprimé
       edit: Éditer le Sujet
+      first_of_messageboard:
+        title: Welcome to your messageboard's very first thread
       follow: Suivre le sujet
       followed_by: 'Suivi par :'
       followed_by_noone: Personne ne suit ce sujet

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -67,6 +67,14 @@ fr:
       topics_and_posts_counts: "%{topics_count} sujets / %{posts_count} commentaires"
       update: :thredded.form.update
       updated_notice: La catégorie a été mise à jour
+    messageboard_first_topic:
+      content: |-
+        There's not a whole lot here for now.
+
+        These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+        You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+        Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
+      title: Welcome to your messageboard's very first thread
     messageboard_group:
       create: Créer un nouveau groupe de catégorie
       form:
@@ -114,13 +122,6 @@ fr:
       delete_confirm: Êtes-vous sure de vouloir effacé ce commentaire ?
       deleted_notice: Votre commentaire a été effacé.
       edit: :thredded.nav.edit_post
-      first_of_messageboard:
-        content: |-
-          There's not a whole lot here for now.
-
-          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
-          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
-          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Contenu
         create_btn: Soumettre la réponse
@@ -200,8 +201,6 @@ fr:
       delete_topic: Supprimer le Sujet
       deleted_notice: Sujet supprimé
       edit: Éditer le Sujet
-      first_of_messageboard:
-        title: Welcome to your messageboard's very first thread
       follow: Suivre le sujet
       followed_by: 'Suivi par :'
       followed_by_noone: Personne ne suit ce sujet

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -67,6 +67,14 @@ it:
       topics_and_posts_counts: "%{topics_count} discussioni / %{posts_count} messaggi"
       update: :thredded.form.update
       updated_notice: La bacheca è stata aggiornata
+    messageboard_first_topic:
+      content: |-
+        Non c'è molto qui, per ora.
+
+        Questi forum girano su [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+        Puoi contattare il team di Thredded attraverso [la chat room di Thredded](https://gitter.im/thredded/thredded).
+        Per favore, facci sapere che stai usando Thredded con un tweet a [@thredded](https://twitter.com/thredded)!
+      title: Benvenuto nella prima discussione di questa bacheca
     messageboard_group:
       create: Crea un nuovo Gruppo di bacheche
       form:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -114,6 +114,13 @@ pl:
       delete_confirm: Jesteś pewny, że chcesz usunąć ten post?
       deleted_notice: Twój post został usunięty.
       edit: :thredded.nav.edit_post
+      first_of_messageboard:
+        content: |-
+          There's not a whole lot here for now.
+
+          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Treść
         create_btn: Wyślij odpowiedź
@@ -192,6 +199,8 @@ pl:
       delete_topic: Usuń temat
       deleted_notice: Temat usunięty.
       edit: Edytuj temat
+      first_of_messageboard:
+        title: Welcome to your messageboard's very first thread
       follow: Obserwuj temat
       followed_by: 'Obserwowany przez:'
       followed_by_noone: Nikt nie obserwuje tego tematu

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -67,6 +67,14 @@ pl:
       topics_and_posts_counts: "%{topics_count} tematów / %{posts_count} postów"
       update: :thredded.form.update
       updated_notice: Tablica została zaktualizowana
+    messageboard_first_topic:
+      content: |-
+        There's not a whole lot here for now.
+
+        These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+        You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+        Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
+      title: Welcome to your messageboard's very first thread
     messageboard_group:
       create: Stwórz nową Grupę
       form:
@@ -114,13 +122,6 @@ pl:
       delete_confirm: Jesteś pewny, że chcesz usunąć ten post?
       deleted_notice: Twój post został usunięty.
       edit: :thredded.nav.edit_post
-      first_of_messageboard:
-        content: |-
-          There's not a whole lot here for now.
-
-          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
-          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
-          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Treść
         create_btn: Wyślij odpowiedź
@@ -199,8 +200,6 @@ pl:
       delete_topic: Usuń temat
       deleted_notice: Temat usunięty.
       edit: Edytuj temat
-      first_of_messageboard:
-        title: Welcome to your messageboard's very first thread
       follow: Obserwuj temat
       followed_by: 'Obserwowany przez:'
       followed_by_noone: Nikt nie obserwuje tego tematu

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -116,6 +116,13 @@ pt-BR:
       delete_confirm: Você tem certeza que deseja remover este post?
       deleted_notice: Seu post foi removido.
       edit: :thredded.nav.edit_post
+      first_of_messageboard:
+        content: |-
+          There's not a whole lot here for now.
+
+          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Conteúdo
         create_btn: Enviar Resposta
@@ -197,6 +204,8 @@ pt-BR:
       delete_topic: Remover Tópico
       deleted_notice: Tópico removido
       edit: Editar Tópico
+      first_of_messageboard:
+        title: Welcome to your messageboard's very first thread
       follow: Siga este tópico
       followed_by: 'Seguido por:'
       followed_by_noone: Ninguém está seguindo este tópico

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -69,6 +69,14 @@ pt-BR:
       topics_and_posts_counts: "%{topics_count} tópicos / %{posts_count} posts"
       update: :thredded.form.update
       updated_notice: Fórum de mensagem foi atualizado
+    messageboard_first_topic:
+      content: |-
+        There's not a whole lot here for now.
+
+        These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+        You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+        Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
+      title: Welcome to your messageboard's very first thread
     messageboard_group:
       create: Criar um novo grupo de mensagens
       form:
@@ -116,13 +124,6 @@ pt-BR:
       delete_confirm: Você tem certeza que deseja remover este post?
       deleted_notice: Seu post foi removido.
       edit: :thredded.nav.edit_post
-      first_of_messageboard:
-        content: |-
-          There's not a whole lot here for now.
-
-          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
-          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
-          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Conteúdo
         create_btn: Enviar Resposta
@@ -204,8 +205,6 @@ pt-BR:
       delete_topic: Remover Tópico
       deleted_notice: Tópico removido
       edit: Editar Tópico
-      first_of_messageboard:
-        title: Welcome to your messageboard's very first thread
       follow: Siga este tópico
       followed_by: 'Seguido por:'
       followed_by_noone: Ninguém está seguindo este tópico

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -66,6 +66,14 @@ ru:
       topics_and_posts_counts: "%{topics_count} тем / %{posts_count} постов"
       update: :thredded.form.update
       updated_notice: Форум обновлен
+    messageboard_first_topic:
+      content: |-
+        There's not a whole lot here for now.
+
+        These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+        You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+        Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
+      title: Welcome to your messageboard's very first thread
     messageboard_group:
       create: Создать группу форумов
       form:
@@ -112,13 +120,6 @@ ru:
       delete_confirm: Вы уверены что хотите удалить пост?
       deleted_notice: Пост был удален.
       edit: :thredded.nav.edit_post
-      first_of_messageboard:
-        content: |-
-          There's not a whole lot here for now.
-
-          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
-          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
-          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Контент
         create_btn: Ответить
@@ -197,8 +198,6 @@ ru:
       delete_topic: Удалить тему
       deleted_notice: Тема "удалена"
       edit: Редактировать тему
-      first_of_messageboard:
-        title: Welcome to your messageboard's very first thread
       follow: Наблюдать за темой
       followed_by: Наблюдаю
       followed_by_noone: Никто не наблюдает за этой темой

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -112,6 +112,13 @@ ru:
       delete_confirm: Вы уверены что хотите удалить пост?
       deleted_notice: Пост был удален.
       edit: :thredded.nav.edit_post
+      first_of_messageboard:
+        content: |-
+          There's not a whole lot here for now.
+
+          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: Контент
         create_btn: Ответить
@@ -190,6 +197,8 @@ ru:
       delete_topic: Удалить тему
       deleted_notice: Тема "удалена"
       edit: Редактировать тему
+      first_of_messageboard:
+        title: Welcome to your messageboard's very first thread
       follow: Наблюдать за темой
       followed_by: Наблюдаю
       followed_by_noone: Никто не наблюдает за этой темой

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -64,6 +64,14 @@ zh-CN:
       topics_and_posts_counts: "%{topics_count} 帖子 / %{posts_count} 回复"
       update: :thredded.form.update
       updated_notice: 板块已更新
+    messageboard_first_topic:
+      content: |-
+        There's not a whole lot here for now.
+
+        These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+        You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+        Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
+      title: Welcome to your messageboard's very first thread
     messageboard_group:
       create: 创建一个新的板块分组
       form:
@@ -109,13 +117,6 @@ zh-CN:
       delete_confirm: 你确定删除该回复吗？
       deleted_notice: 你的回复已删除
       edit: :thredded.nav.edit_post
-      first_of_messageboard:
-        content: |-
-          There's not a whole lot here for now.
-
-          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
-          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
-          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: 内容
         create_btn: 提交回复
@@ -192,8 +193,6 @@ zh-CN:
       delete_topic: 删除帖子
       deleted_notice: 帖子已删除
       edit: 编辑帖子
-      first_of_messageboard:
-        title: Welcome to your messageboard's very first thread
       follow: 关注该帖子
       followed_by: 关注者：
       followed_by_noone: 无人关注该帖子

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -109,6 +109,13 @@ zh-CN:
       delete_confirm: 你确定删除该回复吗？
       deleted_notice: 你的回复已删除
       edit: :thredded.nav.edit_post
+      first_of_messageboard:
+        content: |-
+          There's not a whole lot here for now.
+
+          These forums are powered by [Thredded](https://github.com/thredded/thredded) v%{thredded_version}.
+          You can contact the Thredded team via the [Thredded chat room](https://gitter.im/thredded/thredded).
+          Please let us know that you are using Thredded by tweeting [@thredded](https://twitter.com/thredded)!
       form:
         content_label: 内容
         create_btn: 提交回复
@@ -185,6 +192,8 @@ zh-CN:
       delete_topic: 删除帖子
       deleted_notice: 帖子已删除
       edit: 编辑帖子
+      first_of_messageboard:
+        title: Welcome to your messageboard's very first thread
       follow: 关注该帖子
       followed_by: 关注者：
       followed_by_noone: 无人关注该帖子


### PR DESCRIPTION
This commit allows customizing the first messageboard post content and topic title by setting the following I18n keys:

- `thredded.topics.first_of_messageboard.title`
- `thredded.posts.first_of_messageboard.content`

The current english text has been copied over in all the locale files to keep the current behaviour.

Note: if [this PR](https://github.com/thredded/thredded/pull/669) is merged before of this, it will break the build, as the italian translation I provided in the other PR doesn't include the new keys mentioned above. Let me know if you need the translation.