### PR TITLE
Messageboard grid: Incomplete rows up to 6 cells

### DIFF
--- a/app/assets/stylesheets/thredded/components/_messageboard.scss
+++ b/app/assets/stylesheets/thredded/components/_messageboard.scss
@@ -157,6 +157,11 @@
         }
       }
 
+      // A helper class for sizing incomplete rows with more than two missing items.
+      .thredded--grid-sizer {
+        @extend %thredded--messageboards-cell-flex;
+      }
+
       .thredded--messageboard {
         @extend %thredded--messageboards-cell-flex;
         margin-top: $margin-y;

--- a/app/views/thredded/messageboards/_grid_sizers.html.erb
+++ b/app/views/thredded/messageboards/_grid_sizers.html.erb
@@ -1,0 +1,2 @@
+<%# Ensures that cells in incomplete rows are sized correctly (up to 5 missing cells). %>
+<i class="thredded--grid-sizer"></i><i class="thredded--grid-sizer"></i><i class="thredded--grid-sizer"></i>

--- a/app/views/thredded/messageboards/index.html.erb
+++ b/app/views/thredded/messageboards/index.html.erb
@@ -15,6 +15,7 @@
               <%= render partial: 'thredded/messageboards/messageboard',
                          collection: group.messageboards %>
             <% end %>
+            <%= render partial: 'thredded/messageboards/grid_sizers' %>
           </div>
         <% end %>
       <% end %>

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -3,7 +3,7 @@
 class User < ActiveRecord::Base
   validates :name, presence: true
 
-  # Finds the post by its ID, or raises {Errors::UserNotFound}.
+  # Finds the user by their ID or raises {Errors::UserNotFound}.
   # @param id [String, Number]
   # @return [User]
   # @raise [Errors::UserNotFound] if the user with the given ID does not exist.


### PR DESCRIPTION
A few forums that use Thredded are configured with a very large width limit for the messageboards page.

Our current styles only size up to 2 missing cells in incomplete rows correctly (using `before` and `after` pseudo-elements). This adds support for up to 5 missing cells in incomplete rows.

Some examples of the problem in the wild:
* https://alonetone.com/discuss - "Making Music"
* https://www.notebook.ai/forum - "Technology"
