### PR TITLE
Allow disabling user links

### DIFF
--- a/app/views/thredded/users/_link.html.erb
+++ b/app/views/thredded/users/_link.html.erb
@@ -1,6 +1,11 @@
 <% if user %>
   <% if !user.thredded_anonymous? %>
-<a href="<%= user_path(user) %>"><%= user.thredded_display_name %></a>
+    <% user_path = user_path(user) %>
+    <% if user_path.blank? %>
+<span class='thredded--username'><%= user.thredded_display_name %></span>
+    <% else %>
+<a href="<%= user_path %>"><%= user.thredded_display_name %></a>
+    <% end %>
   <% else %>
 <%= user.thredded_display_name %>
   <% end %>

--- a/lib/generators/thredded/install/templates/initializer.rb
+++ b/lib/generators/thredded/install/templates/initializer.rb
@@ -19,6 +19,8 @@ Thredded.user_name_column = :name
 # The path (or URL) you will use to link to your users' profiles.
 # When linking to a user, Thredded will use this lambda to spit out
 # the path or url to your user. This lambda is evaluated in the view context.
+# If the lambda returns nil, a span element is returned instead of a link; so
+# setting this to always return nil effectively disables all user links.
 Thredded.user_path = lambda do |user|
   user_path = :"#{Thredded.user_class_name.demodulize.underscore}_path"
   main_app.respond_to?(user_path) ? main_app.send(user_path, user) : "/users/#{user.to_param}"

--- a/spec/lib/thredded_spec.rb
+++ b/spec/lib/thredded_spec.rb
@@ -19,6 +19,12 @@ describe Thredded, '.user_path', thredded_reset: [:@@user_path] do
     Thredded.user_path = ->(_user) { reverse }
     expect(Thredded.user_path(_view_context = 'abc', _user = nil)).to eq 'cba'
   end
+
+  it 'returns nil' do
+    me = build_stubbed(:user, name: 'joel')
+    Thredded.user_path = ->(_user) { nil }
+    expect(Thredded.user_path(_view_context = nil, _user = me)).to be_nil
+  end
 end
 
 describe Thredded, '.user_display_name_method', thredded_reset: %i[@@user_display_name_method @@user_name_column] do

--- a/spec/views/thredded/user/link_spec.rb
+++ b/spec/views/thredded/user/link_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'partial: thredded/users/link' do
     HTML
   end
 
-  it 'with nil user path' do
+  it 'with nil user path', thredded_reset: [:@@user_path] do
     Thredded.user_path = ->(_user) { nil }
     render_partial build_stubbed(:user, id: 5, name: 'joel')
     expect(rendered).to eq <<-HTML.strip_heredoc

--- a/spec/views/thredded/user/link_spec.rb
+++ b/spec/views/thredded/user/link_spec.rb
@@ -28,4 +28,12 @@ RSpec.describe 'partial: thredded/users/link' do
       <em>#{I18n.t('thredded.null_user_name')}</em>
     HTML
   end
+
+  it 'with nil user path' do
+    Thredded.user_path = ->(_user) { nil }
+    render_partial build_stubbed(:user, id: 5, name: 'joel')
+    expect(rendered).to eq <<-HTML.strip_heredoc
+      <span class='thredded--username'>joel</span>
+    HTML
+  end
 end


### PR DESCRIPTION
This commit changes the user link partial to render a span element
instead of a link when the user_path lambda is evaluated to nil.

Therefor, it allows disabling all user links by setting the `user_path`
lambda to always return nil.

This can be useful if, for any reason, you only want to link to some
user profiles (just write the lambda so that it returns only valid
links, and nil otherwise), or if you want to completely disable the
profile link feature.