### PR TITLE
Reduces number of queries in AutofollowUsers

### DIFF
--- a/app/commands/thredded/autofollow_users.rb
+++ b/app/commands/thredded/autofollow_users.rb
@@ -36,13 +36,18 @@ module Thredded
     # @return [Enumerable<Thredded.user_class>]
     def auto_followers
       user_board_prefs = post.messageboard.user_messageboard_preferences.each_with_object({}) do |ump, h|
-        h[ump.user] = ump
+        h[ump.user_id] = ump
       end
       Thredded.user_class.includes(:thredded_user_preference)
         .select(Thredded.user_class.primary_key)
         .find_each(batch_size: 50_000).select do |user|
-        (user_board_prefs[user] ||
-            Thredded::UserMessageboardPreference.new(messageboard: post.messageboard, user: user)).auto_follow_topics?
+
+        result = user_board_prefs[user.id]
+        result ||= Thredded::UserMessageboardPreference.new(
+          messageboard: post.messageboard,
+          user_preference: user.thredded_user_preference
+        )
+        result.auto_follow_topics?
       end
     end
 


### PR DESCRIPTION
`AutofollowUsers` needs to iterate over all users to check if given user
needs to follow new post.

There were two performance problems in this code:
1. In the code that constructed a hash with messageboard preferences for
each user who had one there was no eager loading. This resulted in one
`SELECT` query for each user with messageboard preferences.
2. There is eager loading for `User#thredded_user_preference`
association. Because it wasn't passed to
`Thredded::UserMessageboardPreference` Rails didn't use eager loaded
object and fired a query instead. This resulted in one `SELECT` query
for each user.

This commit fixes both problems by adding `:user` eager loading for
`user_messageboard_preferences` and by explitly passing `user_preference`
to `Thredded::UserMessageboardPreference` initializer to ensure that
eager loaded object is used.

closes https://github.com/thredded/thredded/issues/687