### PR TITLE
Update MacOS installation instructions for chromedriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ On Mac, run:
 
 ```bash
 brew cask install chromium
-brew install chromedriver
+brew cask install chromedriver
 ```
 
 To get better page saves (`page.save_and_open_page`) from local capybara specs ensure you are running the server locally 


### PR DESCRIPTION
```
Error: No available formula with the name "chromedriver"
It was migrated from homebrew/core to homebrew/cask.
You can access it again by running:
  brew tap homebrew/cask
And then you can install it by running:
  brew cask install chromedriver
```