### PR TITLE
json actions for mark_as_read and mark_as_unread for post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # (unreleased)
 
+## Added
+
+* There are new actions (starting ./action ) for extending Thredded with ajax such as POST .../action/posts/ID/mark_as_read.json. 
+
 ## Changed
 
 Due to a new /action route, if you have a Messageboard called "Action" you may need to change its slug:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Due to a new /action route, if you have a Messageboard called "Action" you may n
   `Thredded.posts_per_page`. The unread+followed counter now also gets updated.
   [#755](https://github.com/thredded/thredded/issues/755)
   [#759](https://github.com/thredded/thredded/pull/759)
-* No longer breaks if `main_app` ovverides `Kaminar.config.page_method_name`.
+* No longer breaks if `main_app` ovverides `Kaminari.config.page_method_name`.
   [#741](https://github.com/thredded/thredded/issues/741)
 * Messageboard grid now correctly sizes cells in incomplete rows up to 6 cells.
   [#754](https://github.com/thredded/thredded/pull/754)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# (unreleased)
+
+## Changed
+
+Due to a new /action route, if you have a Messageboard called "Action" you may need to change its slug:
+
+```Thredded::Messageboard.where(slug: 'action').each{|m| m.update(slug: 'action-messageboard')}```
+
 # v0.16.1
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -631,6 +631,10 @@ brew cask install chromium
 brew install chromedriver
 ```
 
+To get better page saves (`page.save_and_open_page`) from local capybara specs ensure you are running the server locally 
+and set `export CAPYBARA_ASSET_HOST=http://localhost:3000` (or whatever host/port your server is on) before running your 
+test suite.  
+
 ### Ruby
 
 Thredded Ruby code formatting is ensured by [Rubocop](https://github.com/bbatsov/rubocop). Run `rubocop -a` to ensure a

--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -7,6 +7,7 @@ module Thredded
     include Thredded::NewPostParams
 
     helper_method :topic
+    before_action :assign_messageboard_for_actions, only: %i[mark_as_read mark_as_unread]
     after_action :update_user_activity
 
     after_action :verify_authorized
@@ -94,6 +95,10 @@ module Thredded
       Thredded::Topic
         .where(messageboard: messageboard)
         .friendly_find!(params[:topic_id])
+    end
+
+    def assign_messageboard_for_actions
+      @messageboard = post.postable.messageboard
     end
 
     def post

--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -58,7 +58,7 @@ module Thredded
       authorize post, :read?
       UserTopicReadState.touch!(thredded_current_user.id, post)
       respond_to do |format|
-        format.html { redirect_to request.referer || post_path(post, user: thredded_current_user) }
+        format.html { redirect_back fallback_location: post_path(post, user: thredded_current_user) }
         format.json { render(json: { read: true }) }
       end
     end

--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -53,10 +53,22 @@ module Thredded
                     notice: I18n.t('thredded.posts.deleted_notice')
     end
 
+    def mark_as_read
+      authorize post, :read?
+      UserTopicReadState.touch!(thredded_current_user.id, post)
+      respond_to do |format|
+        format.html { redirect_to request.referer || post_path(post, user: thredded_current_user) }
+        format.json { render(json: { read: true }) }
+      end
+    end
+
     def mark_as_unread
       authorize post, :read?
       post.mark_as_unread(thredded_current_user)
-      after_mark_as_unread # customization hook
+      respond_to do |format|
+        format.html { after_mark_as_unread } # customization hook
+        format.json { render(json: { read: false }) }
+      end
     end
 
     def quote

--- a/app/controllers/thredded/private_posts_controller.rb
+++ b/app/controllers/thredded/private_posts_controller.rb
@@ -51,10 +51,22 @@ module Thredded
                     notice: I18n.t('thredded.posts.deleted_notice')
     end
 
+    def mark_as_read
+      authorize post, :read?
+      UserPrivateTopicReadState.touch!(thredded_current_user.id, post)
+      respond_to do |format|
+        format.html { redirect_to request.referer || post_path(post, user: thredded_current_user) }
+        format.json { render(json: { read: true }) }
+      end
+    end
+
     def mark_as_unread
       authorize post, :read?
       post.mark_as_unread(thredded_current_user)
-      after_mark_as_unread # customization hook
+      respond_to do |format|
+        format.html { after_mark_as_unread } # customization hook
+        format.json { render(json: { read: false }) }
+      end
     end
 
     def quote

--- a/app/controllers/thredded/private_posts_controller.rb
+++ b/app/controllers/thredded/private_posts_controller.rb
@@ -7,7 +7,6 @@ module Thredded
     include NewPrivatePostParams
 
     helper_method :topic
-    after_action :update_user_activity
 
     after_action :verify_authorized
 

--- a/app/controllers/thredded/private_posts_controller.rb
+++ b/app/controllers/thredded/private_posts_controller.rb
@@ -55,7 +55,7 @@ module Thredded
       authorize post, :read?
       UserPrivateTopicReadState.touch!(thredded_current_user.id, post)
       respond_to do |format|
-        format.html { redirect_to request.referer || post_path(post, user: thredded_current_user) }
+        format.html { redirect_back fallback_location: post_path(post, user: thredded_current_user) }
         format.json { render(json: { read: true }) }
       end
     end

--- a/app/helpers/thredded/urls_helper.rb
+++ b/app/helpers/thredded/urls_helper.rb
@@ -128,7 +128,7 @@ module Thredded
       if post.private_topic_post?
         mark_as_unread_private_topic_private_post_path(post.postable, post)
       else
-        mark_as_unread_messageboard_topic_post_path(post.messageboard, post.postable, post)
+        mark_as_unread_post_path(post)
       end
     end
 

--- a/app/helpers/thredded/urls_helper.rb
+++ b/app/helpers/thredded/urls_helper.rb
@@ -126,7 +126,7 @@ module Thredded
 
     def mark_unread_path(post, _params = {})
       if post.private_topic_post?
-        mark_as_unread_private_topic_private_post_path(post.postable, post)
+        mark_as_unread_private_post_path(post)
       else
         mark_as_unread_post_path(post)
       end

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -8,6 +8,7 @@ module Thredded
                 # Avoid route conflicts
                 reserved_words: ::Thredded::FriendlyIdReservedWordsAndPagination.new(
                   %w[
+                    action
                     admin
                     autocomplete-users
                     messageboards

--- a/app/views/thredded/error_pages/forbidden.json.erb
+++ b/app/views/thredded/error_pages/forbidden.json.erb
@@ -1,0 +1,5 @@
+{
+  "error": {
+    "message": "Forbidden"
+  }
+}

--- a/app/views/thredded/error_pages/not_found.json.erb
+++ b/app/views/thredded/error_pages/not_found.json.erb
@@ -1,0 +1,5 @@
+{
+  "error": {
+    "message": "Not Found"
+  }
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,6 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
         resource :preview, only: [:update], controller: 'private_post_previews'
         member do
           get 'quote'
-          post 'mark_as_unread'
         end
       end
     end
@@ -92,6 +91,13 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
   scope path: 'action' do
     # flat urls under here for anything which is non-visible to users & search engines (typically json actions)
     resources :posts, only: %i[] do
+      member do
+        post 'mark_as_read'
+        post 'mark_as_unread'
+      end
+    end
+
+    resources :private_posts, only: %i[] do
       member do
         post 'mark_as_read'
         post 'mark_as_unread'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,11 +89,13 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  # flat urls for anything which is non-visible to users & search engines
-  resources :posts, only: %i[] do
-    member do
-      post 'mark_as_read'
-      post 'mark_as_unread'
+  scope path: 'action' do
+    # flat urls under here for anything which is non-visible to users & search engines (typically json actions)
+    resources :posts, only: %i[] do
+      member do
+        post 'mark_as_read'
+        post 'mark_as_unread'
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,6 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
         resource :preview, only: [:update], controller: 'post_previews'
         member do
           get 'quote'
-          post 'mark_as_unread' # deprecated
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,9 +84,17 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
         resource :preview, only: [:update], controller: 'post_previews'
         member do
           get 'quote'
-          post 'mark_as_unread'
+          post 'mark_as_unread' # deprecated
         end
       end
+    end
+  end
+
+  # flat urls for anything which is non-visible to users & search engines
+  resources :posts, only: %i[] do
+    member do
+      post 'mark_as_read'
+      post 'mark_as_unread'
     end
   end
 

--- a/spec/controllers/thredded/posts_controller_spec.rb
+++ b/spec/controllers/thredded/posts_controller_spec.rb
@@ -24,6 +24,12 @@ module Thredded
         expect(UserTopicReadState).to receive(:touch!).with(user.id, the_post)
         do_post_request
       end
+
+      it 'sets the messageboard correctly' do
+        do_post_request
+        expect(assigns(:messageboard)).to eq(messageboard)
+      end
+
       context 'json format' do
         subject(:do_post_request) do
           post :mark_as_read, params: { id: the_post.id, format: :json }
@@ -45,6 +51,11 @@ module Thredded
       it 'marks as unread' do
         UserTopicReadState.touch!(user.id, the_post)
         expect { do_post_request }.to change(UserTopicReadState, :count).by(-1)
+      end
+
+      it 'sets the messageboard correctly' do
+        do_post_request
+        expect(assigns(:messageboard)).to eq(messageboard)
       end
 
       context 'json format' do

--- a/spec/controllers/thredded/posts_controller_spec.rb
+++ b/spec/controllers/thredded/posts_controller_spec.rb
@@ -26,7 +26,7 @@ module Thredded
       end
       context 'json format' do
         subject(:do_post_request) do
-          post :mark_as_read, params: { messageboard_id: messageboard.id, id: topic.id, format: :json }
+          post :mark_as_read, params: { id: the_post.id, format: :json }
         end
 
         it 'returns changed status' do

--- a/spec/controllers/thredded/posts_controller_spec.rb
+++ b/spec/controllers/thredded/posts_controller_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Thredded
+  describe PostsController do
+    routes { Thredded::Engine.routes }
+
+    let(:user) { create(:user) }
+    let(:messageboard) { create(:messageboard) }
+    let(:topic) { create(:topic, messageboard: messageboard, title: 'hi') }
+    let(:the_post) { create(:post, postable: topic, content: 'hi') }
+
+    before do
+      allow(controller).to receive_messages(
+        the_current_user: user,
+      )
+    end
+
+    describe 'POST mark_as_read' do
+      subject(:do_post_request) { post :mark_as_read, params: { id: the_post.id } }
+
+      it 'marks as read' do
+        expect(UserTopicReadState).to receive(:touch!).with(user.id, the_post)
+        do_post_request
+      end
+      context 'json format' do
+        subject(:do_post_request) do
+          post :mark_as_read, params: { messageboard_id: messageboard.id, id: topic.id, format: :json }
+        end
+
+        it 'returns changed status' do
+          expect(UserTopicReadState).to receive(:touch!).with(user.id, the_post)
+          do_post_request
+          expect(JSON.parse(response.body)).to include('read' => true)
+        end
+      end
+    end
+
+    describe 'POST mark_as_unread' do
+      subject(:do_post_request) do
+        post :mark_as_unread, params: { id: the_post.id }
+      end
+
+      it 'marks as unread' do
+        UserTopicReadState.touch!(user.id, the_post)
+        expect { do_post_request }.to change(UserTopicReadState, :count).by(-1)
+      end
+
+      context 'json format' do
+        subject(:do_post_request) do
+          post :mark_as_unread, params: { id: the_post.id, format: :json }
+        end
+
+        it 'returns changed status' do
+          do_post_request
+          expect(JSON.parse(response.body)).to include('read' => false)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/thredded/private_posts_controller_spec.rb
+++ b/spec/controllers/thredded/private_posts_controller_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Thredded
+  describe PrivatePostsController do
+    routes { Thredded::Engine.routes }
+
+    let(:user) { create(:user) }
+    let(:private_topic) { create(:private_topic, users: [user, other_user]) }
+    let(:private_post) { create(:private_post, postable: private_topic) }
+    let(:other_user) { create(:user) }
+
+    before do
+      allow(controller).to receive_messages(the_current_user: user)
+    end
+
+    describe 'POST mark_as_read' do
+      subject(:do_post_request) { post :mark_as_read, params: { id: private_post.id } }
+
+      it 'marks as read' do
+        expect(UserPrivateTopicReadState).to receive(:touch!).with(user.id, private_post)
+        do_post_request
+      end
+
+      context 'json format' do
+        subject(:do_post_request) do
+          post :mark_as_read, params: { id: private_post.id, format: :json }
+        end
+
+        it 'returns changed status' do
+          expect(UserPrivateTopicReadState).to receive(:touch!).with(user.id, private_post)
+          do_post_request
+          expect(JSON.parse(response.body)).to include('read' => true)
+        end
+      end
+    end
+
+    describe 'POST mark_as_unread' do
+      subject(:do_post_request) do
+        post :mark_as_unread, params: { id: private_post.id }
+      end
+
+      it 'marks as unread' do
+        UserPrivateTopicReadState.touch!(user.id, private_post)
+        expect { do_post_request }.to change(UserPrivateTopicReadState, :count).by(-1)
+      end
+
+      context 'json format' do
+        subject(:do_post_request) do
+          post :mark_as_unread, params: { id: private_post.id, format: :json }
+        end
+
+        it 'returns changed status' do
+          do_post_request
+          expect(JSON.parse(response.body)).to include('read' => false)
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/thredded/urls_helper_spec.rb
+++ b/spec/helpers/thredded/urls_helper_spec.rb
@@ -4,14 +4,14 @@ require 'spec_helper'
 
 module Thredded
   describe UrlsHelper do
-
-    describe ".mark_unread_path" do
+    describe '.mark_unread_path' do
       let(:user) { create(:user) }
       let(:private_topic) { create(:private_topic, users: [user, other_user]) }
       let(:private_post) { create(:private_post, postable: private_topic) }
       let(:other_user) { create(:user) }
-      it "works with private posts" do
-        expect(UrlsHelper.mark_unread_path(private_post)).to start_with("/thredded/action")
+
+      it 'works with private posts' do
+        expect(UrlsHelper.mark_unread_path(private_post)).to start_with('/thredded/action')
       end
     end
   end

--- a/spec/helpers/thredded/urls_helper_spec.rb
+++ b/spec/helpers/thredded/urls_helper_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Thredded
+  describe UrlsHelper do
+
+    describe ".mark_unread_path" do
+      let(:user) { create(:user) }
+      let(:private_topic) { create(:private_topic, users: [user, other_user]) }
+      let(:private_post) { create(:private_post, postable: private_topic) }
+      let(:other_user) { create(:user) }
+      it "works with private posts" do
+        expect(UrlsHelper.mark_unread_path(private_post)).to start_with("/thredded/action")
+      end
+    end
+  end
+end

--- a/spec/models/thredded/messageboard_spec.rb
+++ b/spec/models/thredded/messageboard_spec.rb
@@ -15,7 +15,7 @@ module Thredded
     end
 
     it 'has prevents some slugs which would be collisions with routes' do
-      ['admin', 'action'].each do |collision|
+      %w[admin action].each do |collision|
         messageboard = build(:messageboard, name: collision)
         expect(messageboard).to be_valid
         expect(messageboard.slug).not_to be_blank

--- a/spec/models/thredded/messageboard_spec.rb
+++ b/spec/models/thredded/messageboard_spec.rb
@@ -14,6 +14,15 @@ module Thredded
       expect(messageboard.slug).to eq 'super-friends'
     end
 
+    it 'has prevents some slugs which would be collisions with routes' do
+      ['admin', 'action'].each do |collision|
+        messageboard = build(:messageboard, name: collision)
+        expect(messageboard).to be_valid
+        expect(messageboard.slug).not_to be_blank
+        expect(messageboard.slug).not_to eq collision
+      end
+    end
+
     describe '#recently_active_users' do
       it 'returns users active for a messageboard' do
         messageboard   = create(:messageboard)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -171,3 +171,5 @@ Capybara.configure do |config|
   # bump from the default of 2 seconds because travis can be slow
   config.default_max_wait_time = 5
 end
+
+Capybara.asset_host = ENV['CAPYBARA_ASSET_HOST'] if ENV['CAPYBARA_ASSET_HOST']


### PR DESCRIPTION
There are some "api" endpoints (for ajax calls from mainapp or extensions) that I need and think maybe other people might need, so I'm could pull these into Thredded core.

However this may be unneeded.

However I also think (as I've illustrated in this PR) that we ought to not use the hierarchical routes unless they are being shown to the user / search engines (ie. GET routes to display things). This would make the routes file a bit easier to navigate and make the url-generation functions and paths more straightforward

ie.
```
mark_as_unread_post_path(post)
#  /posts/:id/mark_as_unread(.:format)
```

rather than
```
mark_as_unread_messageboard_topic_post_path(post.messageboard, post.postable, post)
# /:messageboard_id/:topic_id/:id/mark_as_unread(.:format)  
```

Unless there are objections, we can start moving the paths across (and changing the helpers to point to the new paths), keeping the old more complex paths till the next minor bump when we can drop them. 