### PR TITLE
Feature: Reporting posts to moderation for review

### DIFF
--- a/app/controllers/thredded/posts_controller.rb
+++ b/app/controllers/thredded/posts_controller.rb
@@ -81,10 +81,10 @@ module Thredded
       authorize_reading post
       post.update(moderation_state: 'pending_moderation')
       respond_to do |format|
-        format.html {
+        format.html do
           redirect_back fallback_location: post_path(post, user: thredded_current_user),
                         notice: I18n.t('thredded.posts.reported_post')
-        }
+        end
         format.json { render(json: { reported: true }) }
       end
     end

--- a/app/policies/thredded/post_policy.rb
+++ b/app/policies/thredded/post_policy.rb
@@ -47,7 +47,7 @@ module Thredded
 
     def report?
       # Only allow logged-in users to report posts
-      !(@user.is_a?(Thredded::NullUser))
+      !(@user.is_a? Thredded::NullUser)
     end
 
     def anonymous?

--- a/app/policies/thredded/post_policy.rb
+++ b/app/policies/thredded/post_policy.rb
@@ -45,6 +45,11 @@ module Thredded
       !@post.first_post_in_topic? && update?
     end
 
+    def report?
+      # Only allow logged-in users to report posts
+      !(@user.is_a?(Thredded::NullUser))
+    end
+
     def anonymous?
       @user.thredded_anonymous?
     end

--- a/app/view_models/thredded/post_view.rb
+++ b/app/view_models/thredded/post_view.rb
@@ -45,6 +45,10 @@ module Thredded
       @can_moderate ||= @policy.moderate?
     end
 
+    def can_report?
+      @can_report ||= @policy.report?
+    end
+
     def quote_url_params
       if @post.private_topic_post?
         { post: { quote_private_post_id: @post.id } }

--- a/app/view_models/thredded/post_view.rb
+++ b/app/view_models/thredded/post_view.rb
@@ -65,6 +65,10 @@ module Thredded
       Thredded::UrlsHelper.mark_unread_path(@post)
     end
 
+    def report_path
+      Thredded::UrlsHelper.report_post_path(@post)
+    end
+
     def destroy_path
       Thredded::UrlsHelper.delete_post_path(@post)
     end

--- a/app/views/thredded/posts_common/_actions.html.erb
+++ b/app/views/thredded/posts_common/_actions.html.erb
@@ -10,7 +10,7 @@
     <% if post.can_destroy? %>
       <%= render 'thredded/posts_common/actions/delete', post: post %>
     <% end %>
-    <% if thredded_signed_in? %>
+    <% if post.can_report? %>
       <%= render 'thredded/posts_common/actions/report', post: post %>
     <% end %>
     <% if post.read_state %>

--- a/app/views/thredded/posts_common/_actions.html.erb
+++ b/app/views/thredded/posts_common/_actions.html.erb
@@ -10,8 +10,7 @@
     <% if post.can_destroy? %>
       <%= render 'thredded/posts_common/actions/delete', post: post %>
     <% end %>
-    <%# TODO: if user_signed_in? %>
-    <% if true %>
+    <% if thredded_signed_in? %>
       <%= render 'thredded/posts_common/actions/report', post: post %>
     <% end %>
     <% if post.read_state %>

--- a/app/views/thredded/posts_common/_actions.html.erb
+++ b/app/views/thredded/posts_common/_actions.html.erb
@@ -10,6 +10,10 @@
     <% if post.can_destroy? %>
       <%= render 'thredded/posts_common/actions/delete', post: post %>
     <% end %>
+    <%# TODO: if user_signed_in? %>
+    <% if true %>
+      <%= render 'thredded/posts_common/actions/report', post: post %>
+    <% end %>
     <% if post.read_state %>
       <%= view_hooks.post_common.mark_as_unread.render self, post: post do %>
         <%= render 'thredded/posts_common/actions/mark_as_unread', post: post %>

--- a/app/views/thredded/posts_common/actions/_report.html.erb
+++ b/app/views/thredded/posts_common/actions/_report.html.erb
@@ -1,0 +1,3 @@
+<%= button_to t('thredded.posts.report'), post.report_path,
+              method: :post,
+              class: 'thredded--post--report thredded--post--dropdown--actions--item' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,8 @@ en:
         update_btn_submitting: :thredded.form.update_btn_submitting
       pending_moderation_notice: Your post will be published when it has been reviewed by a moderator.
       quote_btn: Quote
+      report: Report Post
+      reported_post: This post has been reported to moderation for review.
       spoiler_summary: Spoiler - click to show.
       spoiler_summary_for_email: 'Spoiler - select the contents below to see:'
     preferences:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
       member do
         post 'mark_as_read'
         post 'mark_as_unread'
+        post 'report'
       end
     end
 
@@ -101,6 +102,7 @@ Thredded::Engine.routes.draw do # rubocop:disable Metrics/BlockLength
       member do
         post 'mark_as_read'
         post 'mark_as_unread'
+        post 'report'
       end
     end
   end


### PR DESCRIPTION
This PR adds the ability for users to report posts to moderation. It re-uses the existing moderation queue already in place.

Questions:

* Will sticking things in the existing moderation queue instantly hide those topics for forums that require moderation before post visibility? This seems undesirable.

* Is "logged-in users" the best policy requirement for who can or cannot report posts?

Other notes:

* I think, ideally, the best UX after reporting would be to replace the "Report Post" menu item with a greyed-out "Reported Post" to signify the user has already reported that post. I can't think of a way to track this without requiring a database migration, so I fell back on just having a notice display informing the user that they've successfully reported the post. (Another option is greying out the report option if `moderation_state` is `pending_moderation`, but I don't think it's a good idea to expose to _other_ users which posts have/haven't been reported).

This was a quick implementation because some forums I run on thredded very frequently request this feature, and I'm definitely open to revisions and feedback. 

Thanks for everything you do, guys. :)

Screenshots:

![2019-02-22-151203_609x390_scrot](https://user-images.githubusercontent.com/538235/53271491-40c24f00-36b4-11e9-9a3f-52875aee633f.png)
