### PR TITLE
Easy switch of js driver for deubgging js feature specs

### DIFF
--- a/spec/features/thredded/user_sends_new_private_topic_spec.rb
+++ b/spec/features/thredded/user_sends_new_private_topic_spec.rb
@@ -5,8 +5,7 @@ require 'spec_helper'
 RSpec.feature 'User sends a new private topic' do
   it 'with title, recipient and content' do
     PageObject::User.new(create(:user, name: 'joel')).log_in
-    messageboard = create(:messageboard)
-    private_topic = PageObject::PrivateTopics.new(messageboard)
+    private_topic = PageObject::PrivateTopics.new('A new message')
     private_topic.create_private_topic
     private_topic.visit_private_topic_list
     expect(private_topic).to be_on_private_list

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -166,7 +166,7 @@ Capybara.register_driver :headless_chromium do |app|
   options.add_argument 'window-size=1280,1024'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
-Capybara.javascript_driver = :headless_chromium
+Capybara.javascript_driver = ENV['CAPYBARA_JS_DRIVER']&.to_sym || :headless_chromium
 Capybara.configure do |config|
   # bump from the default of 2 seconds because travis can be slow
   config.default_max_wait_time = 5

--- a/spec/support/features/page_object/private_topics.rb
+++ b/spec/support/features/page_object/private_topics.rb
@@ -54,6 +54,6 @@ module PageObject
 
     private
 
-    attr_reader :messageboard, :private_title
+    attr_reader :private_title
   end
 end


### PR DESCRIPTION
Now you can do:
    
    CAPYBARA_JS_DRIVER=selenium_chrome rspec spec --tag=js
    CAPYBARA_JS_DRIVER=selenium rspec spec --tag=js

(also clean up old test)