### PR TITLE
Protect against onebox errors

### DIFF
--- a/lib/thredded/html_pipeline/onebox_filter.rb
+++ b/lib/thredded/html_pipeline/onebox_filter.rb
@@ -75,7 +75,7 @@ module Thredded
           preview.to_s.strip
         end
       rescue => e
-        puts "Onebox error for #{url}: #{e} "
+        Rails.logger.error("Onebox error for #{url}: #{e}")
         url
       end
 

--- a/lib/thredded/html_pipeline/onebox_filter.rb
+++ b/lib/thredded/html_pipeline/onebox_filter.rb
@@ -74,7 +74,7 @@ module Thredded
         else
           preview.to_s.strip
         end
-      rescue => e
+      rescue StandardError => e
         Rails.logger.error("Onebox error for #{url}: #{e}")
         <<~HTML
           <p><a href="#{ERB::Util.html_escape(url)}" target="_blank" rel="nofollow noopener">#{ERB::Util.html_escape(url)}</p>

--- a/lib/thredded/html_pipeline/onebox_filter.rb
+++ b/lib/thredded/html_pipeline/onebox_filter.rb
@@ -74,6 +74,9 @@ module Thredded
         else
           preview.to_s.strip
         end
+      rescue => e
+        puts "Onebox error for #{url}: #{e} "
+        url
       end
 
       def onebox_options(_url)

--- a/lib/thredded/html_pipeline/onebox_filter.rb
+++ b/lib/thredded/html_pipeline/onebox_filter.rb
@@ -76,7 +76,9 @@ module Thredded
         end
       rescue => e
         Rails.logger.error("Onebox error for #{url}: #{e}")
-        url
+        <<~HTML
+          <p><a href="#{ERB::Util.html_escape(url)}" target="_blank" rel="nofollow noopener">#{ERB::Util.html_escape(url)}</p>
+        HTML
       end
 
       def onebox_options(_url)

--- a/spec/lib/thredded/content_formatter_spec.rb
+++ b/spec/lib/thredded/content_formatter_spec.rb
@@ -108,6 +108,29 @@ describe Thredded::ContentFormatter do
       end
     end
 
+    context "with no onebox caching" do
+      around do |example|
+        onebox_views_cache = Thredded::HtmlPipeline::OneboxFilter.onebox_views_cache
+        onebox_data_cache = Thredded::HtmlPipeline::OneboxFilter.onebox_data_cache
+        Thredded::HtmlPipeline::OneboxFilter.onebox_views_cache = ActiveSupport::Cache::MemoryStore.new
+        Thredded::HtmlPipeline::OneboxFilter.onebox_data_cache = ActiveSupport::Cache::MemoryStore.new
+        example.run
+        Thredded::HtmlPipeline::OneboxFilter.onebox_views_cache = onebox_views_cache
+        Thredded::HtmlPipeline::OneboxFilter.onebox_data_cache = onebox_data_cache
+      end
+
+      context 'if onebox throws an error' do
+        it "we just render the url" do
+          allow(Onebox).to receive(:preview) do
+            raise "Onebox internal error"
+          end
+          rendered = format_content(xkcd_url)
+          expect(rendered).not_to include('onebox')
+          expect(rendered).to eq(xkcd_url)
+        end
+      end
+    end
+
     it 'renders FakeContent sample oneboxes' do
       # This also ensures all the oneboxes are VCR'd
       expect { format_content(FakeContent::ONEBOXES.join("\n")) }.to_not raise_error

--- a/spec/lib/thredded/content_formatter_spec.rb
+++ b/spec/lib/thredded/content_formatter_spec.rb
@@ -108,7 +108,7 @@ describe Thredded::ContentFormatter do
       end
     end
 
-    context "with no onebox caching" do
+    context 'with no onebox caching' do
       around do |example|
         onebox_views_cache = Thredded::HtmlPipeline::OneboxFilter.onebox_views_cache
         onebox_data_cache = Thredded::HtmlPipeline::OneboxFilter.onebox_data_cache
@@ -120,13 +120,12 @@ describe Thredded::ContentFormatter do
       end
 
       context 'if onebox throws an error' do
-        it "we just render the url" do
-          allow(Onebox).to receive(:preview) do
-            raise "Onebox internal error"
-          end
-          rendered = format_content(xkcd_url)
-          expect(rendered).not_to include('onebox')
-          expect(rendered).to eq(xkcd_url)
+        subject { format_content(xkcd_url) }
+
+        it 'renders just the url without error' do
+          allow(Onebox).to receive(:preview).and_raise('Onebox internal error')
+          expect(subject).not_to include('onebox')
+          expect(subject).to eq(xkcd_url)
         end
       end
     end

--- a/spec/lib/thredded/content_formatter_spec.rb
+++ b/spec/lib/thredded/content_formatter_spec.rb
@@ -125,7 +125,8 @@ describe Thredded::ContentFormatter do
         it 'renders just the url without error' do
           allow(Onebox).to receive(:preview).and_raise('Onebox internal error')
           expect(subject).not_to include('onebox')
-          expect(subject).to eq(xkcd_url)
+          expect(subject).to include(xkcd_url)
+          expect(subject).to match /href=["']#{xkcd_url}/
         end
       end
     end


### PR DESCRIPTION
Fixes #682 

@glebm Are we ok to use Rails.logger ? Mine was first example of it (in webapps I'd use some kind of exception notifier (Rollbar or Bugsnag or whatever, but Rails.logger is our best bet I presume for the engine) 