### PR TITLE
topics.es6: Update unread+followed count immediately

### DIFF
--- a/app/assets/javascripts/thredded/components/topics.es6
+++ b/app/assets/javascripts/thredded/components/topics.es6
@@ -20,22 +20,43 @@
     return Math.ceil(numPosts / postsPerPage);
   }
 
-  function getTopicNode(node) {
+  function getAncestorTag(node, ancestorTagName) {
     do {
       node = node.parentNode;
-    } while (node && node.tagName !== 'ARTICLE');
+    } while (node && node.tagName !== ancestorTagName);
     return node;
+  }
+
+  function getTopicNode(node) {
+    return getAncestorTag(node, 'ARTICLE');
+  }
+
+  function getUnreadNavItem(unreadFollowedCountElement) {
+    return getAncestorTag(unreadFollowedCountElement, 'LI');
   }
 
   function initTopicsList(topicsList) {
     const postsPerPage = +topicsList.getAttribute('data-thredded-topic-posts-per-page') || 25;
+    const isPrivateTopics = topicsList.getAttribute('data-thredded-topics') === 'private';
+    const unreadFollowedCountElement = document.querySelector('[data-unread-followed-count]');
     topicsList.addEventListener('click', (evt) => {
       const link = evt.target;
       if (link.tagName !== 'A' || link.parentNode.tagName !== 'H1') return;
       const topic = getTopicNode(link);
       if (pageNumber(link.href) === totalPages(+topic.querySelector(POSTS_COUNT_SELECTOR).textContent, postsPerPage)) {
+        if (!isPrivateTopics && unreadFollowedCountElement &&
+          topic.hasAttribute('data-followed') && topic.hasAttribute('data-unread')) {
+          const count = (+unreadFollowedCountElement.textContent) - 1;
+          if (count === 0) {
+            const navItem = getUnreadNavItem(unreadFollowedCountElement);
+            navItem.parentElement.removeChild(navItem);
+          } else {
+            unreadFollowedCountElement.textContent = count.toLocaleString();
+          }
+        }
         topic.classList.add(TOPIC_READ_CLASS);
         topic.classList.remove(TOPIC_UNREAD_CLASS);
+        topic.removeAttribute('data-unread');
       }
     });
   }

--- a/app/view_models/thredded/topic_view.rb
+++ b/app/view_models/thredded/topic_view.rb
@@ -34,7 +34,7 @@ module Thredded
 
     # @return [Boolean] whether the topic is followed by the current user.
     def followed?
-      @follow
+      !!@follow # rubocop:disable Style/DoubleNegation
     end
 
     def follow_reason

--- a/app/views/thredded/private_topics/index.html.erb
+++ b/app/views/thredded/private_topics/index.html.erb
@@ -5,7 +5,7 @@
 <%= thredded_page do %>
   <%= content_tag :section,
                   class: 'thredded--main-section thredded--private-topics',
-                  'data-thredded-topics' => true,
+                  'data-thredded-topics' => 'private',
                   'data-thredded-topic-posts-per-page' => Thredded.posts_per_page do %>
 
     <% if @private_topics.empty? -%>

--- a/app/views/thredded/shared/nav/_unread_topics.html.erb
+++ b/app/views/thredded/shared/nav/_unread_topics.html.erb
@@ -6,7 +6,7 @@
       <% if unread_followed_topics_count > 0 -%>
         <%= define_svg_icons 'thredded/follow.svg' %>
         <span class="thredded--user-navigation--unread-topics--followed-count"><%=shared_inline_svg "thredded/follow.svg", class: "thredded--unread-topics--followed-icon", role:"img" %>
-            <%= unread_followed_topics_count %></span>
+          <span data-unread-followed-count><%= unread_followed_topics_count %></span></span>
       <% end -%>
     <% end %>
   </li>

--- a/app/views/thredded/topics/_topic.html.erb
+++ b/app/views/thredded/topics/_topic.html.erb
@@ -1,7 +1,12 @@
 <%= content_tag :article,
                 id:    dom_id(topic),
                 class: ['thredded--topics--topic', topic_css_classes(topic)],
-                data: {topic: topic.id, messageboard: topic.messageboard_id} do %>
+                data: {
+                    topic: topic.id,
+                    messageboard: topic.messageboard_id,
+                    unread: !topic.read? || nil,
+                    followed: topic.followed? || nil
+                } do %>
   <div class="thredded--topics--posts-count"><%= topic.posts_count %></div>
 
   <div class="thredded--topics--follow-info" title="<%= topic_follow_reason_text topic.follow_reason %>">


### PR DESCRIPTION
When clicking through to the last page of an unread+followed topic, update the count immediately, so that the correct count is displayed when going back to a cached page (Turbolinks).