### PR TITLE
Feature: Unread page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.15.2
+
+## Added
+
+* Adds a global / messageboard-level unread page. Topics are ordered followed-first. The navigation link has a badge
+  indicating the numbers of followed unread topics. If there are no unread topics at all (including non-followed ones),
+  the link is not displayed.
+  [#709](https://github.com/thredded/thredded/pull/709)
+
 # v0.15.1
 
 ## Fixed

--- a/app/assets/stylesheets/thredded/_thredded.scss
+++ b/app/assets/stylesheets/thredded/_thredded.scss
@@ -7,6 +7,7 @@
 @import "layout/main-navigation";
 @import "layout/search-navigation";
 @import "layout/user-navigation";
+@import "layout/scoped-navigation";
 @import "layout/navigation";
 @import "layout/moderation";
 @import "layout/user";

--- a/app/assets/stylesheets/thredded/components/_base.scss
+++ b/app/assets/stylesheets/thredded/components/_base.scss
@@ -23,3 +23,7 @@
 .thredded--embed-16-by-9 {
   @extend %thredded--embed-16-by-9;
 }
+
+.thredded--spacer {
+  flex-grow: 1;
+}

--- a/app/assets/stylesheets/thredded/layout/_main-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_main-navigation.scss
@@ -9,8 +9,8 @@
 
 .thredded--main-navigation {
   @extend %thredded--list-unstyled;
-  @include thredded--clearfix;
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .thredded--navigation-breadcrumbs {

--- a/app/assets/stylesheets/thredded/layout/_moderation.scss
+++ b/app/assets/stylesheets/thredded/layout/_moderation.scss
@@ -3,14 +3,15 @@
   @include thredded-media-desktop-and-up {
     margin-bottom: $thredded-base-spacing;
   }
+}
 
-  &--items {
-    @extend %thredded--nav-tabs;
-    margin-bottom: $thredded-small-spacing;
-  }
-  &--item {
-    @extend %thredded--nav-tabs--item;
-  }
+.thredded--moderation-navigation--items {
+  @extend %thredded--nav-tabs;
+  margin-bottom: $thredded-small-spacing;
+}
+
+.thredded--moderation-navigation--item {
+  @extend %thredded--nav-tabs--item;
 }
 
 .thredded--pending-moderation .thredded--moderation-navigation--pending,

--- a/app/assets/stylesheets/thredded/layout/_navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_navigation.scss
@@ -1,4 +1,6 @@
 .thredded--navigation {
+  display: flex;
+  flex-direction: column;
   position: relative;
   .thredded--icon {
     display: none;
@@ -6,7 +8,29 @@
 }
 
 @include thredded-media-tablet-and-down {
-  $icon-nav-item-width: 2.625rem;
+  $icon-nav-item-gutter: 0.5rem;
+  $icon-nav-item-width: (2.125rem + $icon-nav-item-gutter);
+  %icon-nav-item {
+    box-sizing: border-box;
+    margin: 0 0 0 $icon-nav-item-gutter;
+    padding: 0;
+    vertical-align: top;
+    a {
+      position: relative;
+      display: block;
+      padding: 0.4375rem 0 0.375rem 0;
+    }
+    .thredded--icon {
+      display: block;
+      width: 2rem;
+      height: 2rem;
+    }
+  }
+  %icon-counter {
+    bottom: 0.3125rem;
+    position: absolute;
+    right: -0.1875rem;
+  }
   .thredded--navigation {
     position: relative;
     width: 100%;
@@ -17,11 +41,18 @@
   }
   .thredded--navigation-breadcrumbs {
     font-size: $thredded-font-size-small;
-    padding-right: $icon-nav-item-width * 2;
-    .thredded--is-moderator & {
+    padding-right: $icon-nav-item-width * 1;
+    .thredded--global-nav-icons-1 & {
+      padding-right: $icon-nav-item-width * 2;
+    }
+    .thredded--global-nav-icons-2 & {
       padding-right: $icon-nav-item-width * 3;
     }
+    .thredded--global-nav-icons-3 & {
+      padding-right: $icon-nav-item-width * 4;
+    }
   }
+
   .thredded--navigation--search-topics {
     display: none;
     .thredded--messageboards-index &,
@@ -29,6 +60,7 @@
     .thredded--topic-search-results & {
       @media screen {
         display: block;
+        width: 100%;
       }
     }
   }
@@ -42,37 +74,22 @@
       display: block;
       margin-bottom: 0;
     }
-    %icon-nav-item {
-      box-sizing: border-box;
-      display: inline-block;
-      margin: 0 0 0 ($thredded-small-spacing/2);
-      padding: 0;
-      vertical-align: top;
-      a {
-        position: relative;
-        display: block;
-        padding: 0.4375rem 0 0.375rem 0;
-      }
-      .thredded--icon {
-        display: block;
-        width: 2rem;
-        height: 2rem;
+    &--item {
+      .thredded--nav-text {
+        display: none;
       }
     }
-    %icon-counter {
-      bottom: 0.3125rem;
-      position: absolute;
-      right: -0.1875rem;
-    }
-    .thredded--nav-text {
-      display: none;
+    &--unread-topics {
+      @extend %icon-nav-item;
+      &--followed-count {
+        @extend %icon-counter;
+      }
     }
     &--settings {
       @extend %icon-nav-item;
     }
     &--private-topics {
       @extend %icon-nav-item;
-      margin-top: 1px;
       &--unread {
         @extend %icon-counter;
       }
@@ -82,6 +99,24 @@
       &--pending-count {
         @extend %icon-counter
       }
+    }
+    &--moderation.thredded--is-current ~ &--settings,
+    &--moderation.thredded--is-current ~ &--private-topics {
+      display: none;
+    }
+  }
+  .thredded--scoped-navigation {
+    position: absolute;
+    top: 0;
+    right: 0;
+    .thredded--global-nav-icons-1 & {
+      right: $icon-nav-item-width;
+    }
+    .thredded--global-nav-icons-2 & {
+      right: $icon-nav-item-width * 2;
+    }
+    .thredded--global-nav-icons-3 & {
+      right: $icon-nav-item-width * 3;
     }
   }
 }

--- a/app/assets/stylesheets/thredded/layout/_scoped-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_scoped-navigation.scss
@@ -1,0 +1,5 @@
+.thredded--scoped-navigation {
+  @extend %thredded--nav-tabs;
+  border-bottom: 0;
+  display: flex;
+}

--- a/app/assets/stylesheets/thredded/layout/_user-navigation.scss
+++ b/app/assets/stylesheets/thredded/layout/_user-navigation.scss
@@ -1,6 +1,7 @@
 .thredded--user-navigation {
   @extend %thredded--nav-tabs;
-  text-align: right;
+  display: flex;
+  justify-content: flex-end;
   @media print {
     display: none;
   }
@@ -15,6 +16,7 @@
 }
 
 .thredded--user-navigation--private-topics--unread,
-.thredded--user-navigation--moderation--pending-count {
+.thredded--user-navigation--moderation--pending-count,
+.thredded--user-navigation--unread-topics--followed-count {
   @extend %thredded--nav-tabs--item--badge;
 }

--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -6,31 +6,49 @@ module Thredded
     include Thredded::NewPostParams
 
     before_action :thredded_require_login!,
-                  only: %i[edit new update create destroy follow unfollow]
+                  only: %i[edit new update create destroy follow unfollow unread]
+
+    before_action :verify_messageboard,
+                  only: %i[index search unread]
 
     before_action :use_topic_messageboard,
                   only: %i[show edit update destroy follow unfollow]
 
     after_action :update_user_activity
 
-    after_action :verify_authorized, except: %i[search]
+    after_action :verify_authorized, except: %i[search unread]
     after_action :verify_policy_scoped, except: %i[show new create edit update destroy follow unfollow]
 
     def index
-      authorize_reading messageboard
-      unless params_match?(canonical_messageboard_params)
-        skip_policy_scope
-        return redirect_to(canonical_messageboard_params)
-      end
-
       page_scope = policy_scope(messageboard.topics)
         .order_sticky_first.order_recently_posted_first
+        .includes(:categories, :last_user, :user)
         .page(current_page)
       return redirect_to(last_page_params(page_scope)) if page_beyond_last?(page_scope)
       @topics = Thredded::TopicsPageView.new(thredded_current_user, page_scope)
-      Thredded::TopicForm.new(messageboard: messageboard, user: thredded_current_user).tap do |form|
-        @new_topic = form if policy(form.topic).create?
-      end
+      @new_topic = init_new_topic
+    end
+
+    def unread
+      page_scope = topics_scope
+        .unread(thredded_current_user)
+        .order_followed_first(thredded_current_user).order_recently_posted_first
+        .includes(:categories, :last_user, :user)
+        .page(current_page)
+      return redirect_to(last_page_params(page_scope)) if page_beyond_last?(page_scope)
+      @topics = Thredded::TopicsPageView.new(thredded_current_user, page_scope)
+      @new_topic = init_new_topic
+    end
+
+    def search
+      @query = params[:q].to_s
+      page_scope = topics_scope
+        .search_query(@query)
+        .order_recently_posted_first
+        .includes(:categories, :last_user, :user)
+        .page(current_page)
+      return redirect_to(last_page_params(page_scope)) if page_beyond_last?(page_scope)
+      @topics = Thredded::TopicsPageView.new(thredded_current_user, page_scope)
     end
 
     def show
@@ -42,38 +60,8 @@ module Thredded
         .page(current_page)
       return redirect_to(last_page_params(page_scope)) if page_beyond_last?(page_scope)
       @posts = Thredded::TopicPostsPageView.new(thredded_current_user, topic, page_scope)
-
-      if thredded_signed_in?
-        Thredded::UserTopicReadState.touch!(thredded_current_user.id, topic.id, page_scope.last)
-      end
-
+      Thredded::UserTopicReadState.touch!(thredded_current_user.id, topic.id, page_scope.last) if thredded_signed_in?
       @new_post = Thredded::PostForm.new(user: thredded_current_user, topic: topic, post_params: new_post_params)
-    end
-
-    def search
-      in_messageboard = params.key?(:messageboard_id)
-      if in_messageboard
-        authorize_reading messageboard
-        unless params_match?(canonical_messageboard_params)
-          skip_policy_scope
-          return redirect_to(canonical_messageboard_params)
-        end
-      end
-      @query = params[:q].to_s
-      topics_scope = policy_scope(
-        if in_messageboard
-          messageboard.topics
-        else
-          Thredded::Topic.where(messageboard_id: policy_scope(Thredded::Messageboard.all).pluck(:id))
-        end
-      )
-      page_scope = topics_scope
-        .search_query(@query)
-        .order_recently_posted_first
-        .includes(:categories, :last_user, :user)
-        .page(current_page)
-      return redirect_to(last_page_params(page_scope)) if page_beyond_last?(page_scope)
-      @topics = Thredded::TopicsPageView.new(thredded_current_user, page_scope)
     end
 
     def new
@@ -152,6 +140,20 @@ module Thredded
     end
 
     private
+
+    def init_new_topic
+      return unless in_messageboard?
+      form = Thredded::TopicForm.new(messageboard: messageboard, user: thredded_current_user)
+      form if policy(form.topic).create?
+    end
+
+    def verify_messageboard
+      return unless in_messageboard?
+      authorize_reading messageboard
+      return if params_match?(canonical_messageboard_params)
+      skip_policy_scope
+      redirect_to(canonical_messageboard_params)
+    end
 
     def canonical_messageboard_params
       { messageboard_id: messageboard.slug }

--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -20,9 +20,20 @@ module Thredded
     end
 
     def thredded_container_classes
-      ['thredded--main-container', content_for(:thredded_page_id)].tap do |classes|
-        classes << 'thredded--is-moderator' unless moderatable_messageboards_ids.empty?
-      end
+      [
+        'thredded--main-container',
+        content_for(:thredded_page_id),
+        "thredded--global-nav-icons-#{global_nav_icons_count}",
+        ('thredded--is-moderator' unless moderatable_messageboards_ids.empty?),
+        ('thredded--private-messaging-enabled' if Thredded.private_messaging_enabled),
+      ].compact
+    end
+
+    def global_nav_icons_count
+      result = 1 # Notification Settings
+      result += 1 if Thredded.private_messaging_enabled
+      result += 1 if moderatable_messageboards_ids.present?
+      result
     end
 
     # Render the page container with the supplied block as content.
@@ -102,18 +113,6 @@ module Thredded
       else
         t('thredded.topics.not_following')
       end
-    end
-
-    def unread_private_topics_count
-      @unread_private_topics_count ||=
-        if thredded_signed_in?
-          Thredded::PrivateTopic
-            .for_user(thredded_current_user)
-            .unread(thredded_current_user)
-            .count
-        else
-          0
-        end
     end
 
     def moderatable_messageboards_ids

--- a/app/helpers/thredded/nav_helper.rb
+++ b/app/helpers/thredded/nav_helper.rb
@@ -27,6 +27,14 @@ module Thredded
       ]
     )
 
+    USER_NAV_UNREAD_TOPICS = Set.new(
+      %w[thredded--unread-topics]
+    )
+
+    def current_page_unread_topics?
+      USER_NAV_UNREAD_TOPICS.include?(content_for(:thredded_page_id))
+    end
+
     def current_page_preferences?
       USER_NAV_PREFERENCES_PAGES.include?(content_for(:thredded_page_id))
     end
@@ -37,6 +45,10 @@ module Thredded
 
     def current_page_private_topics?
       USER_NAV_PRIVATE_TOPICS_PAGES.include?(content_for(:thredded_page_id))
+    end
+
+    def nav_back_path(messageboard = nil)
+      messageboard ? messageboard_topics_path(messageboard) : messageboards_path
     end
   end
 end

--- a/app/helpers/thredded/urls_helper.rb
+++ b/app/helpers/thredded/urls_helper.rb
@@ -95,6 +95,17 @@ module Thredded
       edit_preferences_url(messageboard, params.merge(only_path: true))
     end
 
+    # @param [Thredded::Messageboard, nil] messageboard
+    # @param [Hash] params additional params
+    def unread_topics_path(messageboard: nil, **params)
+      params[:only_path] = true
+      if messageboard
+        unread_messageboard_topics_url(messageboard, params)
+      else
+        unread_topics_url(params)
+      end
+    end
+
     # @param messageboard [Thredded::Messageboard, nil]
     # @return [String] the path to the global or messageboard search.
     def search_path(messageboard = nil)

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -16,6 +16,7 @@ module Thredded
                     private-posts
                     private-topics
                     theme-preview
+                    unread
                   ]
                 )
 

--- a/app/models/thredded/topic.rb
+++ b/app/models/thredded/topic.rb
@@ -14,6 +14,13 @@ module Thredded
     scope :search_query, ->(query) { ::Thredded::TopicsSearch.new(query, self).search }
 
     scope :order_sticky_first, -> { order(sticky: :desc) }
+    scope :order_followed_first, lambda { |user|
+      user_follows = UserTopicFollow.arel_table
+      joins(arel_table.join(user_follows, Arel::Nodes::OuterJoin)
+              .on(user_follows[:topic_id].eq(arel_table[:id])
+                  .and(user_follows[:user_id].eq(user.id))).join_sources)
+        .order(Arel::Nodes::Ascending.new(user_follows[:id].eq(nil)))
+    }
 
     scope :followed_by, lambda { |user|
       joins(:user_follows)

--- a/app/views/thredded/messageboards/_messageboard_actions.html.erb
+++ b/app/views/thredded/messageboards/_messageboard_actions.html.erb
@@ -1,0 +1,7 @@
+<div class="thredded--messageboards--actions">
+  <% if policy(messageboard).update? %>
+    <a class="thredded--button" href="<%= edit_messageboard_path(messageboard) %>" rel="nofollow">
+      <%= t('thredded.nav.edit_messageboard') %>
+    </a>
+  <% end %>
+</div>

--- a/app/views/thredded/shared/_nav.html.erb
+++ b/app/views/thredded/shared/_nav.html.erb
@@ -12,8 +12,13 @@
     <%= yield :thredded_main_navigation %>
   <% else %>
     <div class="thredded--main-navigation">
+      <%# Navigation scoped to the current messageboard if any. %>
       <%= yield :thredded_breadcrumbs %>
       <%= render 'thredded/search/form', messageboard: messageboard_or_nil %>
+      <div class="thredded--spacer"></div>
+      <div class="thredded--scoped-navigation">
+        <%= render 'thredded/shared/nav/unread_topics', messageboard: messageboard_or_nil %>
+      </div>
     </div>
   <% end %>
 </nav>

--- a/app/views/thredded/shared/nav/_moderation.html.erb
+++ b/app/views/thredded/shared/nav/_moderation.html.erb
@@ -1,7 +1,7 @@
 <% if moderatable_messageboards_ids.present? %>
   <% current = current_page_moderation? %>
   <li class="thredded--user-navigation--item thredded--user-navigation--moderation<%= ' thredded--is-current' if current %>">
-    <%= link_to (current ? messageboards_path : pending_moderation_path), rel: 'nofollow' do %>
+    <%= link_to current ? nav_back_path : pending_moderation_path, rel: 'nofollow' do %>
       <%= inline_svg 'thredded/moderation.svg',
                      class: 'thredded--icon',
                      title: t('thredded.nav.moderation') %>

--- a/app/views/thredded/shared/nav/_notification_preferences.html.erb
+++ b/app/views/thredded/shared/nav/_notification_preferences.html.erb
@@ -1,7 +1,6 @@
 <% current = current_page_preferences? %>
 <li class="thredded--user-navigation--settings thredded--user-navigation--item<%= ' thredded--is-current' if current %>">
-  <%= link_to current ? (messageboard ? messageboard_topics_path(messageboard) : messageboards_path)
-                      : edit_preferences_path(messageboard), rel: 'nofollow' do %>
+  <%= link_to current ? nav_back_path(messageboard) : edit_preferences_path(messageboard), rel: 'nofollow' do %>
     <%= inline_svg 'thredded/settings.svg', class: 'thredded--icon', title: t('thredded.nav.settings') %>
     <span class="thredded--nav-text"><%= t('thredded.nav.settings') %></span>
   <% end %>

--- a/app/views/thredded/shared/nav/_private_topics.html.erb
+++ b/app/views/thredded/shared/nav/_private_topics.html.erb
@@ -1,6 +1,6 @@
 <% current = current_page_private_topics? %>
 <li class="thredded--user-navigation--item thredded--user-navigation--private-topics<%= ' thredded--is-current' if current %>">
-  <%= link_to (current ? messageboards_path : private_topics_path), rel: 'nofollow' do %>
+  <%= link_to current ? nav_back_path : private_topics_path, rel: 'nofollow' do %>
     <%= inline_svg 'thredded/private-messages.svg',
                    class: 'thredded--icon',
                    title: t('thredded.nav.private_topics') %>

--- a/app/views/thredded/shared/nav/_unread_topics.html.erb
+++ b/app/views/thredded/shared/nav/_unread_topics.html.erb
@@ -1,0 +1,12 @@
+<% current = current_page_unread_topics? %>
+<% if unread_topics_count > 0 || current %>
+  <li class="thredded--user-navigation--unread-topics thredded--user-navigation--item<%= ' thredded--is-current' if current %>">
+    <%= link_to current ? nav_back_path(messageboard) : unread_topics_path(messageboard: messageboard), rel: 'nofollow' do %>
+      <%= inline_svg 'thredded/follow.svg', class: 'thredded--icon' %>
+      <span class="thredded--nav-text"><%= t('thredded.nav.unread_topics') %></span>
+      <% if unread_followed_topics_count > 0 -%>
+        <span class="thredded--user-navigation--unread-topics--followed-count"><%= unread_followed_topics_count %></span>
+      <% end -%>
+    <% end %>
+  </li>
+<% end %>

--- a/app/views/thredded/topics/index.html.erb
+++ b/app/views/thredded/topics/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :thredded_breadcrumbs, render('thredded/shared/breadcrumbs') %>
 
 <%= thredded_page do %>
-  <div class="thredded--svg-definitions ">
+  <div class="thredded--svg-definitions">
     <%= inline_svg 'thredded/follow.svg', id: 'thredded-follow-icon', title: nil %>
     <%= inline_svg 'thredded/unfollow.svg', id: 'thredded-unfollow-icon' %>
   </div>
@@ -25,11 +25,5 @@
     <%= paginate @topics %>
   </footer>
 
-  <div class="thredded--messageboards--actions">
-    <% if policy(messageboard).update? %>
-      <a class="thredded--button" href="<%= edit_messageboard_path(messageboard) %>" rel="nofollow">
-        <%= t('thredded.nav.edit_messageboard') %>
-      </a>
-    <% end %>
-  </div>
+  <%= render 'thredded/messageboards/messageboard_actions', messageboard: messageboard %>
 <% end %>

--- a/app/views/thredded/topics/unread.html.erb
+++ b/app/views/thredded/topics/unread.html.erb
@@ -1,0 +1,33 @@
+<% content_for :thredded_page_title,
+               messageboard_or_nil ?
+                   t('thredded.unread_topics.page_title_in_messageboard', messageboard: messageboard.name) :
+                   t('thredded.unread_topics.page_title') %>
+<% content_for :thredded_page_id, 'thredded--unread-topics' %>
+<% content_for :thredded_breadcrumbs, render('thredded/shared/breadcrumbs') %>
+
+<%= thredded_page do %>
+  <% if @topics.present? %>
+    <div class="thredded--svg-definitions ">
+      <%= inline_svg 'thredded/follow.svg', id: 'thredded-follow-icon', title: nil %>
+      <%= inline_svg 'thredded/unfollow.svg', id: 'thredded-unfollow-icon' %>
+    </div>
+    <%= content_tag :section, class: 'thredded--main-section thredded--topics', 'data-thredded-topics' => true do %>
+      <%= render 'thredded/topics/form',
+                 topic: @new_topic,
+                 css_class: 'thredded--is-compact',
+                 placeholder: t('thredded.topics.form.title_placeholder_start') if @new_topic %>
+      <%= render partial: 'thredded/topics/topic',
+                 collection: @topics,
+                 locals: { topics: @topics } %>
+    <% end %>
+    <footer class="thredded--pagination-bottom">
+      <%= paginate @topics %>
+    </footer>
+  <% else %>
+    <div class="thredded--empty">
+      <h3 class="thredded--empty--title"><%= t 'thredded.unread_topics.empty.title' %></h3>
+      <p><%= t 'thredded.unread_topics.empty.content' %></p>
+    </div>
+  <% end %>
+  <%= render 'thredded/messageboards/messageboard_actions', messageboard: messageboard if messageboard_or_nil %>
+<% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -117,6 +117,7 @@ de:
       moderation_users: Nutzer
       private_topics: Private Unterhaltungen
       settings: Benachrichtigungseinstellungen
+      unread_topics: Ungelesen
     null_user_name: Gelöschte Nutzer
     posts:
       delete: Beitrag gelöscht
@@ -242,6 +243,12 @@ de:
       unfollow: Nich mehr folgen
       unfollowed_notice: Du folgst der Diskussion nicht mehr
       updated_notice: Beitrag aktualisiert
+    unread_topics:
+      empty:
+        content: Du hast alles gelesen, was es gibt. Komm später wieder für mehr!
+        title: Alles gelesen!
+      page_title: Ungelesene Themen
+      page_title_in_messageboard: "%{messageboard}: Ungelesene Themen"
     users:
       currently_online: Zurzeit Online
       last_active_html: Zuletzt aktiv %{time_ago}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,7 @@ en:
       moderation_users: Users
       private_topics: Private Messages
       settings: Notification Settings
+      unread_topics: Unread
     null_user_name: Deleted user
     posts:
       delete: Delete Post
@@ -238,6 +239,12 @@ en:
       unfollow: Stop following
       unfollowed_notice: You are no longer following this topic
       updated_notice: Topic updated
+    unread_topics:
+      empty:
+        content: You've read all there is. Come back later for more!
+        title: All read!
+      page_title: Unread topics
+      page_title_in_messageboard: "%{messageboard}: Unread topics"
     users:
       currently_online: Currently Online
       last_active_html: Last active %{time_ago}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -118,6 +118,7 @@ es:
       moderation_users: Usuarios
       private_topics: Mensajes Privados
       settings: Ajuste de Notificaciones
+      unread_topics: No leído
     null_user_name: Usuario eliminado
     posts:
       delete: Eliminar Mensaje
@@ -242,6 +243,12 @@ es:
       unfollow: Deja de seguir
       unfollowed_notice: Has dejado de seguir este tema
       updated_notice: Tema actualizado
+    unread_topics:
+      empty:
+        content: Has leído todo lo que hay. ¡Vuelve más tarde para más!
+        title: "¡Todo leido!"
+      page_title: Temas no leídos
+      page_title_in_messageboard: "%{messageboard}: temas no leídos"
     users:
       currently_online: En línea
       last_active_html: Última vez activo hace %{time_ago}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -116,6 +116,7 @@ fr:
       moderation_users: Utilisateurs
       private_topics: Messages privés
       settings: Paramètres de notifications
+      unread_topics: Non lu
     null_user_name: Utilisateur effacé
     posts:
       delete: Supprimer le commentaire
@@ -240,6 +241,12 @@ fr:
       unfollow: Arrêter de suivre
       unfollowed_notice: Vous ne suivez dorénavant plus ce sujet
       updated_notice: Sujet mis à jour
+    unread_topics:
+      empty:
+        content: Vous avez lu tout ce qu'il y a. Revenez plus tard pour plus!
+        title: Tout lire!
+      page_title: Sujets non lus
+      page_title_in_messageboard: "%{messageboard}: sujets non lus"
     users:
       currently_online: En ce moment connecté
       last_active_html: 'Actif pour la dernière fois : %{time_ago}'

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -116,6 +116,7 @@ it:
       moderation_users: Utenti
       private_topics: Messaggi Privati
       settings: Impostazioni Notifiche
+      unread_topics: Non letto
     null_user_name: Utente cancellato
     posts:
       delete: Cancella messaggio
@@ -242,6 +243,12 @@ it:
       unfollow: Non seguire più questa discussione
       unfollowed_notice: Ora non stai più seguendo questa discussione
       updated_notice: Discussione aggiornata
+    unread_topics:
+      empty:
+        content: Hai letto tutto quello che c'è. Torna più tardi per di più!
+        title: Tutto letto!
+      page_title: Argomenti non letti
+      page_title_in_messageboard: "%{messageboard}: argomenti non letti"
     users:
       currently_online: Attualmente connessi
       last_active_html: Ultima attività %{time_ago}

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -116,6 +116,7 @@ pl:
       moderation_users: Użytkownicy
       private_topics: Prywatne wiadomości
       settings: Ustawienia powiadomień
+      unread_topics: Nieprzeczytane
     null_user_name: Usunięci użytkownicy
     posts:
       delete: Usuń post
@@ -238,6 +239,12 @@ pl:
       unfollow: Przestań obserwować
       unfollowed_notice: Przestałeś obserwować ten temat
       updated_notice: Temat zaktualizowany
+    unread_topics:
+      empty:
+        content: Przeczytałeś wszystko, co istnieje. Przyjdź później po więcej!
+        title: Wszystko przeczytane!
+      page_title: Nieprzeczytane tematy
+      page_title_in_messageboard: "%{messageboard}: Nieprzeczytane tematy"
     users:
       currently_online: Aktualnie online
       last_active_html: Ostatnio aktywny %{time_ago}

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -118,6 +118,7 @@ pt-BR:
       moderation_users: Usuários
       private_topics: Mensagens Privadas
       settings: Configurações de Notificação
+      unread_topics: Não lida
     null_user_name: Usuário deletado
     posts:
       delete: Remover Post
@@ -243,6 +244,12 @@ pt-BR:
       unfollow: Pare de seguir
       unfollowed_notice: Você não está mais seguindo este tópico
       updated_notice: Tópico atualizado
+    unread_topics:
+      empty:
+        content: Você leu tudo o que existe. Volte mais tarde para mais!
+        title: Tudo lido!
+      page_title: Tópicos não lidos
+      page_title_in_messageboard: "%{messageboard}: Tópicos não lidos"
     users:
       currently_online: Atualmente Online
       last_active_html: Última %{time_ago} ativa

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -114,6 +114,7 @@ ru:
       moderation_users: Пользователи
       private_topics: Личное
       settings: Настройки
+      unread_topics: Непрочитанные
     null_user_name: Пользователь удален
     posts:
       delete: Удалить пост
@@ -236,6 +237,12 @@ ru:
       unfollow: Не следить за темой
       unfollowed_notice: Вы не следите за темой
       updated_notice: Тема обновлена
+    unread_topics:
+      empty:
+        content: Вы все прочитали. Вернитесь позже и может будет еще что-нибудь!
+        title: Все прочитано!
+      page_title: Непрочитанные темы
+      page_title_in_messageboard: "%{messageboard}: непрочитанные темы"
     users:
       currently_online: Онлайн
       last_active_html: Последняя активность %{time_ago}

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -111,6 +111,7 @@ zh-CN:
       moderation_users: 用户
       private_topics: 私人对话
       settings: 通知设置
+      unread_topics: 未读
     null_user_name: 删除用户
     posts:
       delete: 删除回复
@@ -231,6 +232,12 @@ zh-CN:
       unfollow: 取消关注
       unfollowed_notice: 你不再关注该帖子
       updated_notice: 帖子已更新
+    unread_topics:
+      empty:
+        content: 你已经读完了。稍后再回来获取更多！
+        title: 全部阅读！
+      page_title: 未读主题
+      page_title_in_messageboard: "%{messageboard}：未读主题"
     users:
       currently_online: 目前在线
       last_active_html: 最后活跃%{time_ago}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,12 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  resources :topics, path: '', only: [] do
+    collection do
+      get '/unread', action: :unread, as: :unread
+    end
+  end
+
   resource :preferences, only: %i[edit update], as: :global_preferences
   resource :messageboard, path: 'messageboards', only: [:new]
   resources :messageboards, only: %i[edit update]
@@ -64,6 +70,7 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
       collection do
         get '(page-:page)', action: :index, as: '', constraints: page_constraint
         get '/category/:category_id', action: :category, as: :categories
+        get '/unread', action: :unread, as: :unread
       end
       member do
         get '(page-:page)', action: :show, as: '', constraints: page_constraint

--- a/spec/features/thredded/user_visits_unread_page.rb
+++ b/spec/features/thredded/user_visits_unread_page.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+feature 'User viewing unread topics' do
+  let(:user) { create(:user) }
+  let(:messageboard) { create(:messageboard) }
+
+  scenario 'sees unread topics, sorted followed-first' do
+    create_topic(title: 'Read topic', read: true)
+    create_topic(title: 'Read followed topic', read: true, followed: true)
+    unread_topic = create_topic(title: 'Unread topic')
+    unread_followed_topic = create_topic(title: 'Unread followed topic', followed: true)
+
+    topics = PageObject::Topics.new(messageboard)
+    nav = PageObject::Navigation.new
+    PageObject::User.new(user).log_in
+    topics.visit_index
+    expect(nav.unread_followed_topics_count).to eq(1)
+    nav.click_unread
+    expect(topics.displayed_titles)
+      .to eq [
+        unread_followed_topic.title,
+        unread_topic.title,
+      ]
+  end
+
+  def create_topic(title:, read: false, followed: false)
+    topic = create(:topic, with_posts: 1, messageboard: messageboard, title: title)
+    create(:user_topic_read_state, user: user, postable: topic, read_at: topic.updated_at) if read
+    create(:user_topic_follow, user: user, topic: topic) if followed
+    topic
+  end
+end

--- a/spec/support/features/page_object/navigation.rb
+++ b/spec/support/features/page_object/navigation.rb
@@ -7,5 +7,15 @@ module PageObject
     def has_unread_private_topics?
       all('.thredded--user-navigation--private-topics--unread').any?
     end
+
+    def unread_followed_topics_count
+      badge = find('.thredded--user-navigation--unread-topics--followed-count')
+      return 0 unless badge
+      badge.text.to_i
+    end
+
+    def click_unread
+      click_link(text: /\A#{Regexp.escape I18n.t('thredded.nav.unread_topics')}(?: \d+)?\z/)
+    end
   end
 end

--- a/spec/support/features/page_object/topics.rb
+++ b/spec/support/features/page_object/topics.rb
@@ -70,6 +70,10 @@ module PageObject
       has_content?(topic_title)
     end
 
+    def displayed_titles
+      all('.thredded--topics--title a').map(&:text)
+    end
+
     def has_sticky_divider?
       has_css?('.thredded--topics--sticky-topics-divider')
     end

--- a/spec/views/thredded/messageboards/index.html.erb_spec.rb
+++ b/spec/views/thredded/messageboards/index.html.erb_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'thredded/messageboards/index' do
         moderatable_messageboards_ids: [],
         thredded_signed_in?: true,
         unread_private_topics_count: 1,
+        unread_topics_count: 0,
       )
     )
 


### PR DESCRIPTION
Adds a global / messageboard-level unread page.
Topics are ordered followed-first.

The navigation link has a badge indicating the numbers of followed unread topics.

If there are no unread topics at all (including non-followed ones), the
link is not displayed.

This makes topic following useful even for users who opt-out of all notifications.

![unread-desktop](https://user-images.githubusercontent.com/216339/41196781-1afc64ec-6c41-11e8-8b9c-cd4fb4284bcb.png)

![unread-mobile](https://user-images.githubusercontent.com/216339/41196782-1ccecef4-6c41-11e8-83dc-1bdae71ad399.png)

Fixes #708 

/cc @timdiggins 