### PR TITLE
Cache @-mentioned users when rendering posts

### DIFF
--- a/app/commands/thredded/at_notification_extractor.rb
+++ b/app/commands/thredded/at_notification_extractor.rb
@@ -16,7 +16,8 @@ module Thredded
       Thredded::HtmlPipeline::AtMentionFilter.new(
         html,
         view_context: view_context,
-        users_provider: ->(user_names) { @post.readers_from_user_names(user_names).to_a }
+        users_provider: ::Thredded::UsersProvider,
+        users_provider_scope: @post.readers
       ).mentioned_users
     end
   end

--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -85,7 +85,8 @@ module Thredded
     # @param content_partial [String]
     def render_posts(posts, partial: 'thredded/posts/post', content_partial: 'thredded/posts/content', locals: {})
       posts_with_contents = render_collection_to_strings_with_cache(
-        partial: content_partial, collection: posts, as: :post, expires_in: 1.week
+        partial: content_partial, collection: posts, as: :post, expires_in: 1.week,
+        locals: { options: { users_provider: ::Thredded::UsersProviderWithCache.new } }
       )
       render partial: partial, collection: posts_with_contents, as: :post_and_content, locals: locals
     end

--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -33,20 +33,14 @@ module Thredded
 
     # @param view_context [Object] the context of the rendering view.
     # @return [String] formatted and sanitized html-safe post content.
-    def filtered_content(view_context, users_provider: ->(names) { readers_from_user_names(names) }, **options)
-      Thredded::ContentFormatter.new(view_context, users_provider: users_provider, **options).format_content(content)
+    def filtered_content(view_context, users_provider: ::Thredded::UsersProvider, **options)
+      Thredded::ContentFormatter.new(
+        view_context, users_provider: users_provider, users_provider_scope: readers, **options
+      ).format_content(content)
     end
 
     def first_post_in_topic?
       postable.first_post == self
-    end
-
-    # @return [ActiveRecord::Relation<Thredded.user_class>] users from the list of user names that can read this post.
-    # @api private
-    def readers_from_user_names(user_names)
-      DbTextSearch::CaseInsensitive
-        .new(readers, Thredded.user_name_column)
-        .in(user_names)
     end
 
     # Marks all the posts from the given one as unread for the given user

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -23,6 +23,7 @@ require 'thredded/html_pipeline/kramdown_filter'
 require 'thredded/html_pipeline/onebox_filter'
 require 'thredded/html_pipeline/wrap_iframes_filter'
 require 'thredded/html_pipeline/spoiler_tag_filter'
+require 'thredded/users_provider'
 
 # Asset compilation
 require 'autoprefixer-rails'

--- a/lib/thredded/html_pipeline/at_mention_filter.rb
+++ b/lib/thredded/html_pipeline/at_mention_filter.rb
@@ -10,6 +10,7 @@ module Thredded
       def initialize(doc, context = nil, result = nil)
         super doc, context, result
         @users_provider = context[:users_provider]
+        @users_provider_scope = context[:users_provider_scope]
         @view_context = context[:view_context]
       end
 
@@ -30,7 +31,7 @@ module Thredded
         names = []
         process_text_nodes! { |node| names.concat mentioned_names(node.to_html) }
         names.uniq!
-        @users_provider.call(names)
+        @users_provider.call(names, @users_provider_scope)
       end
 
       private
@@ -43,8 +44,8 @@ module Thredded
 
       def highlight!(text_node_html)
         names = mentioned_names(text_node_html)
-        return if names.blank?
-        @users_provider.call(names).each do |user|
+        return if names.blank? || @users_provider.nil?
+        @users_provider.call(names, @users_provider_scope).each do |user|
           name = user.thredded_display_name
           maybe_quoted_name = name =~ /[., ()]/ ? %("#{name}") : name
           url = Thredded.user_path(@view_context, user)

--- a/lib/thredded/users_provider.rb
+++ b/lib/thredded/users_provider.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Thredded
+  module UsersProvider
+    module_function
+
+    def call(user_names, scope)
+      DbTextSearch::CaseInsensitive
+        .new(scope, Thredded.user_name_column)
+        .in(user_names)
+    end
+  end
+
+  class UsersProviderWithCache
+    def initialize
+      @mutex = Mutex.new
+      @cache = {}
+    end
+
+    def call(names, scope)
+      # This is not the same as the database lowercasing but it's OK.
+      # The worst that can happen is some cache misses.
+      names_with_lowercase = names.zip(names.map(&:downcase))
+      cached = uncached = nil
+      result = @mutex.synchronize do
+        scope_cache = (@cache[scope.to_sql] ||= {})
+        cached, uncached = names_with_lowercase.partition { |(_, lowercase)| scope_cache.key?(lowercase) }
+        fetched = UsersProvider.call(uncached.map(&:first), scope)
+        fetched.each do |user|
+          scope_cache[user.send(Thredded.user_name_column).downcase] = user
+        end
+        cached.map { |(_, lowercase)| scope_cache[lowercase] }.concat(fetched)
+      end
+      result.uniq!
+      result.compact!
+      Rails.logger.info(
+        "  [Thredded::UsersProviderWithCache] #{names.size} user names => #{result.size} users "\
+          "(#{cached.size} cached, #{uncached.size} uncached)"
+      )
+      result
+    end
+  end
+end

--- a/spec/lib/thredded/content_formatter_spec.rb
+++ b/spec/lib/thredded/content_formatter_spec.rb
@@ -10,7 +10,8 @@ describe Thredded::ContentFormatter do
   def format_post_content(post)
     Thredded::ContentFormatter.new(
       ViewContextStub,
-      users_provider: ->(names) { post.readers_from_user_names(names) }
+      users_provider: ::Thredded::UsersProvider,
+      users_provider_scope: post.readers
     ).format_content(post.content)
   end
 
@@ -61,8 +62,8 @@ describe Thredded::ContentFormatter do
 '<a href="mailto:email@jane.com">email@jane.com</a>, <a href="mailto:email@joe.com">email@joe.com</a>,'\
 ' <code>@joe</code>.</p>'
 
-      expect(post).to receive(:readers_from_user_names)
-        .with(['sam 1', 'joe', 'unknown'])
+      expect(::Thredded::UsersProvider).to receive(:call)
+        .with(['sam 1', 'joe', 'unknown'], kind_of(ActiveRecord::Relation))
         .and_return([sam, joe])
 
       expect(format_post_content(post)).to eq expected_html


### PR DESCRIPTION
I went with caching instead of pre-scanning, because fully correct scanning would require us to run most of the content formatter (all the way up to `AtMentionFilter`), which can be slow.

Fixes #771