### PR TITLE
Can specify next page when creating new topic.

### DIFF
--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -88,7 +88,7 @@ module Thredded
       @new_topic = Thredded::TopicForm.new(new_topic_params)
       authorize_creating @new_topic.topic
       if @new_topic.save
-        redirect_to messageboard_topics_path(messageboard)
+        redirect_to next_page_after_create(params[:next_page])
       else
         render :new
       end
@@ -140,6 +140,19 @@ module Thredded
     end
 
     private
+
+    def next_page_after_create(next_page)
+      case next_page
+      when 'messageboard', '', nil
+        return messageboard_topics_path(messageboard)
+      when 'topic'
+        messageboard_topic_path(messageboard, @new_topic.topic)
+      when %r{\A/[^/]\S+\Z}
+        next_page
+      else
+        fail "Unexpected value for next page: #{next_page.inspect}"
+      end
+    end
 
     def in_messageboard?
       params.key?(:messageboard_id)

--- a/app/controllers/thredded/topics_controller.rb
+++ b/app/controllers/thredded/topics_controller.rb
@@ -147,7 +147,7 @@ module Thredded
         return messageboard_topics_path(messageboard)
       when 'topic'
         messageboard_topic_path(messageboard, @new_topic.topic)
-      when %r{\A/[^/]\S+\Z}
+      when %r{\A/[^/]\S+\z}
         next_page
       else
         fail "Unexpected value for next page: #{next_page.inspect}"

--- a/app/views/thredded/topics/_form.html.erb
+++ b/app/views/thredded/topics/_form.html.erb
@@ -7,6 +7,8 @@
                  'data-autocomplete-min-length' => Thredded.autocomplete_min_length,
                  'data-thredded-submit-hotkey' => true,
              } do |form| %>
+  <%= hidden_field_tag("next_page", params[:next_page]) %>
+
   <ul class="thredded--form-list on-top">
     <li class="title">
       <%= form.label :title, t('thredded.topics.form.title_label') %>

--- a/spec/features/thredded/user_creates_new_topic_spec.rb
+++ b/spec/features/thredded/user_creates_new_topic_spec.rb
@@ -39,6 +39,15 @@ RSpec.feature 'User creates new topic' do
     expect(topic_form).not_to have_a_sticky_checkbox
   end
 
+  it 'redirects to a specific next_page (topic)' do
+    topic = new_topic
+    topic.visit_form(next_page: 'topic')
+    topic.with_title('Sample thread title')
+    topic.with_content('Hello *world*!')
+    topic.submit
+    expect(page).to have_current_path(topic.latest_topic_path)
+  end
+
   context 'as an admin' do
     it 'and can make it locked or sticky' do
       topic_form = new_topic_as_an_admin

--- a/spec/support/features/page_object/topics.rb
+++ b/spec/support/features/page_object/topics.rb
@@ -50,12 +50,16 @@ module PageObject
       visit messageboard_topics_path(messageboard)
     end
 
-    def visit_form
-      visit new_messageboard_topic_path(messageboard)
+    def visit_form(next_page: nil)
+      visit new_messageboard_topic_path(messageboard, next_page: next_page)
     end
 
     def visit_latest_topic
-      visit messageboard_topic_path(messageboard, Thredded::Topic.last)
+      visit latest_topic_path
+    end
+
+    def latest_topic_path
+      messageboard_topic_path(messageboard, Thredded::Topic.last)
     end
 
     def visit_topic_edit


### PR DESCRIPTION
Pass next_page param with new_topic_url. 

`next_page` can be:

*  "messageboard" (or empty same as current behaviour) to display messageboard topics after creating topic
*  "topic" to display topic after creating topic
* a path starting with / to redirect to this specific path. 

closes #619.