### PR TITLE
Switch to cuprite for integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ addons:
   apt:
     packages:
     - chromium-browser
-    # TODO: Use chromedriver from apt once it's been updated to v2.37+.
-    # - chromium-chromedriver
 
 before_install:
   # Rails 4.x requires bundler version < 2.0.
@@ -44,15 +42,11 @@ env:
   global:
   - COVERAGE=1
   - TRAVIS=1
-  - CHROMEDRIVER_PATH=$PWD/chromedriver
 services:
 - postgresql
 - mysql
 
 before_script:
-- >
-  wget -q https://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip &&
-  unzip chromedriver_linux64.zip
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
 - chmod +x ./cc-test-reporter
 - ./cc-test-reporter before-build

--- a/spec/features/thredded/user_replies_to_post_spec.rb
+++ b/spec/features/thredded/user_replies_to_post_spec.rb
@@ -30,8 +30,11 @@ RSpec.feature 'User replying to topic' do
     # Expect current path to not change because the JS magic takes place
     expect(page).to have_current_path(current_path)
     # Wait for the async quote content fetch completion
-    Timeout.timeout(1) do
-      loop { break if posts.post_form.content != '...' }
+    Timeout.timeout(2) do
+      loop do
+        break if posts.post_form.content != '...' && !posts.post_form.content.empty?
+        sleep(0.2)
+      end
     end
     expect(posts.post_form.content).to(start_with('>').and(end_with("\n\n")))
   end

--- a/spec/features/thredded/user_sends_new_private_topic_spec.rb
+++ b/spec/features/thredded/user_sends_new_private_topic_spec.rb
@@ -28,13 +28,13 @@ RSpec.feature 'User sends a new private topic' do
       find(:css, '[name="private_topic[user_names]"]').hover
       find(:css, '[name="private_topic[user_names]"]').click
       find(:css, '[name="private_topic[user_names]"]').send_keys('Bar')
-      expect(page).to have_css('ul.thredded--textcomplete-dropdown li', count: 3)
+      expect(page).to have_css('ul.thredded--textcomplete-dropdown li.textcomplete-item', count: 3)
       find(:css, '[name="private_topic[user_names]"]').send_keys('b')
-      expect(page).to have_css('ul.thredded--textcomplete-dropdown li', count: 3)
+      expect(page).to have_css('ul.thredded--textcomplete-dropdown li.textcomplete-item', count: 3)
       find(:css, '[name="private_topic[user_names]"]').send_keys('ara')
-      expect(page).to have_css('ul.thredded--textcomplete-dropdown li', count: 2)
+      expect(page).to have_css('ul.thredded--textcomplete-dropdown li.textcomplete-item', count: 2)
       find(:css, '[name="private_topic[user_names]"]').send_keys(' Fleis')
-      expect(page).to have_css('ul.thredded--textcomplete-dropdown li', count: 1)
+      expect(page).to have_css('ul.thredded--textcomplete-dropdown li.textcomplete-item', count: 1)
       find(:css, '[name="private_topic[user_names]"]').send_keys("\n")
       expect(find(:css, '[name="private_topic[user_names]"]').value).to eq('Barbara Fleischman, ')
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -146,27 +146,22 @@ RSpec.configure do |config| # rubocop:disable Metrics/BlockLength
   end
 end
 
-require 'selenium-webdriver'
+require 'capybara/cuprite'
 
-Selenium::WebDriver::Chrome.path = ENV['CHROMIUM_BIN'] || %w[
+browser_path = ENV['CHROMIUM_BIN'] || %w[
   /usr/bin/chromium-browser
   /Applications/Chromium.app/Contents/MacOS/Chromium
   /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome
 ].find { |path| File.executable?(path) }
-Selenium::WebDriver::Chrome.driver_path = ENV['CHROMEDRIVER_PATH'] || %w[
-  /usr/bin/chromedriver
-  /usr/lib/chromium-browser/chromedriver
-  /usr/local/bin/chromedriver
-].find { |path| File.executable?(path) }
 
-Capybara.register_driver :headless_chromium do |app|
-  options = ::Selenium::WebDriver::Chrome::Options.new
-  options.add_argument 'headless'
-  options.add_argument 'disable-gpu'
-  options.add_argument 'window-size=1280,1024'
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+Capybara.register_driver :cuprite do |app|
+  options = {
+    window_size: [1280, 1024]
+  }
+  options[:browser_path] = browser_path if browser_path
+  Capybara::Cuprite::Driver.new(app, options)
 end
-Capybara.javascript_driver = ENV['CAPYBARA_JS_DRIVER']&.to_sym || :headless_chromium
+Capybara.javascript_driver = ENV['CAPYBARA_JS_DRIVER']&.to_sym || :cuprite
 Capybara.configure do |config|
   # bump from the default of 2 seconds because travis can be slow
   config.default_max_wait_time = 5

--- a/spec/support/features/page_object/post.rb
+++ b/spec/support/features/page_object/post.rb
@@ -59,6 +59,7 @@ module PageObject
           # the mouse towards an element, then clicking.
           # The click could then be performed on a dropdown action.
           toggle.hover
+          sleep(0.2) # wait a bit for animation
         end
       end
     end

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -51,6 +51,7 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
 
   # test dependencies
   s.add_development_dependency 'capybara', '~> 2.4'
+  s.add_development_dependency 'cuprite', '>= 0.5'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_bot_rails', '>= 5.0.1'
   s.add_development_dependency 'faker', '>= 1.9.3'
@@ -58,7 +59,6 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
   s.add_development_dependency 'rspec-rails', '>= 3.5.0'
   s.add_development_dependency 'rubocop', '= 0.58.2'
   s.add_development_dependency 'rubocop-rspec', '= 1.28.0'
-  s.add_development_dependency 'selenium-webdriver', '>= 3.5.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'webmock'
 


### PR DESCRIPTION
Cuprite is faster and doesn't require chromedriver and selenium (it talks to chrome directly).

As of v0.5, it's no longer flaky on our test suite.

Closes #785 