### PR TITLE
Fix content caching on Rails 5.2

### DIFF
--- a/app/view_models/thredded/post_view.rb
+++ b/app/view_models/thredded/post_view.rb
@@ -12,6 +12,8 @@ module Thredded
              :approved?,
              :blocked?,
              :last_moderation_record,
+             :cache_key,
+             :cache_key_with_version,
              to: :@post
 
     # @param post [Thredded::PostCommon]
@@ -69,11 +71,6 @@ module Thredded
 
     def permalink_path
       Thredded::UrlsHelper.permalink_path(@post)
-    end
-
-    # This cache key is used only for caching the content.
-    def cache_key
-      @post.cache_key
     end
 
     POST_IS_READ = :read


### PR DESCRIPTION
Thanks to @jflat06 for debugging this issue.
Fixes #712

Explanation from @jflat06:

The PostView object was acting as a proxy for Post caching. It included a function to forward
cache_key to the cache_key of Post.

However, in rails 5.2+, the defaults for how cache version have been updated, and now use a
different function, cache_key_with_version. This function doesn't exist in PostView, so the
new-style caching is getting confused and serving stale data. This commit adds forwarding for
cache_key_with_version from PostView->Post.