### PR TITLE
Improve Rails 6 support

### DIFF
--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -24,7 +24,7 @@ module Thredded
     validates :name, uniqueness: true, length: { within: Thredded.messageboard_name_length_range }, presence: true
     validates :topics_count, numericality: true
     validates :position, presence: true, on: :update
-    before_save :ensure_position, on: :create
+    before_save :ensure_position
 
     def ensure_position
       self.position ||= (created_at || Time.zone.now).to_i

--- a/app/models/thredded/messageboard_group.rb
+++ b/app/models/thredded/messageboard_group.rb
@@ -10,7 +10,7 @@ module Thredded
     scope :ordered, -> { order(position: :asc, id: :asc) }
     validates :name, presence: true, uniqueness: true
     validates :position, presence: true, on: :update
-    before_save :ensure_position, on: :create
+    before_save :ensure_position
 
     def ensure_position
       self.position ||= Time.zone.now.to_i


### PR DESCRIPTION
This PR removes 2 instances of the invalid (and unused) option `:on` for `before_save` callbacks in models.

Without this change, the following error is raised in Rails 6: 
`Unknown key: :on. Valid keys are: :if, :unless, :prepend`

Please note that the `:on` option was a no-op before Rails 6, so this PR does not change any behavior. 

However, Rails 6 introduced stricter option checking for model callbacks:  https://github.com/rails/rails/pull/30919

These were the only changes required to get Thredded happy on Rails 6 for http://github.com/sudara/alonetone — Impressive!🥇

