### PR TITLE
treat current user search differently than past results in private message participants.

### DIFF
--- a/app/assets/javascripts/thredded/components/users_select.es6
+++ b/app/assets/javascripts/thredded/components/users_select.es6
@@ -44,7 +44,7 @@
           current.push(char);
       }
     }
-    if (current.length) result.push({name: current.join(''), index: currentIndex});
+    if (current.length) result.current = {name: current.join(''), index: currentIndex};
     return result;
   }
 
@@ -77,8 +77,8 @@
       index: 0,
       match: (text) => {
         const names = parseNames(text);
-        if (names.length) {
-          const {name, index} = names[names.length - 1];
+        if (names.current) {
+          const {name, index} = names.current;
           const matchData = [name];
           matchData.index = index;
           return matchData;

--- a/spec/features/thredded/user_sends_new_private_topic_spec.rb
+++ b/spec/features/thredded/user_sends_new_private_topic_spec.rb
@@ -5,8 +5,7 @@ require 'spec_helper'
 RSpec.feature 'User sends a new private topic' do
   it 'with title, recipient and content' do
     PageObject::User.new(create(:user, name: 'joel')).log_in
-    messageboard = create(:messageboard)
-    private_topic = PageObject::PrivateTopics.new(messageboard)
+    private_topic = PageObject::PrivateTopics.new('A new message')
     private_topic.create_private_topic
     private_topic.visit_private_topic_list
     expect(private_topic).to be_on_private_list

--- a/spec/features/thredded/user_sends_new_private_topic_spec.rb
+++ b/spec/features/thredded/user_sends_new_private_topic_spec.rb
@@ -10,4 +10,33 @@ RSpec.feature 'User sends a new private topic' do
     private_topic.visit_private_topic_list
     expect(private_topic).to be_on_private_list
   end
+
+
+  describe "autocompletion in textbox", js: true do
+    let(:user_names) { ["Barbara Fleischman", "Barb", "Barbara", "Eric"] }
+    let!(:users) { user_names.map { |n| create(:user, name: n) } }
+    before do
+      PageObject::User.new(create(:user, name: 'joel')).log_in
+    end
+    it "shows dropdown" do
+      private_topic = PageObject::PrivateTopics.new("A new message")
+      click_on "Private Messages"
+      click_on "Start your first private conversation"
+
+
+      fill_in I18n.t('thredded.private_topics.form.title_label'), with: private_topic.private_title
+      find(:css, '[name="private_topic[user_names]"]').hover
+      find(:css, '[name="private_topic[user_names]"]').click
+      find(:css, '[name="private_topic[user_names]"]').send_keys("Bar")
+      expect(page).to have_css("ul.thredded--textcomplete-dropdown li", count: 3)
+      find(:css, '[name="private_topic[user_names]"]').send_keys("b")
+      expect(page).to have_css("ul.thredded--textcomplete-dropdown li", count: 3)
+      find(:css, '[name="private_topic[user_names]"]').send_keys("ara")
+      expect(page).to have_css("ul.thredded--textcomplete-dropdown li", count: 2)
+      find(:css, '[name="private_topic[user_names]"]').send_keys(" Fleis")
+      expect(page).to have_css("ul.thredded--textcomplete-dropdown li", count: 1)
+      find(:css, '[name="private_topic[user_names]"]').send_keys("\n")
+      expect(find(:css, '[name="private_topic[user_names]"]').value).to eq("Barbara Fleischman, ")
+    end
+  end
 end

--- a/spec/features/thredded/user_sends_new_private_topic_spec.rb
+++ b/spec/features/thredded/user_sends_new_private_topic_spec.rb
@@ -11,32 +11,32 @@ RSpec.feature 'User sends a new private topic' do
     expect(private_topic).to be_on_private_list
   end
 
-
-  describe "autocompletion in textbox", js: true do
-    let(:user_names) { ["Barbara Fleischman", "Barb", "Barbara", "Eric"] }
+  describe 'autocompletion in textbox', js: true do
+    let(:user_names) { ['Barbara Fleischman', 'Barb', 'Barbara', 'Eric'] }
     let!(:users) { user_names.map { |n| create(:user, name: n) } }
+
     before do
       PageObject::User.new(create(:user, name: 'joel')).log_in
     end
-    it "shows dropdown" do
-      private_topic = PageObject::PrivateTopics.new("A new message")
-      click_on "Private Messages"
-      click_on "Start your first private conversation"
 
+    it 'shows dropdown' do
+      private_topic = PageObject::PrivateTopics.new('A new message')
+      click_on 'Private Messages'
+      click_on 'Start your first private conversation'
 
       fill_in I18n.t('thredded.private_topics.form.title_label'), with: private_topic.private_title
       find(:css, '[name="private_topic[user_names]"]').hover
       find(:css, '[name="private_topic[user_names]"]').click
-      find(:css, '[name="private_topic[user_names]"]').send_keys("Bar")
-      expect(page).to have_css("ul.thredded--textcomplete-dropdown li", count: 3)
-      find(:css, '[name="private_topic[user_names]"]').send_keys("b")
-      expect(page).to have_css("ul.thredded--textcomplete-dropdown li", count: 3)
-      find(:css, '[name="private_topic[user_names]"]').send_keys("ara")
-      expect(page).to have_css("ul.thredded--textcomplete-dropdown li", count: 2)
-      find(:css, '[name="private_topic[user_names]"]').send_keys(" Fleis")
-      expect(page).to have_css("ul.thredded--textcomplete-dropdown li", count: 1)
+      find(:css, '[name="private_topic[user_names]"]').send_keys('Bar')
+      expect(page).to have_css('ul.thredded--textcomplete-dropdown li', count: 3)
+      find(:css, '[name="private_topic[user_names]"]').send_keys('b')
+      expect(page).to have_css('ul.thredded--textcomplete-dropdown li', count: 3)
+      find(:css, '[name="private_topic[user_names]"]').send_keys('ara')
+      expect(page).to have_css('ul.thredded--textcomplete-dropdown li', count: 2)
+      find(:css, '[name="private_topic[user_names]"]').send_keys(' Fleis')
+      expect(page).to have_css('ul.thredded--textcomplete-dropdown li', count: 1)
       find(:css, '[name="private_topic[user_names]"]').send_keys("\n")
-      expect(find(:css, '[name="private_topic[user_names]"]').value).to eq("Barbara Fleischman, ")
+      expect(find(:css, '[name="private_topic[user_names]"]').value).to eq('Barbara Fleischman, ')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -166,7 +166,7 @@ Capybara.register_driver :headless_chromium do |app|
   options.add_argument 'window-size=1280,1024'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
-Capybara.javascript_driver = :headless_chromium
+Capybara.javascript_driver = ENV['CAPYBARA_JS_DRIVER']&.to_sym || :headless_chromium
 Capybara.configure do |config|
   # bump from the default of 2 seconds because travis can be slow
   config.default_max_wait_time = 5

--- a/spec/support/features/page_object/private_topics.rb
+++ b/spec/support/features/page_object/private_topics.rb
@@ -52,8 +52,6 @@ module PageObject
       has_css? 'article h1 a', text: private_title
     end
 
-    private
-
     attr_reader :private_title
   end
 end

--- a/spec/support/features/page_object/private_topics.rb
+++ b/spec/support/features/page_object/private_topics.rb
@@ -54,6 +54,6 @@ module PageObject
 
     private
 
-    attr_reader :messageboard, :private_title
+    attr_reader :private_title
   end
 end


### PR DESCRIPTION
ensure that a comma splits off results from new search.
closes #745.