### PR TITLE
Feature: Spoiler tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # v0.15.0 (unreleased)
 
+## Added
+
+* Spoiler tags via `<spoiler></spoiler>` or `[spoiler][/spoiler]`.
+  Supported out of the box for any markup processor.
+  Spoilers are focusable and are activated on mousedown, spacebar, or enter. They can also be nested.
+  Markup is configurable via `Thredded::SpoilerTagFilter.spoiler_tags`.
+  [#701](https://github.com/thredded/thredded/pull/701)
+
 ## Fixed
 
 * Fixes a race condition when setting `last_seen_at` for the user.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ _Thredded_ is a Rails 4.2+ forum/messageboard engine. Its goal is to be as simpl
 
 Some of the features currently in Thredded:
 
-* Markdown (default) or BBCode post formatting.
+* Markdown (default) and / or BBCode post formatting, with [onebox] and `<spoiler>` / `[spoiler]` tag support.
 * (Un)read posts tracking.
 * Email notifications, topic subscriptions, @-mentions, per-messageboard notification settings.
 * Private group messaging.
@@ -28,6 +28,7 @@ If you're looking for variations on a theme - see [Discourse]. However, It is a 
 application and not an engine like Thredded.
 
 [Discourse]: http://www.discourse.org/
+[onebox]: https://github.com/discourse/onebox
 
 Table of Contents
 =================

--- a/app/assets/javascripts/thredded/components/preview_area.es6
+++ b/app/assets/javascripts/thredded/components/preview_area.es6
@@ -1,6 +1,8 @@
 //= require thredded/core/serialize_form
+//= require thredded/components/spoilers
 
 (() => {
+  const Thredded = window.Thredded;
   const PREVIEW_AREA_SELECTOR = '[data-thredded-preview-area]';
   const PREVIEW_AREA_POST_SELECTOR = '[data-thredded-preview-area-post]';
 
@@ -49,6 +51,7 @@
     onPreviewResponse(data) {
       this.preview.style.display = 'block';
       this.previewPost.innerHTML = data;
+      Thredded.spoilers.init(this.previewPost);
     }
   }
 

--- a/app/assets/javascripts/thredded/components/spoilers.es6
+++ b/app/assets/javascripts/thredded/components/spoilers.es6
@@ -1,0 +1,37 @@
+//= require thredded/core/on_page_load
+
+(() => {
+  const Thredded = window.Thredded;
+  const COMPONENT_SELECTOR = '.thredded--post--content--spoiler';
+  const OPEN_CLASS = 'thredded--post--content--spoiler--is-open';
+
+  Thredded.spoilers = {
+    init(root) {
+      Array.prototype.forEach.call(root.querySelectorAll(COMPONENT_SELECTOR), (node) => {
+        node.addEventListener('mousedown', (evt) => {
+          evt.stopPropagation();
+          this.toggle(evt.currentTarget);
+        });
+        node.addEventListener('keypress', (evt) => {
+          if (event.key === ' ' || event.key === 'Enter') {
+            evt.preventDefault();
+            evt.stopPropagation();
+            this.toggle(evt.currentTarget);
+          }
+        });
+      });
+    },
+
+    toggle(node) {
+      const isOpen = node.classList.contains(OPEN_CLASS);
+      node.classList.toggle(OPEN_CLASS);
+      node.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+      node.firstElementChild.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+      node.lastElementChild.setAttribute('aria-hidden', isOpen ? 'true' : 'false');
+    }
+  };
+
+  Thredded.onPageLoad(() => {
+    Thredded.spoilers.init(document);
+  });
+})();

--- a/app/assets/stylesheets/thredded/_email.scss
+++ b/app/assets/stylesheets/thredded/_email.scss
@@ -49,3 +49,28 @@
     }
   }
 }
+
+.thredded--post--content--spoiler {
+  background-color: $thredded-spoiler-background-color;
+  padding: 16px;
+
+  &--summary {
+    border-bottom: 1px solid $thredded-dark-gray;
+  }
+
+  &--contents {
+    color: transparent !important;
+
+    * {
+      color: transparent !important;
+    }
+
+    a {
+      text-decoration: underline;
+    }
+
+    > *:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/thredded/_thredded.scss
+++ b/app/assets/stylesheets/thredded/_thredded.scss
@@ -24,6 +24,7 @@
 @import "components/messageboard";
 @import "components/pagination";
 @import "components/post";
+@import "components/spoiler";
 @import "components/post-form";
 @import "components/preferences";
 @import "components/topic-delete";

--- a/app/assets/stylesheets/thredded/base/_typography.scss
+++ b/app/assets/stylesheets/thredded/base/_typography.scss
@@ -44,7 +44,7 @@
   border-left: solid 5px $thredded-blockquote-border-color;
   padding: 1rem;
 
-  p:last-of-type {
+  > *:last-child {
     margin-bottom: 0;
   }
 

--- a/app/assets/stylesheets/thredded/base/_variables.scss
+++ b/app/assets/stylesheets/thredded/base/_variables.scss
@@ -22,7 +22,7 @@ $thredded-inline-spacing: 0.4375em !default;
 
 // Named colors
 $thredded-brand: #4a90e2 !default;
-$thredded-dark-gray: #333 !default;
+$thredded-dark-gray: rgba(#424242, 0.25) !default;
 $thredded-light-gray: #eee !default;
 
 // Colors of text, background, actions (links), and navigation
@@ -38,8 +38,7 @@ $thredded-nav-current-color: $thredded-action-color !default;
 $thredded-overlay-background-color: opacify($thredded-background-color, 1) !default;
 $thredded-overlay-box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .14), 0 3px 1px -2px rgba(0, 0, 0, .2), 0 1px 5px 0 rgba(0, 0, 0, .12) !default;
 $thredded-secondary-nav-color: $thredded-secondary-text-color !default;
-$thredded-spoiler-hidden-color: $thredded-light-gray !default;
-$thredded-spoiler-shown-color: black !default;
+$thredded-spoiler-background-color: rgba(0, 0, 0, .06) !default;
 $thredded-code-selected-line-background: #f8eec7 !default;
 
 

--- a/app/assets/stylesheets/thredded/components/_post.scss
+++ b/app/assets/stylesheets/thredded/components/_post.scss
@@ -124,15 +124,4 @@
   pre {
     overflow-x: auto;
   }
-
-  &--spoiler {
-    color: $thredded-spoiler-hidden-color;
-    background-color: $thredded-spoiler-hidden-color;
-    cursor: pointer;
-
-    &:hover,
-    &:focus {
-      color: $thredded-spoiler-shown-color;
-    }
-  }
 }

--- a/app/assets/stylesheets/thredded/components/_spoiler.scss
+++ b/app/assets/stylesheets/thredded/components/_spoiler.scss
@@ -1,0 +1,41 @@
+.thredded--post--content--spoiler {
+  background-color: $thredded-spoiler-background-color;
+  cursor: pointer;
+  margin: 0 0 $thredded-small-spacing;
+  padding: $thredded-small-spacing;
+  position: relative;
+
+  &--contents {
+    visibility: hidden;
+
+    > *:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &--summary {
+    @extend %thredded--link;
+    position: absolute;
+    visibility: visible;
+  }
+
+  .thredded--post--content--spoiler {
+    visibility: visible;
+  }
+
+  table {
+    td, th {
+      border-color: $thredded-dark-gray;
+    }
+  }
+
+  &.thredded--post--content--spoiler--is-open {
+    > .thredded--post--content--spoiler--contents {
+      visibility: visible;
+    }
+
+    > .thredded--post--content--spoiler--summary {
+      display: none;
+    }
+  }
+}

--- a/app/views/thredded/posts/edit.html.erb
+++ b/app/views/thredded/posts/edit.html.erb
@@ -2,6 +2,7 @@
 <% content_for :thredded_page_id, 'thredded--edit-post' %>
 <% content_for :thredded_breadcrumbs do %>
   <ul class="thredded--navigation-breadcrumbs">
+    <li><%= link_to @post_form.topic.title, post_path(@post_form.post, user: thredded_current_user) %></li>
     <li><%= link_to t('thredded.nav.edit_post'), edit_post_path(@post_form.post) %></li>
   </ul>
 <% end %>

--- a/app/views/thredded/private_posts/edit.html.erb
+++ b/app/views/thredded/private_posts/edit.html.erb
@@ -2,6 +2,7 @@
 <% content_for :thredded_page_id, 'thredded--edit-post' %>
 <% content_for :thredded_breadcrumbs do %>
   <ul class="thredded--navigation-breadcrumbs">
+    <li><%= link_to @post_form.topic.title, post_path(@post_form.post, user: thredded_current_user) %></li>
     <li><%= link_to t('thredded.nav.edit_post'), edit_post_path(@post_form.post) %></li>
   </ul>
 <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -132,6 +132,8 @@ de:
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Dein Beitrag wird veröffentlicht, sobald ein Moderator ihn angeschaut hat.
       quote_btn: Zitat
+      spoiler_summary: Spoiler - klicken um zu zeigen.
+      spoiler_summary_for_email: 'Spoiler - Wählen Sie den Inhalt unten, um zu sehen:'
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,8 @@ en:
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Your post will be published when it has been reviewed by a moderator.
       quote_btn: Quote
+      spoiler_summary: Spoiler - click to show.
+      spoiler_summary_for_email: 'Spoiler - select the contents below to see:'
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -133,6 +133,8 @@ es:
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Tu post será publicado cuando haya sido revisado por un moderador.
       quote_btn: Citar
+      spoiler_summary: 'Spoiler: haz clic para mostrar.'
+      spoiler_summary_for_email: 'Spoiler: selecciona el contenido a continuación para ver:'
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -131,6 +131,8 @@ fr:
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Votre commentaire sera publié dès qu'il aura été validé par un modérateur.
       quote_btn: Citer
+      spoiler_summary: Spoiler - cliquez pour afficher.
+      spoiler_summary_for_email: 'Spoiler - sélectionnez le contenu ci-dessous pour voir:'
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -131,6 +131,8 @@ it:
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Il tuo messaggio sarà pubblicato dopo essere stato controllato da un moderatore.
       quote_btn: Citazione
+      spoiler_summary: Spoiler - clicca per mostrare.
+      spoiler_summary_for_email: 'Spoiler: seleziona i contenuti sotto per vedere:'
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -131,6 +131,8 @@ pl:
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Twój post zostanie zamieszczony po zweryfikowaniu go przez moderatora.
       quote_btn: Zacytować
+      spoiler_summary: Spoiler - kliknij, aby pokazać.
+      spoiler_summary_for_email: 'Spoiler - wybierz zawartość poniżej, aby zobaczyć:'
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -133,6 +133,8 @@ pt-BR:
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: O envio da mensagem será publicada quando foi revisado por um moderador.
       quote_btn: Citar
+      spoiler_summary: Spoiler - clique para mostrar.
+      spoiler_summary_for_email: 'Spoiler - selecione o conteúdo abaixo para ver:'
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -129,6 +129,8 @@ ru:
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Ваш пост будет опубликован, когда будет одобрен модератором.
       quote_btn: Цитировать
+      spoiler_summary: Спойлер - нажмите, чтобы показать.
+      spoiler_summary_for_email: 'Спойлер - выделите содержимое ниже, чтобы увидеть:'
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -126,6 +126,8 @@ zh-CN:
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: 你的回复将在审核之后公开发表
       quote_btn: 引用
+      spoiler_summary: 剧透 - 点击显示。
+      spoiler_summary_for_email: 扰流板 - 选择下面的内容来查看：
     preferences:
       edit:
         page_title: :thredded.nav.settings

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -16,11 +16,13 @@ require 'inline_svg'
 # Require these explictly to make sure they are not reloaded.
 # This allows for configuring them by accessing class methods in the initializer.
 require 'thredded/formatting_demo_content'
+require 'thredded/html_pipeline/utils'
 require 'thredded/html_pipeline/at_mention_filter'
 require 'thredded/html_pipeline/autolink_filter'
 require 'thredded/html_pipeline/kramdown_filter'
 require 'thredded/html_pipeline/onebox_filter'
 require 'thredded/html_pipeline/wrap_iframes_filter'
+require 'thredded/html_pipeline/spoiler_tag_filter'
 
 # Asset compilation
 require 'autoprefixer-rails'

--- a/lib/thredded/content_formatter.rb
+++ b/lib/thredded/content_formatter.rb
@@ -25,7 +25,7 @@ module Thredded
         'span'   => %w[class],
         'div'    => %w[class],
         :all     => HTML::Pipeline::SanitizationFilter::WHITELIST[:attributes][:all] +
-          %w[aria-label aria-labelledby aria-hidden],
+          %w[aria-expanded aria-label aria-labelledby aria-live aria-hidden aria-pressed role],
       }
     )
 
@@ -33,6 +33,7 @@ module Thredded
     # input: markup, output: markup.
     mattr_accessor :before_markup_filters
     self.before_markup_filters = [
+      Thredded::HtmlPipeline::SpoilerTagFilter::BeforeMarkup
     ]
 
     # Markup filters, such as BBCode, Markdown, Autolink, etc.
@@ -51,6 +52,7 @@ module Thredded
       Thredded::HtmlPipeline::AutolinkFilter,
       HTML::Pipeline::EmojiFilter,
       Thredded::HtmlPipeline::AtMentionFilter,
+      Thredded::HtmlPipeline::SpoilerTagFilter::AfterMarkup,
     ]
 
     # Filters that sanitize the resulting HTML.

--- a/lib/thredded/email_transformer.rb
+++ b/lib/thredded/email_transformer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'thredded/email_transformer/onebox'
+require 'thredded/email_transformer/spoiler'
 
 module Thredded
   # This transformer should applied to emails so that they render correctly in the email clients.
@@ -12,7 +13,7 @@ module Thredded
   #
   module EmailTransformer
     mattr_accessor :transformers
-    self.transformers = [Onebox]
+    self.transformers = [Onebox, Spoiler]
 
     # @param doc [Nokogiri::HTML::Document]
     def self.call(doc)

--- a/lib/thredded/email_transformer/spoiler.rb
+++ b/lib/thredded/email_transformer/spoiler.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'thredded/email_transformer/base'
+module Thredded
+  module EmailTransformer
+    # Changes the spoiler tags to work in emails.
+    class Spoiler < Base
+      def call
+        doc.css('.thredded--post--content--spoiler--summary').each do |node|
+          node.content = I18n.t('thredded.posts.spoiler_summary_for_email')
+        end
+        doc.css('.thredded--post--content--spoiler--contents img').each do |img|
+          text = "#{img['src']} #{" (#{img['alt']})" if img['alt'].present?}"
+          img.swap(
+            if img.parent.name == 'a' && img.parent.children.size == 1
+              doc.document.create_text_node(text)
+            else
+              doc.document.create_element('a', text, href: img['src'], target: '_blank')
+            end
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/thredded/formatting_demo_content.rb
+++ b/lib/thredded/formatting_demo_content.rb
@@ -8,6 +8,18 @@ module Thredded
     end
     self.parts = [
       <<-'MARKDOWN',
+#### Spoilers
+
+Use `<spoiler></spoiler>` or `[spoiler][/spoiler]` tags to create spoiler boxes like this one:
+
+<spoiler>
+Harry Potter books are better than the movies.
+
+![nyancat](https://storage.googleapis.com/glebm-stuff/nyancat.gif)
+
+https://www.youtube.com/watch?v=5lBBUPVuusM
+</spoiler>
+
 #### Oneboxes
 
 URLs of supported resources are replaced with boxes like these:

--- a/lib/thredded/html_pipeline/onebox_filter.rb
+++ b/lib/thredded/html_pipeline/onebox_filter.rb
@@ -5,6 +5,8 @@ require 'onebox'
 module Thredded
   module HtmlPipeline
     class OneboxFilter < ::HTML::Pipeline::Filter
+      include ::Thredded::HtmlPipeline::Utils
+
       SANITIZE_CONFIG = Sanitize::Config.merge(
         Sanitize::Config::ONEBOX,
         attributes: {
@@ -51,7 +53,7 @@ module Thredded
           next unless url.present? && url == element.content && on_its_own_line?(element)
           onebox_html = render_onebox_with_cache(url)
           next if onebox_html.empty?
-          fixup_paragraph! element
+          extract_block_from_paragraph! element
           element.swap onebox_html
         end
         doc
@@ -100,43 +102,6 @@ module Thredded
       def all_blank_until_br?(nodes)
         nodes.take_while { |node| !node_name?(node, 'br') }
           .all? { |node| node.text? && node.blank? }
-      end
-
-      def fixup_paragraph!(element)
-        # Can't have a div inside a paragraph, so split the paragraph
-        p = element.parent
-        return unless node_name?(p, 'p')
-        children_after = p.children[p.children.index(element) + 1..-1]
-        remove_leading_blanks! children_after
-        # Move the onebox out of and after the paragraph
-        p.add_next_sibling element
-        # Move all the elements after the onebox to a new paragraph
-        unless children_after.empty?
-          new_p = Nokogiri::XML::Node.new 'p', doc
-          element.add_next_sibling new_p
-          children_after.each { |child| new_p.add_child child }
-        end
-        # The original paragraph might have been split just after a <br> or whitespace, remove them if so:
-        remove_leading_blanks! p.children.reverse
-        p.remove if p.children.empty?
-      end
-
-      # @param children [Nokogiri::XML::NodeSet]
-      def remove_leading_blanks!(children)
-        to_remove = children.take_while do |c|
-          if node_name?(c, 'br') || c.text? && c.content.blank?
-            c.remove
-            true
-          else
-            c.content = c.content.lstrip
-            false
-          end
-        end
-        to_remove.each { |c| children.delete(c) }
-      end
-
-      def node_name?(node, node_name)
-        node && node.node_name && node.node_name.casecmp(node_name).zero?
       end
     end
   end

--- a/lib/thredded/html_pipeline/spoiler_tag_filter.rb
+++ b/lib/thredded/html_pipeline/spoiler_tag_filter.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Thredded
+  module HtmlPipeline
+    module SpoilerTagFilter
+      PLACEHOLDER_START_CLASS = 'thredded-spoiler-placeholder-start-24uob7bajv5'
+      PLACEHOLDER_END_CLASS = 'thredded-spoiler-placeholder-end-24uob7bajv5'
+      PLACEHOLDER_START_BLOCK = "<p class='#{PLACEHOLDER_START_CLASS}' title='%s'></p>"
+      PLACEHOLDER_END_BLOCK = "<p class='#{PLACEHOLDER_END_CLASS}' title='%s'></p>"
+      PLACEHOLDER_START_SPAN = "<i class='#{PLACEHOLDER_START_CLASS}' title='%s'></i>"
+      PLACEHOLDER_END_SPAN = "<i class='#{PLACEHOLDER_END_CLASS}' title='%s'></i>"
+
+      class << self
+        # @return [[[String, String]]] Pairs of opening and closing spoiler tags.
+        attr_reader :spoiler_tags
+
+        # @api private
+        attr_reader :spoiler_tags_replacements
+
+        # @api private
+        attr_reader :spoiler_tags_inverse_replacements
+
+        # @param [[[String, String]]] spoiler_tags
+        def spoiler_tags=(spoiler_tags)
+          @spoiler_tags = spoiler_tags
+          @spoiler_tags_replacements = spoiler_tags.flat_map.with_index do |(open, close), i|
+            [[/((?:\A|\r?\n|>)[ ]*)#{Regexp.escape(open)}(?=[ \t]*\r?(?:\n|\z))/, "\\1#{PLACEHOLDER_START_BLOCK % i}"],
+             [/((?:\A|\r?\n|>)[ ]*)#{Regexp.escape(close)}(?=[ \t]*\r?(?:\n|\z))/, "\\1#{PLACEHOLDER_END_BLOCK % i}"],
+             [open, PLACEHOLDER_START_SPAN % i],
+             [close, PLACEHOLDER_END_SPAN % i]]
+          end
+          @spoiler_tags_inverse_replacements = spoiler_tags.flat_map.with_index do |(open, close), i|
+            [[PLACEHOLDER_START_BLOCK % i, open],
+             [PLACEHOLDER_END_BLOCK % i, close],
+             [PLACEHOLDER_START_SPAN % i, open],
+             [PLACEHOLDER_END_SPAN % i, close]]
+          end
+        end
+      end
+
+      self.spoiler_tags = [
+        %w[<spoiler> </spoiler>],
+        %w[[spoiler] [/spoiler]]
+      ]
+
+      class BeforeMarkup < ::HTML::Pipeline::Filter
+        def call
+          @html = +html # Unfreeze
+          SpoilerTagFilter.spoiler_tags_replacements.each do |(pattern, replacement)|
+            html.gsub! pattern, replacement
+          end
+          html
+        end
+      end
+
+      class AfterMarkup < ::HTML::Pipeline::Filter
+        include ::Thredded::HtmlPipeline::Utils
+
+        SPOILER_START = [PLACEHOLDER_START_BLOCK, PLACEHOLDER_START_SPAN].freeze
+        SPOILER_END = [PLACEHOLDER_END_BLOCK, PLACEHOLDER_END_SPAN].freeze
+
+        def call
+          doc.css(".#{PLACEHOLDER_START_CLASS}").each do |placeholder_start|
+            process(placeholder_start)
+          end
+          doc.search('.//text()').each do |node|
+            content = +node.content # Unfreeze
+            SpoilerTagFilter.spoiler_tags_inverse_replacements.each do |(pattern, replacement)|
+              content.gsub! pattern, replacement
+            end
+            node.content = content
+          end
+          doc
+        end
+
+        protected
+
+        # @param [Nokogiri::XML::Document] document
+        # @param [Array<Nokogiri::XML::Node>] children
+        def build_spoiler_tag(document, children)
+          document.create_element(
+            'div',
+            class: 'thredded--post--content--spoiler',
+            tabindex: 0,
+            role: 'figure',
+            'aria-expanded' => 'false',
+          ) << document.create_element(
+            'div',
+            I18n.t('thredded.posts.spoiler_summary'),
+            class: 'thredded--post--content--spoiler--summary',
+            'aria-hidden' => 'false',
+          ) << document.create_element(
+            'div',
+            class: 'thredded--post--content--spoiler--contents',
+            'aria-hidden' => 'true',
+          ) { |contents_tag| children.each { |child| contents_tag.add_child child } }
+        end
+
+        private
+
+        def process(placeholder_start)
+          placeholder_end, children = find_placeholder_end(placeholder_start)
+          placeholder_start.remove
+          return if !placeholder_end || children.empty?
+          spoiler_tag = placeholder_end.replace(build_spoiler_tag(doc.document, children))
+          extract_block_from_paragraph! spoiler_tag
+          spoiler_tag
+        end
+
+        def find_placeholder_end(sibling)
+          children = []
+          placeholder_end = nil
+          loop do
+            sibling = sibling.next_sibling
+            break if sibling.nil?
+            if sibling[:class] == PLACEHOLDER_START_CLASS
+              sibling = process(sibling) || sibling
+            elsif sibling[:class] == PLACEHOLDER_END_CLASS
+              placeholder_end = sibling
+              break
+            end
+            children << sibling
+          end
+          [placeholder_end, children]
+        end
+      end
+    end
+  end
+end

--- a/lib/thredded/html_pipeline/utils.rb
+++ b/lib/thredded/html_pipeline/utils.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Thredded
+  module HtmlPipeline
+    module Utils
+      private
+
+      # If the given block element is contained in a paragraph, splits the paragraph and removes unnecessary whitespace.
+      # @param [Nokogiri::HTML::Node] element the block element that may be inside a paragraph.
+      def extract_block_from_paragraph!(element)
+        p = element.parent
+        return unless node_name?(p, 'p')
+        children_after = p.children[p.children.index(element) + 1..-1]
+        remove_leading_blanks! children_after
+        # Move the element out of and after the paragraph
+        p.add_next_sibling element
+        # Move all the elements after the onebox to a new paragraph
+        unless children_after.empty?
+          new_p = Nokogiri::XML::Node.new 'p', doc
+          element.add_next_sibling new_p
+          children_after.each { |child| new_p.add_child child }
+        end
+        # The original paragraph might have been split just after a <br> or whitespace, remove them if so:
+        remove_leading_blanks! p.children.reverse
+        p.remove if p.children.empty?
+      end
+
+      # @param children [Nokogiri::XML::NodeSet]
+      def remove_leading_blanks!(children)
+        to_remove = children.take_while do |c|
+          if node_name?(c, 'br') || c.text? && c.content.blank?
+            c.remove
+            true
+          else
+            c.content = c.content.lstrip
+            false
+          end
+        end
+        to_remove.each { |c| children.delete(c) }
+      end
+
+      def node_name?(node, node_name)
+        node && node.node_name && node.node_name.casecmp(node_name).zero?
+      end
+    end
+  end
+end

--- a/spec/dummy/app/assets/stylesheets/night.scss
+++ b/spec/dummy/app/assets/stylesheets/night.scss
@@ -20,7 +20,9 @@ $thredded-code-selected-line-background: #541;
 $thredded-button-color: $thredded-text-color;
 $thredded-button-hover-background: $material-600;
 $thredded-badge-active-background: $thredded-brand;
+$thredded-dark-gray: rgba(#fff, 0.1);
 $thredded-light-gray: rgba(#424242, 0.8);
+$thredded-spoiler-background-color: rgba(#424242, .32) !default;
 
 $thredded-onebox-favicon-properties: (
   'favicons/amazon.png': (filter: invert(100%) hue-rotate(175deg) brightness(150%)),

--- a/spec/dummy/app/views/home/show.html.erb
+++ b/spec/dummy/app/views/home/show.html.erb
@@ -43,7 +43,9 @@
     <div class="home-container">
       <section>
         <p>
-          Format your posts with <b>Markdown</b> by default.
+          Format your posts with <b>Markdown</b> by default and / or BBCode, with
+          <a href="https://github.com/discourse/onebox" target="_blank">onebox</a> and
+          <code>&lt;spoiler&gt;</code> / <code>[spoiler]</code> tag support.
         </p>
 
         <p>

--- a/spec/lib/thredded/post_contents.yml
+++ b/spec/lib/thredded/post_contents.yml
@@ -71,3 +71,135 @@
   - |
     <pre><code>a &lt;&lt; 1 &gt; 2
     </code></pre>
+
+  spoiler with markdown and html:
+  - |
+    <spoiler>
+    *Emphasis*
+    <table><tr><th>HTML</th></tr><tr><td>table</td></tr></table>
+
+    | Markdown |
+    |---|
+    | table |
+
+    Paragraph.
+    </spoiler>
+  - |
+    <div class="thredded--post--content--spoiler" tabindex="0" role="figure" aria-expanded="false">
+    <div class="thredded--post--content--spoiler--summary" aria-hidden="false">Spoiler - click to show.</div>
+    <div class="thredded--post--content--spoiler--contents" aria-hidden="true">
+    <p><em>Emphasis</em></p>
+    <table>
+    <tr><th>HTML</th></tr>
+    <tr><td>table</td></tr>
+    </table>
+    <table>
+    <thead>
+    <tr>
+    <th>Markdown</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+    <td>table</td>
+    </tr>
+    </tbody>
+    </table>
+    <p>Paragraph.</p>
+    </div>
+    </div>
+
+  spoiler with markdown on a single line:
+  - |
+    <spoiler>Spoiler with **markdown**, single line</spoiler>
+  - |
+    <div class="thredded--post--content--spoiler" tabindex="0" role="figure" aria-expanded="false">
+    <div class="thredded--post--content--spoiler--summary" aria-hidden="false">Spoiler - click to show.</div>
+    <div class="thredded--post--content--spoiler--contents" aria-hidden="true">Spoiler with <strong>markdown</strong>, single line</div>
+    </div>
+
+  spoiler surrounded by text on a single line:
+  - |
+    A <spoiler>**spoiler**</spoiler> surrounded by text on a single line.
+  - |
+    <p>A </p><div class="thredded--post--content--spoiler" tabindex="0" role="figure" aria-expanded="false">
+    <div class="thredded--post--content--spoiler--summary" aria-hidden="false">Spoiler - click to show.</div>
+    <div class="thredded--post--content--spoiler--contents" aria-hidden="true"><strong>spoiler</strong></div>
+    </div><p>surrounded by text on a single line.</p>
+
+  spoiler in a quote:
+  - |
+    > <spoiler>quoted spoiler</spoiler>
+  - |
+    <blockquote>
+    <div class="thredded--post--content--spoiler" tabindex="0" role="figure" aria-expanded="false">
+    <div class="thredded--post--content--spoiler--summary" aria-hidden="false">Spoiler - click to show.</div>
+    <div class="thredded--post--content--spoiler--contents" aria-hidden="true">quoted spoiler</div>
+    </div>
+    </blockquote>
+
+  spoiler in a quote surrounded by text:
+  - |
+    >  A <spoiler>**spoiler**</spoiler> surrounded by text within a quote.
+    > Line 2.
+  - |
+    <blockquote>
+    <p>A </p>
+    <div class="thredded--post--content--spoiler" tabindex="0" role="figure" aria-expanded="false">
+    <div class="thredded--post--content--spoiler--summary" aria-hidden="false">Spoiler - click to show.</div>
+    <div class="thredded--post--content--spoiler--contents" aria-hidden="true"><strong>spoiler</strong></div>
+    </div>
+    <p>surrounded by text within a quote.<br>
+    Line 2.</p>
+    </blockquote>
+
+  spoiler block in a quote:
+  - |
+    > <spoiler>
+    > Hello
+    >
+    > World
+    > </spoiler>
+  - |
+    <blockquote>
+    <div class="thredded--post--content--spoiler" tabindex="0" role="figure" aria-expanded="false">
+    <div class="thredded--post--content--spoiler--summary" aria-hidden="false">Spoiler - click to show.</div>
+    <div class="thredded--post--content--spoiler--contents" aria-hidden="true">
+    <p>Hello</p>
+    <p>World</p>
+    </div>
+    </div>
+    </blockquote>
+
+  spoiler nested within another spoiler:
+  - |
+    <spoiler>
+    A spoiler that has a nested spoiler:
+    <spoiler>
+    Nested spoiler.
+    </spoiler>
+    </spoiler>
+  - |
+    <div class="thredded--post--content--spoiler" tabindex="0" role="figure" aria-expanded="false">
+    <div class="thredded--post--content--spoiler--summary" aria-hidden="false">Spoiler - click to show.</div>
+    <div class="thredded--post--content--spoiler--contents" aria-hidden="true">
+    <p>A spoiler that has a nested spoiler:</p>
+    <div class="thredded--post--content--spoiler" tabindex="0" role="figure" aria-expanded="false">
+    <div class="thredded--post--content--spoiler--summary" aria-hidden="false">Spoiler - click to show.</div>
+    <div class="thredded--post--content--spoiler--contents" aria-hidden="true">
+    <p>Nested spoiler.</p>
+    </div>
+    </div>
+    </div>
+    </div>
+
+  not a spoiler in a code block:
+  - |
+    ```
+    <spoiler>Not a spoiler (in a code block)</spoiler>
+    [spoiler]Not a spoiler (in a code block)[/spoiler]
+    ```
+  - |
+    <pre><code>&lt;spoiler&gt;Not a spoiler (in a code block)&lt;/spoiler&gt;
+    [spoiler]Not a spoiler (in a code block)[/spoiler]
+    </code></pre>

--- a/spec/support/features/fake_content.rb
+++ b/spec/support/features/fake_content.rb
@@ -94,7 +94,7 @@ module FakeContent # rubocop:disable Metrics/ModuleLength
     "Reported on GitHub:\nhttps://github.com/thredded/thredded/issues/545",
   ].freeze
 
-  def post_content(with_everything: false) # rubocop:disable Metrics/CyclomaticComplexity
+  def post_content(with_everything: false) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/MethodLength
     with_smiley = with_everything || rand < 0.1
     with_youtube = with_everything || rand < 0.04
     with_image = with_everything || rand < 0.07
@@ -103,6 +103,7 @@ module FakeContent # rubocop:disable Metrics/ModuleLength
     with_markdown_table = with_everything || rand < 0.02
     with_quote = with_everything || rand < 0.08
     with_onebox = with_everything || rand < 0.08
+    with_spoiler = with_everything || rand < 0.08
 
     result = []
 
@@ -119,6 +120,8 @@ module FakeContent # rubocop:disable Metrics/ModuleLength
     result << markdown_table if with_markdown_table
 
     result << (with_everything ? ONEBOXES.join("\n") : ONEBOXES.sample) if with_onebox
+
+    result << spoiler if with_spoiler
 
     # Randomly quote a piece
     if with_quote
@@ -169,5 +172,18 @@ module FakeContent # rubocop:disable Metrics/ModuleLength
       | 0 | 0 |   0   |
 
     MARKDOWN
+  end
+
+  def spoiler
+    content = [
+      -> { styled_smart_thing(with_smiley: rand < 0.1) },
+      -> { youtube_reference },
+      -> { IMAGES.sample }
+    ].sample.call
+    if content.include?("\n")
+      "<spoiler>\n#{content}\n</spoiler>"
+    else
+      "<spoiler>#{content}</spoiler>"
+    end
   end
 end


### PR DESCRIPTION
Spoiler tags can be added using `<spoiler></spoiler>` or `[spoiler][/spoiler]` markup (configurable via `Thredded::SpoilerTagFilter.spoiler_tags`).

Supported out of the box for any markup processor.
Spoilers are focusable and are activated on mousedown, spacebar, or enter.
They can also be nested.
Their accessibility role is "figure" and they have a dynamically updated `aria-expanded` attribute.