### PR TITLE
Docker fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# Need alpine:edge for Chromium 59
-# TODO: Change "edge" to "3.7" once it's been released.
 FROM alpine:edge
 
 RUN apk add --no-cache \
@@ -7,9 +5,9 @@ RUN apk add --no-cache \
     ruby ruby-bundler ruby-bigdecimal ruby-io-console tzdata nodejs bash \
     # Bundle install deps
     build-base ruby-dev libc-dev libffi-dev linux-headers gmp-dev libressl-dev libxml2-dev libxslt-dev \
-    mariadb-dev postgresql-dev sqlite-dev \
+    mariadb-connector-c-dev postgresql-dev sqlite-dev git \
     # Testing deps
-    chromium chromium-chromedriver
+    chromium
 
 ENV BUNDLE_SILENCE_ROOT_WARNING=1
 ENV BUNDLE_PATH=/bundle
@@ -21,7 +19,5 @@ RUN mkdir -p $APP_HOME
 
 # Copy Gemfile and run bundle install first to allow for caching
 COPY ./lib/thredded/version.rb $APP_HOME/lib/thredded/
-COPY thredded.gemspec shared.gemfile Gemfile $APP_HOME/
+COPY thredded.gemspec shared.gemfile i18n-tasks.gemfile rubocop.gemfile Gemfile $APP_HOME/
 RUN bundle --path=$BUNDLE_PATH
-
-COPY Rakefile config.ru app/ bin/ config/ db/ lib/ script/ spec/ $APP_HOME/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,17 @@ db:
 web:
   build: .
   volumes:
-    - .:/thredded
-    # Ignore these directories
-    - /thredded/.bundle
-    - /thredded/tmp/cache
-    - /thredded/tmp/pids
+    - ./Rakefile:/thredded/Rakefile
+    - ./config.ru:/thredded/config.ru
+    - ./app:/thredded/app
+    - ./bin:/thredded/bin
+    - ./config:/thredded/config
+    - ./db:/thredded/db
+    - ./lib:/thredded/lib
+    - ./script:/thredded/script
+    - ./spec:/thredded/spec
+    - ./vendor:/thredded/vendor
+    # Ignore these paths
     - /thredded/spec/dummy/tmp/
   working_dir: /thredded
   environment:
@@ -20,7 +26,8 @@ web:
     DB_PASSWORD:
   command: >
     bash -c 'script/wait-for-tcp $$DB_1_PORT_5432_TCP_ADDR $$DB_1_PORT_5432_TCP_PORT &&
-             bundle exec rake db:drop db:create db:migrate db:seed &&
+             bundle exec rake db:drop db:create db:migrate &&
+             bundle exec rake db:seed &&
              bundle exec rake dev:server'
   ports:
     - "9292:9292"


### PR DESCRIPTION
1. Install `git` in the web container to allow for installing git gems.
2. Mount individual files and directories so that the container can have a separate Gemfile.lock.

Supercedes #815