### PR TITLE
Topics and post counts: account for visibility

### DIFF
--- a/app/models/concerns/thredded/topic_common.rb
+++ b/app/models/concerns/thredded/topic_common.rb
@@ -69,17 +69,12 @@ module Thredded
         Thredded::TopicCommon::CachingHash.from_relation(read_states)
       end
 
-      public
-
-      # @param user [Thredded.user_class]
-      # @return [Array<[TopicCommon, UserTopicReadStateCommon]>]
-      def with_read_states(user)
-        null_read_state = Thredded::NullUserTopicReadState.new
-        return current_scope.zip([null_read_state]) if user.thredded_anonymous?
-        read_states_by_postable = read_states_by_postable_hash(user)
-        current_scope.map do |postable|
-          [postable, read_states_by_postable[postable] || null_read_state]
-        end
+      # @param [Thredded.user_class] user
+      # @param [Array<Number>] topic_ids
+      # @return [Hash{topic ID => posts count}] Counts of posts visible to the given user in the given topics.
+      def post_counts_for_user_and_topics(user, topic_ids)
+        return {} if topic_ids.empty?
+        Pundit.policy_scope!(user, post_class.all).where(postable_id: topic_ids).group(:postable_id).count
       end
     end
 

--- a/app/models/concerns/thredded/user_topic_read_state_common.rb
+++ b/app/models/concerns/thredded/user_topic_read_state_common.rb
@@ -21,6 +21,11 @@ module Thredded
       post.created_at <= read_at
     end
 
+    # @return [Number]
+    def posts_count
+      read_posts_count + unread_posts_count
+    end
+
     def calculate_post_counts
       unread_posts_count, read_posts_count =
         self.class.visible_posts_scope(user)

--- a/app/models/thredded/null_user_topic_read_state.rb
+++ b/app/models/thredded/null_user_topic_read_state.rb
@@ -2,6 +2,12 @@
 
 module Thredded
   class NullUserTopicReadState
+    attr_reader :posts_count
+
+    def initialize(posts_count:)
+      @posts_count = posts_count
+    end
+
     def page
       1
     end

--- a/app/models/thredded/private_topic.rb
+++ b/app/models/thredded/private_topic.rb
@@ -109,6 +109,24 @@ module Thredded
       def post_class
         Thredded::PrivatePost
       end
+
+      # @param [Thredded.user_class] user
+      # @return [Array<[PrivateTopic, PrivateUserTopicReadState]>]
+      def with_read_states(user)
+        if user.thredded_anonymous?
+          current_scope.map do |topic|
+            [topic, Thredded::NullUserTopicReadState.new(posts_count: topic.posts_count)]
+          end
+        else
+          read_states_by_postable = read_states_by_postable_hash(user)
+          current_scope.map do |topic|
+            [
+              topic,
+              read_states_by_postable[topic] || Thredded::NullUserTopicReadState.new(posts_count: topic.posts_count)
+            ]
+          end
+        end
+      end
     end
   end
 end

--- a/app/view_models/thredded/base_topic_view.rb
+++ b/app/view_models/thredded/base_topic_view.rb
@@ -4,7 +4,6 @@ module Thredded
   # A view model for TopicCommon.
   class BaseTopicView
     delegate :title,
-             :posts_count,
              :last_post_at,
              :created_at,
              :user,
@@ -12,16 +11,16 @@ module Thredded
              :to_model,
              to: :@topic
 
-    delegate :read?, :post_read?,
+    delegate :read?, :post_read?, :posts_count,
              to: :@read_state
 
-    # @param topic [TopicCommon]
-    # @param read_state [UserTopicReadStateCommon, nil]
-    # @param policy [#destroy?]
+    # @param [TopicCommon] topic
+    # @param [UserTopicReadStateCommon, NullUserTopicReadState, nil] read_state
+    # @param [#destroy?] policy
     def initialize(topic, read_state, policy)
-      @read_state = read_state || Thredded::NullUserTopicReadState.new
-      @topic      = topic
-      @policy     = policy
+      @topic = topic
+      @read_state = read_state || Thredded::NullUserTopicReadState.new(posts_count: @topic.posts_count)
+      @policy = policy
     end
 
     def states

--- a/app/view_models/thredded/messageboard_group_view.rb
+++ b/app/view_models/thredded/messageboard_group_view.rb
@@ -10,22 +10,29 @@ module Thredded
     # @param [Thredded.user_class] user The user viewing the messageboards.
     # @param [Boolean] with_unread_topics_counts
     # @return [Array<MessageboardGroupView>]
-    def self.grouped(messageboards_scope, user: nil, with_unread_topics_counts: user && !user.thredded_anonymous?)
+    def self.grouped( # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity
+      messageboards_scope, user: Thredded::NullUser.new, with_unread_topics_counts: !user.thredded_anonymous?
+    )
       scope = messageboards_scope.preload(last_topic: [:last_user])
         .eager_load(:group)
         .order(Arel.sql('COALESCE(thredded_messageboard_groups.position, 0) ASC, thredded_messageboard_groups.id ASC'))
         .ordered
+      topics_scope = Thredded::TopicPolicy::Scope.new(user, Thredded::Topic.all).resolve
       if with_unread_topics_counts
-        topics_scope = Pundit.policy_scope!(user, Thredded::Topic)
         unread_topics_counts = messageboards_scope.unread_topics_counts(user: user, topics_scope: topics_scope)
         unread_followed_topics_counts = messageboards_scope.unread_topics_counts(
           user: user, topics_scope: topics_scope.followed_by(user)
         )
       end
+      topic_counts = topics_scope.group(:messageboard_id).count
+      posts_scope = Thredded::PostPolicy::Scope.new(user, Thredded::Post.all).resolve
+      post_counts = posts_scope.group(:messageboard_id).count
       scope.group_by(&:group).map do |(group, messageboards)|
         MessageboardGroupView.new(group, messageboards.map do |messageboard|
           MessageboardView.new(
             messageboard,
+            topics_count: topic_counts[messageboard.id] || 0,
+            posts_count: post_counts[messageboard.id] || 0,
             unread_topics_count: with_unread_topics_counts && unread_topics_counts[messageboard.id] || 0,
             unread_followed_topics_count:
               with_unread_topics_counts && unread_followed_topics_counts[messageboard.id] || 0

--- a/app/view_models/thredded/messageboard_view.rb
+++ b/app/view_models/thredded/messageboard_view.rb
@@ -6,11 +6,15 @@ module Thredded
     delegate :name,
              :description,
              :locked?,
-             :topics_count,
-             :posts_count,
              :last_topic,
              :last_user,
              to: :@messageboard
+
+    # @return [Integer]
+    attr_reader :topics_count
+
+    # @return [Integer]
+    attr_reader :posts_count
 
     # @return [Integer]
     attr_reader :unread_topics_count
@@ -19,10 +23,20 @@ module Thredded
     attr_reader :unread_followed_topics_count
 
     # @param [Thredded::Messageboard] messageboard
+    # @param [Integer] topics_count
+    # @param [Integer] posts_count
     # @param [Integer] unread_topics_count
     # @param [Integer] unread_followed_topics_count
-    def initialize(messageboard, unread_topics_count: 0, unread_followed_topics_count: 0)
+    def initialize(
+      messageboard,
+      topics_count: messageboard.topics_count,
+      posts_count: messageboard.posts_count,
+      unread_topics_count: 0,
+      unread_followed_topics_count: 0
+    )
       @messageboard = messageboard
+      @topics_count = topics_count
+      @posts_count = posts_count
       @unread_topics_count = unread_topics_count
       @unread_followed_topics_count = unread_followed_topics_count
     end

--- a/app/view_models/thredded/topic_view.rb
+++ b/app/view_models/thredded/topic_view.rb
@@ -7,9 +7,9 @@ module Thredded
              :last_post, :messageboard_id, :messageboard_name,
              to: :@topic
 
-    # @param topic [TopicCommon]
-    # @param read_state [UserTopicReadStateCommon, nil]
-    # @param policy [#destroy?]
+    # @param [Topic] topic
+    # @param [UserTopicReadState, NullUserTopicReadState, nil] read_state
+    # @param [#destroy?] policy
     def initialize(topic, read_state, follow, policy)
       super(topic, read_state, policy)
       @follow = follow

--- a/spec/models/thredded/topic_spec.rb
+++ b/spec/models/thredded/topic_spec.rb
@@ -83,34 +83,6 @@ module Thredded
     end
   end
 
-  describe Topic, '.with_read_states' do
-    let(:user) { create(:user) }
-    let!(:topic) { create(:topic, with_posts: 2) }
-
-    context 'when unread' do
-      it 'returns nulls ' do
-        first = Topic.all.with_read_states(user).first
-        expect(first[0]).to eq(topic)
-        expect(first[1]).to be_an_instance_of(Thredded::NullUserTopicReadState)
-      end
-    end
-
-    context 'when read' do
-      let!(:read_state) do
-        create(
-          :user_topic_read_state, user: user, postable: topic,
-                                  read_at: topic.posts.order_oldest_first.first.created_at
-        )
-      end
-
-      it 'returns read states' do
-        first = Topic.all.with_read_states(user).first
-        expect(first[0]).to eq(topic)
-        expect(first[1]).to eq(read_state)
-      end
-    end
-  end
-
   describe Topic, '.with_read_and_follow_states' do
     let(:user) { create(:user) }
     let!(:topic) { create(:topic, with_posts: 2) }

--- a/spec/models/thredded/user_topic_read_state_spec.rb
+++ b/spec/models/thredded/user_topic_read_state_spec.rb
@@ -83,7 +83,7 @@ module Thredded
   describe NullUserTopicReadState, '#post_read?(post)' do
     it 'is false' do
       post = create(:post)
-      null_user_topic_read_state = NullUserTopicReadState.new
+      null_user_topic_read_state = NullUserTopicReadState.new(posts_count: 1)
       expect(null_user_topic_read_state).not_to be_post_read(post)
     end
   end


### PR DESCRIPTION
Instead of using the cached counter columns, we query for the counts on every page load. Seems fast enough, but can revert and think of another solution if this causes performance issues.

Fixes #756