### PR TITLE
Remove IP tracking from posts for GDPR compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   The valid length range is configurable via the new `Thredded.topic_title_length_range` configuration option.
   [#703](https://github.com/thredded/thredded/pull/703)
 
+## Changed
+
+* Post IP tracking removed from core because it requires explicit consent under GDPR.
+  [#705](https://github.com/thredded/thredded/pull/705)
+
 **NB: If updating to this version from 0.14.x, you **must** copy and run the upgrade migration after updating the gem:
 
 ```console

--- a/app/controllers/concerns/thredded/new_post_params.rb
+++ b/app/controllers/concerns/thredded/new_post_params.rb
@@ -8,7 +8,7 @@ module Thredded
     def new_post_params
       params.fetch(:post, {})
         .permit(:content, :quote_post_id)
-        .merge(ip: request.remote_ip).tap do |p|
+        .tap do |p|
         quote_id = p.delete(:quote_post_id)
         if quote_id
           post = Thredded::Post.find(quote_id)

--- a/app/controllers/concerns/thredded/new_private_post_params.rb
+++ b/app/controllers/concerns/thredded/new_private_post_params.rb
@@ -8,7 +8,7 @@ module Thredded
     def new_private_post_params
       params.fetch(:post, {})
         .permit(:content, :quote_private_post_id)
-        .merge(ip: request.remote_ip).tap do |p|
+        .tap do |p|
         quote_id = p.delete(:quote_private_post_id)
         if quote_id
           post = Thredded::PrivatePost.find(quote_id)

--- a/app/controllers/concerns/thredded/new_private_topic_params.rb
+++ b/app/controllers/concerns/thredded/new_private_topic_params.rb
@@ -11,7 +11,6 @@ module Thredded
         .permit(:title, :content, :user_names, user_ids: [])
         .merge(
           user: thredded_current_user,
-          ip: request.remote_ip
         ).tap { |p| adapt_user_ids! p }
     end
 

--- a/app/controllers/concerns/thredded/new_topic_params.rb
+++ b/app/controllers/concerns/thredded/new_topic_params.rb
@@ -12,7 +12,6 @@ module Thredded
         .merge(
           messageboard: messageboard,
           user: thredded_current_user,
-          ip: request.remote_ip,
         )
     end
   end

--- a/db/migrate/20160329231848_create_thredded.rb
+++ b/db/migrate/20160329231848_create_thredded.rb
@@ -60,7 +60,6 @@ class CreateThredded < Thredded::BaseMigration
     create_table :thredded_posts do |t|
       t.references :user, type: user_id_type, index: false
       t.text :content, limit: 65_535
-      t.string :ip, limit: 45
       t.string :source, limit: 191, default: 'web'
       t.references :postable, null: false, index: false
       t.references :messageboard, null: false, index: false
@@ -80,7 +79,6 @@ class CreateThredded < Thredded::BaseMigration
       t.references :user, type: user_id_type, index: false
       t.text :content, limit: 65_535
       t.references :postable, null: false, index: false
-      t.string :ip, limit: 255
       t.timestamps null: false
     end
 

--- a/db/upgrade_migrations/20180110200009_upgrade_thredded_v0_14_to_v0_15.rb
+++ b/db/upgrade_migrations/20180110200009_upgrade_thredded_v0_14_to_v0_15.rb
@@ -61,6 +61,11 @@ class UpgradeThreddedV014ToV015 < Thredded::BaseMigration
                         ]
     change_column :thredded_topics, :hash_id, :string, limit: 20
     remove_column :thredded_topics, :type
+
+    # Remove IP tracking column from posts
+    # https://github.com/thredded/thredded/pull/705
+    remove_column :thredded_posts, :ip
+    remove_column :thredded_private_posts, :ip
   end
 
   private

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -39,7 +39,6 @@ FactoryBot.define do
     postable { association :topic, user: user, last_user: user }
 
     content { FakeContent.post_content }
-    ip '127.0.0.1'
 
     after :build do |post|
       post.messageboard = post.postable.messageboard
@@ -51,7 +50,6 @@ FactoryBot.define do
     postable { association :private_topic, user: user, last_user: user }
 
     content { Faker::Hacker.say_something_smart }
-    ip '127.0.0.1'
   end
 
   factory :user_preference, class: Thredded::UserPreference do


### PR DESCRIPTION
If I understand GDPR correctly, tracking IPs requires explicit consent.
This commit removes post IP tracking from core.