### PR TITLE
Remove redundant messageboard permission queries

### DIFF
--- a/app/controllers/thredded/messageboards_controller.rb
+++ b/app/controllers/thredded/messageboards_controller.rb
@@ -12,15 +12,14 @@ module Thredded
     end
 
     def new
-      @messageboard = Thredded::Messageboard.new
-      @messageboard_group = Thredded::MessageboardGroup.all
-      authorize_creating @messageboard
+      @new_messageboard = Thredded::Messageboard.new
+      authorize_creating @new_messageboard
     end
 
     def create
-      @messageboard = Thredded::Messageboard.new(messageboard_params)
-      authorize_creating @messageboard
-      if Thredded::CreateMessageboard.new(@messageboard, thredded_current_user).run
+      @new_messageboard = Thredded::Messageboard.new(messageboard_params)
+      authorize_creating @new_messageboard
+      if Thredded::CreateMessageboard.new(@new_messageboard, thredded_current_user).run
         redirect_to root_path
       else
         render :new

--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -56,7 +56,7 @@ module Thredded
       return redirect_to(canonical_topic_params) unless params_match?(canonical_topic_params)
       page_scope = policy_scope(topic.posts)
         .order_oldest_first
-        .includes(:user, :messageboard, :postable)
+        .includes(:user, :messageboard)
         .page(current_page)
       return redirect_to(last_page_params(page_scope)) if page_beyond_last?(page_scope)
       @posts = Thredded::TopicPostsPageView.new(thredded_current_user, topic, page_scope)

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -31,7 +31,7 @@ module Thredded
 
     has_many :categories, dependent: :destroy
     has_many :user_messageboard_preferences, dependent: :destroy
-    has_many :posts, dependent: :destroy
+    has_many :posts, dependent: :destroy, inverse_of: :messageboard
     has_many :topics, dependent: :destroy, inverse_of: :messageboard
 
     belongs_to :last_topic, class_name: 'Thredded::Topic', **(Thredded.rails_gte_51? ? { optional: true } : {})

--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -10,7 +10,8 @@ module Thredded
                inverse_of: :thredded_posts,
                **(Thredded.rails_gte_51? ? { optional: true } : {})
     belongs_to :messageboard,
-               counter_cache: true
+               counter_cache: true,
+               inverse_of: :posts
     belongs_to :postable,
                class_name:    'Thredded::Topic',
                inverse_of:    :posts,

--- a/app/models/thredded/user_permissions/moderate/if_moderator_column_true.rb
+++ b/app/models/thredded/user_permissions/moderate/if_moderator_column_true.rb
@@ -10,6 +10,13 @@ module Thredded
         def thredded_can_moderate_messageboards
           send(Thredded.moderator_column) ? Thredded::Messageboard.all : Thredded::Messageboard.none
         end
+
+        # @param [Thredded::Messageboard] messageboard
+        # @return [Boolean] Whether the user can moderate the given messageboard.
+        def thredded_can_moderate_messageboard?(messageboard)
+          scope = thredded_can_moderate_messageboards
+          scope == Thredded::Messageboard.all || scope.include?(messageboard)
+        end
       end
     end
   end

--- a/app/models/thredded/user_permissions/moderate/none.rb
+++ b/app/models/thredded/user_permissions/moderate/none.rb
@@ -10,6 +10,12 @@ module Thredded
         def thredded_can_moderate_messageboards
           Thredded::Messageboard.none
         end
+
+        # @param [Thredded::Messageboard] messageboard
+        # @return [false] Whether the user can moderate the given messageboard.
+        def thredded_can_moderate_messageboard?(messageboard) # rubocop:disable Lint/UnusedMethodArgument
+          false
+        end
       end
     end
   end

--- a/app/models/thredded/user_permissions/read/all.rb
+++ b/app/models/thredded/user_permissions/read/all.rb
@@ -12,6 +12,13 @@ module Thredded
           Thredded::Messageboard.all
         end
 
+        # @param [Thredded::Messageboard] messageboard
+        # @return [Boolean] Whether the user can read the given messageboard.
+        def thredded_can_read_messageboard?(messageboard)
+          scope = thredded_can_read_messageboards
+          scope == Thredded::Messageboard.all || scope.include?(messageboard)
+        end
+
         module ClassMethods
           # Users that can read some of the given messageboards.
           #

--- a/app/policies/thredded/messageboard_policy.rb
+++ b/app/policies/thredded/messageboard_policy.rb
@@ -13,7 +13,12 @@ module Thredded
 
       # @return [ActiveRecord::Relation<Thredded::Messageboards>]
       def resolve
-        @scope.merge(@user.thredded_can_read_messageboards)
+        readable = @user.thredded_can_read_messageboards
+        if readable == Thredded::Messageboard.all
+          @scope
+        else
+          @scope.merge(readable)
+        end
       end
     end
 
@@ -29,7 +34,7 @@ module Thredded
     end
 
     def read?
-      @user.thredded_admin? || @user.thredded_can_read_messageboards.include?(@messageboard)
+      @user.thredded_admin? || @user.thredded_can_read_messageboard?(@messageboard)
     end
 
     def update?
@@ -43,7 +48,7 @@ module Thredded
     end
 
     def moderate?
-      @user.thredded_admin? || @user.thredded_can_moderate_messageboards.include?(@messageboard)
+      @user.thredded_admin? || @user.thredded_can_moderate_messageboard?(@messageboard)
     end
   end
 end

--- a/app/views/thredded/messageboards/_form.html.erb
+++ b/app/views/thredded/messageboards/_form.html.erb
@@ -21,9 +21,9 @@
       </li>
 
       <li>
-        <%= f.submit @messageboard.persisted? ? t('thredded.messageboard.update') : t('thredded.messageboard.create'),
+        <%= f.submit messageboard.persisted? ? t('thredded.messageboard.update') : t('thredded.messageboard.create'),
                      class: 'thredded--form--submit',
-                     'data-disable-with' => @messageboard.persisted? ?
+                     'data-disable-with' => messageboard.persisted? ?
                          t('thredded.messageboard.form.update_btn_submitting') :
                          t('thredded.messageboard.form.create_btn_submitting') %>
       </li>

--- a/app/views/thredded/messageboards/new.html.erb
+++ b/app/views/thredded/messageboards/new.html.erb
@@ -10,6 +10,6 @@
 
 <%= thredded_page do %>
   <section class="thredded--main-section">
-    <%= render 'form', messageboard: @messageboard %>
+    <%= render 'form', messageboard: @new_messageboard %>
   </section>
 <% end %>

--- a/app/views/thredded/shared/nav/_moderation.html.erb
+++ b/app/views/thredded/shared/nav/_moderation.html.erb
@@ -1,4 +1,4 @@
-<% if moderatable_messageboards_ids.present? %>
+<% if thredded_moderator? %>
   <% current = current_page_moderation? %>
   <li class="thredded--user-navigation--item thredded--user-navigation--moderation<%= ' thredded--is-current' if current %>">
     <%= link_to current ? nav_back_path : pending_moderation_path, rel: 'nofollow' do %>

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -44,6 +44,15 @@ require 'thredded/base_notifier'
 require 'thredded/arel_compat'
 require 'thredded/collection_to_strings_with_cache_renderer'
 
+if Rails::VERSION::MAJOR < 5
+  begin
+    require 'where-or'
+  rescue LoadError
+    $stderr.puts "\nthredded: Please add gem 'where-or' to your Gemfile"
+    exit 1 # rubocop:disable Rails/Exit
+  end
+end
+
 module Thredded # rubocop:disable Metrics/ModuleLength
   class << self
     #== User

--- a/spec/gemfiles/rails_4_2.gemfile
+++ b/spec/gemfiles/rails_4_2.gemfile
@@ -14,4 +14,6 @@ gem 'pg', '~> 0.21'
 # https://github.com/rails/rails/blob/v4.2.10/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L3
 gem 'mysql2', '>= 0.3.13', '< 0.5'
 
+# Backports
+gem 'where-or'
 gem 'backport_new_renderer'

--- a/spec/views/thredded/messageboards/index.html.erb_spec.rb
+++ b/spec/views/thredded/messageboards/index.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'thredded/messageboards/index' do
       receive_messages(
         active_users: [],
         messageboard_or_nil: nil,
-        moderatable_messageboards_ids: [],
+        thredded_moderator?: false,
         thredded_signed_in?: true,
         unread_private_topics_count: 1,
         unread_topics_count: 0,


### PR DESCRIPTION
Remove redundant checks when the the scope for read or moderate is `all` or `none`.