### PR TITLE
Jump to the first unread post when navigating to a topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   Spoilers are focusable and are activated on mousedown, spacebar, or enter. They can also be nested.
   Markup is configurable via `Thredded::SpoilerTagFilter.spoiler_tags`.
   [#701](https://github.com/thredded/thredded/pull/701)
+* Jump to the first unread post when navigating to a topic.
+  [#695](https://github.com/thredded/thredded/pull/695)
 
 ## Fixed
 
@@ -21,7 +23,7 @@
 * Post IP tracking removed from core because it requires explicit consent under GDPR.
   [#705](https://github.com/thredded/thredded/pull/705)
 
-**NB: If updating to this version from 0.14.x, you **must** copy and run the upgrade migration after updating the gem:
+**NB**: If updating to this version from 0.14.x, you **must** copy and run the upgrade migration after updating the gem:
 
 ```console
 cp "$(bundle show thredded)"/db/upgrade_migrations/20180110200009_upgrade_thredded_v0_14_to_v0_15.rb db/migrate

--- a/app/commands/thredded/mark_all_read.rb
+++ b/app/commands/thredded/mark_all_read.rb
@@ -8,14 +8,8 @@ module Thredded
 
       unread_topics.each do |topic|
         last_post = topic.posts.order_oldest_first.last
-        total_pages = topic.posts.page(1).total_pages
 
-        Thredded::UserPrivateTopicReadState.touch!(
-          user.id,
-          topic.id,
-          last_post,
-          total_pages
-        )
+        Thredded::UserPrivateTopicReadState.touch!(user.id, topic.id, last_post)
       end
     end
   end

--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -55,8 +55,7 @@ module Thredded
 
     def mark_as_unread
       authorize post, :read?
-      page = post.page(user: thredded_current_user)
-      post.mark_as_unread(thredded_current_user, page)
+      post.mark_as_unread(thredded_current_user)
       after_mark_as_unread # customization hook
     end
 

--- a/app/controllers/thredded/private_posts_controller.rb
+++ b/app/controllers/thredded/private_posts_controller.rb
@@ -54,8 +54,7 @@ module Thredded
 
     def mark_as_unread
       authorize post, :read?
-      page = post.page
-      post.mark_as_unread(thredded_current_user, page)
+      post.mark_as_unread(thredded_current_user)
       after_mark_as_unread # customization hook
     end
 

--- a/app/controllers/thredded/private_topics_controller.rb
+++ b/app/controllers/thredded/private_topics_controller.rb
@@ -34,9 +34,7 @@ module Thredded
       @posts = Thredded::TopicPostsPageView.new(thredded_current_user, private_topic, page_scope)
 
       if thredded_signed_in?
-        Thredded::UserPrivateTopicReadState.touch!(
-          thredded_current_user.id, private_topic.id, page_scope.last, current_page
-        )
+        Thredded::UserPrivateTopicReadState.touch!(thredded_current_user.id, private_topic.id, page_scope.last)
       end
 
       @new_post = Thredded::PrivatePostForm.new(

--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -44,9 +44,7 @@ module Thredded
       @posts = Thredded::TopicPostsPageView.new(thredded_current_user, topic, page_scope)
 
       if thredded_signed_in?
-        Thredded::UserTopicReadState.touch!(
-          thredded_current_user.id, topic.id, page_scope.last, current_page
-        )
+        Thredded::UserTopicReadState.touch!(thredded_current_user.id, topic.id, page_scope.last)
       end
 
       @new_post = Thredded::PostForm.new(user: thredded_current_user, topic: topic, post_params: new_post_params)

--- a/app/forms/thredded/post_form.rb
+++ b/app/forms/thredded/post_form.rb
@@ -11,7 +11,7 @@ module Thredded
 
     # @param user [Thredded.user_class]
     # @param topic [Topic]
-    # @param post [PrivatePost]
+    # @param post [Post]
     # @param post_params [Hash]
     def initialize(user:, topic:, post: nil, post_params: {})
       @messageboard = topic.messageboard
@@ -47,7 +47,9 @@ module Thredded
 
     def save
       return false unless @post.valid?
+      was_persisted = @post.persisted?
       @post.save!
+      Thredded::UserTopicReadState.touch!(@post.user.id, @topic.id, @post) unless was_persisted
       true
     end
   end

--- a/app/forms/thredded/private_post_form.rb
+++ b/app/forms/thredded/private_post_form.rb
@@ -11,7 +11,7 @@ module Thredded
 
     # @param user [Thredded.user_class]
     # @param topic [PrivateTopic]
-    # @param post [Post]
+    # @param post [PrivatePost]
     # @param post_params [Hash]
     def initialize(user:, topic:, post: nil, post_params: {})
       @topic = topic
@@ -43,7 +43,9 @@ module Thredded
 
     def save
       return false unless @post.valid?
+      was_persisted = @post.persisted?
       @post.save!
+      Thredded::UserPrivateTopicReadState.touch!(@post.user.id, @topic.id, @post) unless was_persisted
       true
     end
   end

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -50,16 +50,15 @@ module Thredded
     # Marks all the posts from the given one as unread for the given user
     # @param user [Thredded.user_class]
     # @param page [Integer]
-    def mark_as_unread(user, page)
+    def mark_as_unread(user)
       if previous_post.nil?
         read_state = postable.user_read_states.find_by(user_id: user.id)
         read_state.destroy if read_state
       else
         read_state = postable.user_read_states.create_with(
-          read_at: previous_post.created_at,
-          page: page
+          read_at: previous_post.created_at
         ).find_or_create_by(user_id: user.id)
-        read_state.update_columns(read_at: previous_post.created_at, page: page)
+        read_state.update_columns(read_at: previous_post.created_at)
       end
     end
 

--- a/app/models/concerns/thredded/topic_common.rb
+++ b/app/models/concerns/thredded/topic_common.rb
@@ -58,6 +58,10 @@ module Thredded
           .merge(reads_class.where(reads[:id].eq(nil).or(reads[:read_at].lt(topics[:last_post_at]))))
       end
 
+      def post_class
+        reflect_on_association(:posts).klass
+      end
+
       private
 
       # @param user [Thredded.user_class]
@@ -65,6 +69,7 @@ module Thredded
       def read_states_by_postable_hash(user)
         read_states = reflect_on_association(:user_read_states).klass
           .where(user_id: user.id, postable_id: current_scope.map(&:id))
+          .with_page_info(posts_scope: Pundit.policy_scope(user, post_class.all))
         Thredded::TopicCommon::CachingHash.from_relation(read_states)
       end
 

--- a/app/models/concerns/thredded/user_topic_read_state_common.rb
+++ b/app/models/concerns/thredded/user_topic_read_state_common.rb
@@ -6,6 +6,8 @@ module Thredded
     included do
       extend ClassMethods
       validates :user_id, uniqueness: { scope: :postable_id }
+      attribute :first_unread_post_page, ActiveRecord::Type::Integer.new
+      attribute :last_read_post_page, ActiveRecord::Type::Integer.new
     end
 
     # @return [Boolean]
@@ -23,20 +25,75 @@ module Thredded
       # @param user_id [Integer]
       # @param topic_id [Integer]
       # @param post [Thredded::PostCommon]
-      # @param post_page [Integer]
-      def touch!(user_id, topic_id, post, post_page)
+      def touch!(user_id, topic_id, post)
         # TODO: Switch to upsert once Travis supports PostgreSQL 9.5.
         # Travis issue: https://github.com/travis-ci/travis-ci/issues/4264
         # Upsert gem: https://github.com/seamusabshere/upsert
         state = find_or_initialize_by(user_id: user_id, postable_id: topic_id)
-        fail ArgumentError, "expected post_page >= 1, given #{post_page.inspect}" if post_page < 1
         return unless !state.read_at? || state.read_at < post.created_at
-        state.update!(read_at: post.created_at, page: post_page)
+        state.update!(read_at: post.created_at)
       end
 
       def read_on_first_post!(user, topic)
-        create!(user: user, postable: topic, read_at: Time.zone.now, page: 1)
+        create!(user: user, postable: topic, read_at: Time.zone.now)
       end
+
+      # Adds `first_unread_post_page` and `last_read_post_page` columns onto the scope.
+      # Skips the records that have no read posts.
+      def with_page_info( # rubocop:disable Metrics/MethodLength
+        posts_per_page: topic_class.default_per_page, posts_scope: post_class.all
+      )
+        states = arel_table
+        self_relation = is_a?(ActiveRecord::Relation) ? self : all
+        if self_relation == unscoped
+          states_select_manager = states
+        else
+          # Using the relation here is redundant but massively improves performance.
+          states_select_manager = Thredded::ArelCompat.new_arel_select_manager(
+            Arel::Nodes::TableAlias.new(Thredded::ArelCompat.relation_to_arel(self_relation), table_name)
+          )
+        end
+        read = if posts_scope == post_class.unscoped
+                 post_class.arel_table
+               else
+                 posts_subquery = Thredded::ArelCompat.relation_to_arel(posts_scope)
+                 Arel::Nodes::TableAlias.new(posts_subquery, 'read_posts')
+               end
+        unread_topics = topic_class.arel_table
+        page_info =
+          states_select_manager
+            .project(
+              states[:id],
+              Arel::Nodes::Case.new(unread_topics[:id].not_eq(nil))
+                .when(Thredded::ArelCompat.true_value(self)).then(
+                  Arel::Nodes::Addition.new(
+                    Thredded::ArelCompat.integer_division(self, read[:id].count, posts_per_page), 1
+                  )
+                ).else(nil)
+                .as('first_unread_post_page'),
+              Arel::Nodes::Addition.new(
+                Thredded::ArelCompat.integer_division(self, read[:id].count, posts_per_page),
+                Arel::Nodes::Case.new(Arel::Nodes::InfixOperation.new(:%, read[:id].count, posts_per_page))
+                  .when(0).then(0).else(1)
+              ).as('last_read_post_page')
+            )
+            .join(read)
+            .on(read[:postable_id].eq(states[:postable_id]).and(read[:created_at].lteq(states[:read_at])))
+            .outer_join(unread_topics)
+            .on(states[:postable_id].eq(unread_topics[:id]).and(unread_topics[:last_post_at].gt(states[:read_at])))
+            .group(states[:id], unread_topics[:id])
+            .as('id_and_page_info')
+
+        # We use a subquery because selected fields must appear in the GROUP BY or be used in an aggregate function.
+        select(states[Arel.star], page_info[:first_unread_post_page], page_info[:last_read_post_page])
+          .joins(states.join(page_info).on(states[:id].eq(page_info[:id])).join_sources)
+      end
+
+      def topic_class
+        reflect_on_association(:postable).klass
+      end
+
+      delegate :post_class, to: :topic_class
     end
   end
 end

--- a/app/models/thredded/null_user_topic_read_state.rb
+++ b/app/models/thredded/null_user_topic_read_state.rb
@@ -13,5 +13,13 @@ module Thredded
     def post_read?(_post)
       false
     end
+
+    def first_unread_post_page
+      nil
+    end
+
+    def last_read_post_page
+      1
+    end
   end
 end

--- a/app/policies/thredded/private_post_policy.rb
+++ b/app/policies/thredded/private_post_policy.rb
@@ -2,6 +2,22 @@
 
 module Thredded
   class PrivatePostPolicy
+    # The scope of readable private posts.
+    # {PrivateTopicPolicy} must be applied separately.
+    class Scope
+      # @param user [Thredded.user_class]
+      # @param scope [ActiveRecord::Relation<Thredded::Post>]
+      def initialize(user, scope)
+        @user = user
+        @scope = scope
+      end
+
+      # @return [ActiveRecord::Relation<Thredded::Post>]
+      def resolve
+        @scope
+      end
+    end
+
     # @param user [Thredded.user_class]
     # @param post [Thredded::PrivatePost]
     def initialize(user, post)

--- a/app/view_hooks/thredded/all_view_hooks.rb
+++ b/app/view_hooks/thredded/all_view_hooks.rb
@@ -36,11 +36,14 @@ module Thredded
     # View hooks for collections of public or private posts.
     class PostsCommon
       # @return [Thredded::AllViewHooks::ViewHook]
+      attr_reader :before_first_unread_post
+      # @return [Thredded::AllViewHooks::ViewHook]
       attr_reader :pagination_top
       # @return [Thredded::AllViewHooks::ViewHook]
       attr_reader :pagination_bottom
 
       def initialize
+        @before_first_unread_post = ViewHook.new
         @pagination_top = ViewHook.new
         @pagination_bottom = ViewHook.new
       end

--- a/app/view_models/thredded/base_topic_view.rb
+++ b/app/view_models/thredded/base_topic_view.rb
@@ -37,7 +37,11 @@ module Thredded
     end
 
     def path
-      Thredded::UrlsHelper.topic_path(@topic, page: @read_state.page)
+      Thredded::UrlsHelper.topic_path(
+        @topic,
+        page: @read_state.first_unread_post_page || @read_state.last_read_post_page,
+        anchor: ('unread' if @read_state.first_unread_post_page)
+      )
     end
   end
 end

--- a/app/view_models/thredded/post_view.rb
+++ b/app/view_models/thredded/post_view.rb
@@ -17,10 +17,14 @@ module Thredded
     # @param post [Thredded::PostCommon]
     # @param policy [#create? #update? #destroy? #moderate?]
     # @param topic_view [Thredded::TopicView]
-    def initialize(post, policy, topic_view: nil)
+    # @param first_in_page [Boolean]
+    # @param first_unread_in_page [Boolean]
+    def initialize(post, policy, topic_view: nil, first_in_page: false, first_unread_in_page: false)
       @post   = post
       @policy = policy
       @topic_view = topic_view
+      @first_unread_in_page = first_unread_in_page
+      @first_in_page = first_in_page
     end
 
     def can_reply?
@@ -84,6 +88,14 @@ module Thredded
       else
         POST_IS_UNREAD
       end
+    end
+
+    def first_unread_in_page?
+      @first_unread_in_page
+    end
+
+    def first_in_page?
+      @first_in_page
     end
   end
 end

--- a/app/view_models/thredded/posts_page_view.rb
+++ b/app/view_models/thredded/posts_page_view.rb
@@ -19,8 +19,17 @@ module Thredded
     # @param paginated_scope [ActiveRecord::Relation<Thredded::PostCommon>]
     def initialize(user, paginated_scope, topic_view: nil)
       @paginated_scope = paginated_scope
-      @post_views      = paginated_scope.map do |post|
-        Thredded::PostView.new(post, Pundit.policy!(user, post), topic_view: topic_view)
+      prev_read = false
+      @post_views = paginated_scope.map.with_index do |post, i|
+        post_read = topic_view.post_read?(post)
+        post_view = Thredded::PostView.new(
+          post, Pundit.policy!(user, post),
+          topic_view: topic_view,
+          first_in_page: i.zero?,
+          first_unread_in_page: !post_read && prev_read
+        )
+        prev_read = post_read
+        post_view
       end
     end
   end

--- a/app/views/thredded/posts/_post.html.erb
+++ b/app/views/thredded/posts/_post.html.erb
@@ -1,4 +1,5 @@
 <% post, content = post_and_content if local_assigns.key?(:post_and_content) %>
+<%= render 'thredded/posts_common/before_first_unread_post', post: post if post.first_unread_in_page? %>
 <%= content_tag :article, id: dom_id(post), class: "thredded--post thredded--#{post.read_state}--post" do %>
   <%= render 'thredded/posts_common/actions', post: post, actions: local_assigns[:actions] %>
   <%= render 'thredded/posts_common/header', post: post %>

--- a/app/views/thredded/posts_common/_before_first_unread_post.html.erb
+++ b/app/views/thredded/posts_common/_before_first_unread_post.html.erb
@@ -1,0 +1,7 @@
+<div class="thredded--before-first-unread-post<%= ' unread--before-first-unread-post--first-in-page' if post.first_in_page? %>">
+  <%= view_hooks.posts_common.before_first_unread_post.render(self, post: post) do %>
+    <% unless post.first_in_page? %>
+      <span id="unread"></span>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/thredded/private_posts/_private_post.html.erb
+++ b/app/views/thredded/private_posts/_private_post.html.erb
@@ -1,5 +1,6 @@
 <% private_post, content = post_and_content if local_assigns.key?(:post_and_content) %>
-<%= content_tag :article, id: dom_id(private_post), class: 'thredded--post' do %>
+<%= render 'thredded/posts_common/before_first_unread_post', post: private_post if private_post.first_unread_in_page? %>
+<%= content_tag :article, id: dom_id(private_post), class: "thredded--post thredded--#{private_post.read_state}--post" do %>
   <%= render 'thredded/posts_common/actions', post: private_post, actions: local_assigns[:actions] %>
   <%= render 'thredded/posts_common/header', post: private_post %>
   <%= content || render('thredded/private_posts/content', post: post) %>

--- a/db/migrate/20160329231848_create_thredded.rb
+++ b/db/migrate/20160329231848_create_thredded.rb
@@ -70,7 +70,7 @@ class CreateThredded < Thredded::BaseMigration
               name:  :index_thredded_posts_for_display
       t.index [:messageboard_id], name: :index_thredded_posts_on_messageboard_id
       t.index [:postable_id], name: :index_thredded_posts_on_postable_id
-      t.index [:postable_id], name: :index_thredded_posts_on_postable_id_and_postable_type
+      t.index %i[postable_id created_at], name: :index_thredded_posts_on_postable_id_and_created_at
       t.index [:user_id], name: :index_thredded_posts_on_user_id
     end
     DbTextSearch::FullText.add_index connection, :thredded_posts, :content, name: :thredded_posts_content_fts
@@ -80,6 +80,7 @@ class CreateThredded < Thredded::BaseMigration
       t.text :content, limit: 65_535
       t.references :postable, null: false, index: false
       t.timestamps null: false
+      t.index %i[postable_id created_at], name: :index_thredded_private_posts_on_postable_id_and_created_at
     end
 
     create_table :thredded_private_topics do |t|
@@ -91,6 +92,7 @@ class CreateThredded < Thredded::BaseMigration
       t.string :hash_id, limit: 20, null: false
       t.datetime :last_post_at
       t.timestamps null: false
+      t.index [:last_post_at], name: :index_thredded_private_topics_on_last_post_at
       t.index [:hash_id], name: :index_thredded_private_topics_on_hash_id
       t.index [:slug],
               name: :index_thredded_private_topics_on_slug,
@@ -129,6 +131,7 @@ class CreateThredded < Thredded::BaseMigration
       t.index %i[moderation_state sticky updated_at],
               order: { sticky: :desc, updated_at: :desc },
               name:  :index_thredded_topics_for_display
+      t.index [:last_post_at], name: :index_thredded_topics_on_last_post_at
       t.index [:hash_id], name: :index_thredded_topics_on_hash_id
       t.index [:slug],
               name: :index_thredded_topics_on_slug,
@@ -194,7 +197,6 @@ class CreateThredded < Thredded::BaseMigration
       create_table table_name do |t|
         t.references :user, type: user_id_type, null: false, index: false
         t.references :postable, null: false, index: false
-        t.integer :page, default: 1, null: false
         t.timestamp :read_at, null: false
         t.index %i[user_id postable_id], name: :"#{table_name}_user_postable", unique: true
       end

--- a/db/upgrade_migrations/20180110200009_upgrade_thredded_v0_14_to_v0_15.rb
+++ b/db/upgrade_migrations/20180110200009_upgrade_thredded_v0_14_to_v0_15.rb
@@ -66,6 +66,19 @@ class UpgradeThreddedV014ToV015 < Thredded::BaseMigration
     # https://github.com/thredded/thredded/pull/705
     remove_column :thredded_posts, :ip
     remove_column :thredded_private_posts, :ip
+
+    # Jump to first unread post
+    # https://github.com/thredded/thredded/pull/695
+    remove_column :thredded_user_topic_read_states, :page
+    remove_column :thredded_user_private_topic_read_states, :page
+    add_index :thredded_topics, [:last_post_at], name: :index_thredded_topics_on_last_post_at
+    add_index :thredded_private_topics, [:last_post_at], name: :index_thredded_private_topics_on_last_post_at
+    add_index :thredded_posts, %i[postable_id created_at], name: :index_thredded_posts_on_postable_id_and_created_at
+    add_index :thredded_private_posts, %i[postable_id created_at],
+              name: :index_thredded_private_posts_on_postable_id_and_created_at
+
+    # Cleanup
+    remove_index :thredded_posts, name: :index_thredded_posts_on_postable_id_and_created_at
   end
 
   private

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -41,6 +41,7 @@ require 'thredded/content_formatter'
 require 'thredded/email_transformer'
 require 'thredded/base_notifier'
 
+require 'thredded/arel_compat'
 require 'thredded/collection_to_strings_with_cache_renderer'
 
 module Thredded

--- a/lib/thredded/arel_compat.rb
+++ b/lib/thredded/arel_compat.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+unless Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2 || Rails::VERSION::MAJOR > 5
+  require 'thredded/rails_lt_5_2_arel_case_node.rb'
+end
+
+module Thredded
+  module ArelCompat
+    module_function
+
+    # @param [#connection] engine
+    # @param [Arel::Nodes::Node] a integer node
+    # @param [Arel::Nodes::Node] b integer node
+    # @return [Arel::Nodes::Node] a / b
+    def integer_division(engine, a, b)
+      if engine.connection.adapter_name =~ /mysql|mariadb/i
+        Arel::Nodes::InfixOperation.new('DIV', a, b)
+      else
+        Arel::Nodes::Division.new(a, b)
+      end
+    end
+
+    if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2 || Rails::VERSION::MAJOR > 5
+      # @param [ActiveRecord::Relation] relation
+      # @return [Arel::Nodes::Node]
+      def relation_to_arel(relation)
+        relation.arel
+      end
+    else
+      def relation_to_arel(relation)
+        Arel.sql("(#{relation.to_sql})")
+      end
+    end
+
+    if Rails::VERSION::MAJOR >= 5
+      # @param [Arel::Nodes::Node] table
+      # @return [Arel::SelectManager]
+      def new_arel_select_manager(table)
+        Arel::SelectManager.new(table)
+      end
+    else
+      def new_arel_select_manager(table)
+        Arel::SelectManager.new(ActiveRecord::Base, table)
+      end
+    end
+
+    if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2 || Rails::VERSION::MAJOR > 5
+      def true_value(_engine)
+        true
+      end
+    else
+      def true_value(engine)
+        engine.connection.adapter_name =~ /sqlite|mysql|mariadb/i ? 1 : true
+      end
+    end
+  end
+end

--- a/lib/thredded/database_seeder.rb
+++ b/lib/thredded/database_seeder.rb
@@ -231,9 +231,9 @@ module Thredded
     def read_topic(topic, user_id)
       read_state = Thredded::UserTopicReadState.find_or_initialize_by(user_id: user_id, postable_id: topic.id)
       if rand(2).zero?
-        read_state.update!(read_at: topic.updated_at, page: 1)
+        read_state.update!(read_at: topic.updated_at)
       else
-        read_state.update!(read_at: topic.posts.order_newest_first.first(2).last.created_at, page: 1)
+        read_state.update!(read_at: topic.posts.order_newest_first.first(2).last.created_at)
       end
     end
 

--- a/lib/thredded/rails_lt_5_2_arel_case_node.rb
+++ b/lib/thredded/rails_lt_5_2_arel_case_node.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module Arel
+  module Nodes
+    class Case < Arel::Nodes::Node
+      include Arel::OrderPredications
+      include Arel::Predications
+      include Arel::AliasPredication
+
+      attr_accessor :case, :conditions, :default
+
+      def initialize(expression = nil, default = nil)
+        @case = expression
+        @conditions = []
+        @default = default
+      end
+
+      def when(condition, expression = nil)
+        @conditions << When.new(Nodes.build_quoted(condition), expression)
+        self
+      end
+
+      def then(expression)
+        @conditions.last.right = Nodes.build_quoted(expression)
+        self
+      end
+
+      def else(expression)
+        @default = Else.new Nodes.build_quoted(expression)
+        self
+      end
+
+      def initialize_copy(other)
+        super
+        @case = @case.clone if @case
+        @conditions = @conditions.map(&:clone)
+        @default = @default.clone if @default
+      end
+
+      def hash
+        [@case, @conditions, @default].hash
+      end
+
+      def eql?(other)
+        self.class == other.class &&
+          self.case == other.case &&
+          conditions == other.conditions &&
+          default == other.default
+      end
+
+      alias == eql?
+    end
+
+    class When < Binary
+    end
+
+    class Else < Unary
+    end
+  end
+end
+
+module Arel
+  module Visitors
+    class DepthFirst < Arel::Visitors::Visitor
+      alias visit_Arel_Nodes_Else unary
+
+      def visit_Arel_Nodes_Case(o) # rubocop:disable Style/MethodName
+        visit o.case
+        visit o.conditions
+        visit o.default
+      end
+
+      alias visit_Arel_Nodes_When binary
+    end
+  end
+end
+
+module Arel
+  module Predications
+    def when(right)
+      Nodes::Case.new(self).when quoted_node(right)
+    end
+  end
+end
+
+module Arel
+  module Visitors
+    class ToSql < Arel::Visitors::Reduce
+      def visit_Arel_Nodes_Case(o, collector) # rubocop:disable Style/MethodName
+        collector << 'CASE '
+        if o.case
+          visit o.case, collector
+          collector << ' '
+        end
+        o.conditions.each do |condition|
+          visit condition, collector
+          collector << ' '
+        end
+        if o.default
+          visit o.default, collector
+          collector << ' '
+        end
+        collector << 'END'
+      end
+
+      def visit_Arel_Nodes_When(o, collector) # rubocop:disable Style/MethodName
+        collector << 'WHEN '
+        visit o.left, collector
+        collector << ' THEN '
+        visit o.right, collector
+      end
+
+      def visit_Arel_Nodes_Else(o, collector) # rubocop:disable Style/MethodName
+        collector << 'ELSE '
+        visit o.expr, collector
+      end
+    end
+  end
+end

--- a/spec/models/thredded/post_spec.rb
+++ b/spec/models/thredded/post_spec.rb
@@ -300,7 +300,7 @@ module Thredded
     context 'when first post' do
       it 'removes the read state' do
         expect do
-          first_post.mark_as_unread(user, page)
+          first_post.mark_as_unread(user)
         end.to change { topic.reload.user_read_states.count }.by(-1)
       end
     end
@@ -308,13 +308,8 @@ module Thredded
     context 'when third (say) post' do
       it 'changes the read state to the previous post' do
         expect do
-          third_post.mark_as_unread(user, page)
+          third_post.mark_as_unread(user)
         end.to change { read_state.reload.read_at }.to eq second_post.created_at
-      end
-
-      it 'changes the page to the previous posts' do
-        third_post.mark_as_unread(user, a_different_page)
-        expect(read_state.reload.page).to eq(a_different_page)
       end
     end
 
@@ -322,18 +317,14 @@ module Thredded
       let(:read_state) { nil }
       it 'marking first post as unread does nothing' do
         expect do
-          first_post.mark_as_unread(user, page)
+          first_post.mark_as_unread(user)
         end.to_not change { topic.reload.user_read_states.count }
       end
       it 'marking third post as unread creates read state for second post' do
         expect do
-          third_post.mark_as_unread(user, page)
+          third_post.mark_as_unread(user)
         end.to change { topic.reload.user_read_states.count }.by(page)
         expect(topic.user_read_states.last.read_at).to eq(second_post.created_at)
-      end
-      it 'uses given page' do
-        third_post.mark_as_unread(user, a_different_page)
-        expect(topic.user_read_states.last.page).to eq(a_different_page)
       end
     end
 
@@ -342,7 +333,7 @@ module Thredded
 
       it 'marking the third post as unread changes read state to second post' do
         expect do
-          third_post.mark_as_unread(user, page)
+          third_post.mark_as_unread(user)
         end.to change { read_state.reload.read_at }.to eq second_post.created_at
       end
     end

--- a/spec/models/thredded/private_post_spec.rb
+++ b/spec/models/thredded/private_post_spec.rb
@@ -82,7 +82,7 @@ module Thredded
     context 'when first post' do
       it 'removes the read state' do
         expect do
-          first_post.mark_as_unread(user, page)
+          first_post.mark_as_unread(user)
         end.to change { private_topic.reload.user_read_states.count }.by(-1)
       end
     end
@@ -90,7 +90,7 @@ module Thredded
     context 'when third (say) post' do
       it 'changes the read state to the previous post' do
         expect do
-          third_post.mark_as_unread(user, page)
+          third_post.mark_as_unread(user)
         end.to change { read_state.reload.read_at }.to eq second_post.created_at
       end
     end
@@ -99,12 +99,12 @@ module Thredded
       let(:read_state) { nil }
       it 'marking first post as unread does nothing' do
         expect do
-          first_post.mark_as_unread(user, page)
+          first_post.mark_as_unread(user)
         end.to_not change { private_topic.reload.user_read_states.count }
       end
       it 'marking third post as unread creates read state' do
         expect do
-          third_post.mark_as_unread(user, page)
+          third_post.mark_as_unread(user)
         end.to change { private_topic.reload.user_read_states.count }
       end
     end
@@ -119,7 +119,7 @@ module Thredded
 
       it 'marking the third post as unread changes read state to second post' do
         expect do
-          third_post.mark_as_unread(user, page)
+          third_post.mark_as_unread(user)
         end.to change { read_state.reload.read_at }.to eq second_post.created_at
       end
     end

--- a/spec/models/thredded/private_topic_spec.rb
+++ b/spec/models/thredded/private_topic_spec.rb
@@ -5,10 +5,10 @@ require 'spec_helper'
 module Thredded
   describe PrivateTopic, '.with_read_states' do
     let(:user) { create(:user) }
-    let!(:private_topic) { create(:private_topic) }
+    let!(:private_topic) { create(:private_topic, with_posts: 2) }
 
     context 'when unread' do
-      it 'returns nulls ' do
+      it 'returns nulls' do
         first = PrivateTopic.all.with_read_states(user).first
         expect(first[0]).to eq(private_topic)
         expect(first[1]).to be_an_instance_of(Thredded::NullUserTopicReadState)
@@ -17,9 +17,12 @@ module Thredded
 
     context 'when read' do
       let!(:read_state) do
-        create(:user_private_topic_read_state, user: user, postable: private_topic, read_at: 1.day.ago)
+        create(
+          :user_private_topic_read_state, user: user, postable: private_topic,
+                                          read_at: private_topic.posts.order_oldest_first.first.created_at
+        )
       end
-      it 'returns read states' do
+      it 'returns read states when there is a read post' do
         first = PrivateTopic.all.with_read_states(user).first
         expect(first[0]).to eq(private_topic)
         expect(first[1]).to eq(read_state)

--- a/spec/models/thredded/topic_spec.rb
+++ b/spec/models/thredded/topic_spec.rb
@@ -85,7 +85,7 @@ module Thredded
 
   describe Topic, '.with_read_states' do
     let(:user) { create(:user) }
-    let!(:topic) { create(:topic) }
+    let!(:topic) { create(:topic, with_posts: 2) }
 
     context 'when unread' do
       it 'returns nulls ' do
@@ -96,7 +96,12 @@ module Thredded
     end
 
     context 'when read' do
-      let!(:read_state) { create(:user_topic_read_state, user: user, postable: topic, read_at: 1.day.ago) }
+      let!(:read_state) do
+        create(
+          :user_topic_read_state, user: user, postable: topic,
+                                  read_at: topic.posts.order_oldest_first.first.created_at
+        )
+      end
       it 'returns read states' do
         first = Topic.all.with_read_states(user).first
         expect(first[0]).to eq(topic)
@@ -107,7 +112,7 @@ module Thredded
 
   describe Topic, '.with_read_and_follow_states' do
     let(:user) { create(:user) }
-    let!(:topic) { create(:topic) }
+    let!(:topic) { create(:topic, with_posts: 2) }
 
     context 'when unread, unfollowed' do
       it 'returns nulls ' do
@@ -119,7 +124,12 @@ module Thredded
     end
 
     context 'when read' do
-      let!(:read_state) { create(:user_topic_read_state, user: user, postable: topic, read_at: 1.day.ago) }
+      let!(:read_state) do
+        create(
+          :user_topic_read_state, user: user, postable: topic,
+                                  read_at: topic.posts.order_oldest_first.first.created_at
+        )
+      end
       it 'returns read states' do
         first = Topic.all.with_read_and_follow_states(user).first
         expect(first[0]).to eq(topic)
@@ -185,7 +195,7 @@ module Thredded
     subject { Topic.unread_followed_by(user) }
 
     def create_read_state(read_at, user_id: user.id)
-      UserTopicReadState.create!(user_id: user_id, postable_id: topic.id, read_at: read_at, page: 1)
+      UserTopicReadState.create!(user_id: user_id, postable_id: topic.id, read_at: read_at)
     end
 
     context 'with following topic' do

--- a/spec/models/thredded/user_topic_read_state_spec.rb
+++ b/spec/models/thredded/user_topic_read_state_spec.rb
@@ -4,12 +4,7 @@ require 'spec_helper'
 
 module Thredded
   describe UserTopicReadState, '#post_read?(post)' do
-    let(:read_state) do
-      create(:user_topic_read_state,
-             postable: create(:topic),
-             user: create(:user),
-             read_at: 1.day.ago)
-    end
+    let(:read_state) { create(:user_topic_read_state, read_at: 1.day.ago) }
 
     it 'is true when post.created_at > read_at' do
       post = create(:post, created_at: 2.days.ago)
@@ -24,6 +19,34 @@ module Thredded
     it 'is false when post.created_at < read_at' do
       post = create(:post, created_at: 1.minute.ago)
       expect(read_state.post_read?(post)).to be_falsey
+    end
+  end
+
+  describe UserTopicReadState, '.include_first_unread' do
+    let(:topic) { create(:topic, with_posts: 5) }
+    let(:posts) { topic.posts.to_a.sort_by(&:created_at) }
+
+    it 'returns the first unread post page and the last read page' do
+      create(:user_topic_read_state, postable: topic, read_at: posts[1].created_at)
+      expect(UserTopicReadState.with_page_info(posts_per_page: 3).to_a)
+        .to(contain_exactly(have_attributes(first_unread_post_page: 1, last_read_post_page: 1)))
+      expect(UserTopicReadState.with_page_info(posts_per_page: 2).to_a)
+        .to(contain_exactly(have_attributes(first_unread_post_page: 2, last_read_post_page: 1)))
+      expect(UserTopicReadState.with_page_info(posts_per_page: 1).to_a)
+        .to(contain_exactly(have_attributes(first_unread_post_page: 3, last_read_post_page: 2)))
+    end
+
+    it 'page info when there are no unread posts' do
+      create(:user_topic_read_state, postable: topic, read_at: posts[-1].created_at)
+      expect(UserTopicReadState.with_page_info(posts_per_page: 3).to_a)
+        .to(contain_exactly(have_attributes(first_unread_post_page: nil, last_read_post_page: 2)))
+    end
+
+    it 'respects the given posts_scope' do
+      create(:user_topic_read_state, postable: topic, read_at: posts[0].created_at)
+      posts_scope = Thredded::Post.where.not(id: posts[1].id)
+      expect(UserTopicReadState.with_page_info(posts_per_page: 1, posts_scope: posts_scope).to_a)
+        .to(contain_exactly(have_attributes(first_unread_post_page: 2, last_read_post_page: 1)))
     end
   end
 

--- a/spec/view_models/thredded/topic_view_spec.rb
+++ b/spec/view_models/thredded/topic_view_spec.rb
@@ -81,8 +81,7 @@ module Thredded
         :user_topic_read_state,
         postable: topic,
         user: user,
-        read_at: topic.last_post.updated_at,
-        page: 4
+        read_at: topic.last_post.updated_at
       )
       topic_view = TopicView.from_user(topic, user)
       expect(topic_view.states[0]).to eq :read
@@ -95,8 +94,7 @@ module Thredded
         :user_topic_read_state,
         postable: topic,
         user: user,
-        read_at: topic.first_post.updated_at - 1.day,
-        page: 4
+        read_at: topic.first_post.updated_at - 1.day
       )
       topic_view = TopicView.from_user(topic, user)
       expect(topic_view.states[0]).to eq :unread


### PR DESCRIPTION
Removes the page column from read states and instead calculates the first unread page and the last read page dynamically in a single monster query that nevertheless is fast when scoped to a user and a list of topics.

Takes into account post policy scopes when calculating page information.