### PR TITLE
Rails 6.2.0.rc2 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rails', '~> 6.0.0.rc1'
+gem 'rails', '~> 6.0.0.rc2'
 gem 'rails-i18n', '~> 6.0.0.beta1'
 
 # https://github.com/rails/rails/blob/v6.0.0.rc1/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L12

--- a/app/models/concerns/thredded/topic_common.rb
+++ b/app/models/concerns/thredded/topic_common.rb
@@ -14,7 +14,9 @@ module Thredded
       scope :order_recently_posted_first, -> { order(last_post_at: :desc, id: :desc) }
       scope :on_page, ->(page_num) { page(page_num) }
 
-      validates :hash_id, presence: true, uniqueness: true
+      validates :hash_id,
+                presence: true,
+                uniqueness: { case_sensitive: true }
       validates :posts_count, numericality: true
 
       validates :title, presence: true, length: { within: Thredded.topic_title_length_range }

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -21,7 +21,10 @@ module Thredded
                   ]
                 )
 
-    validates :name, uniqueness: true, length: { within: Thredded.messageboard_name_length_range }, presence: true
+    validates :name,
+              uniqueness: { case_sensitive: false },
+              length: { within: Thredded.messageboard_name_length_range },
+              presence: true
     validates :topics_count, numericality: true
     validates :position, presence: true, on: :update
     before_save :ensure_position

--- a/app/models/thredded/messageboard_group.rb
+++ b/app/models/thredded/messageboard_group.rb
@@ -8,7 +8,9 @@ module Thredded
              dependent: :nullify
 
     scope :ordered, -> { order(position: :asc, id: :asc) }
-    validates :name, presence: true, uniqueness: true
+    validates :name,
+              presence: true,
+              uniqueness: { case_sensitive: false }
     validates :position, presence: true, on: :update
     before_save :ensure_position
 

--- a/app/models/thredded/user_detail.rb
+++ b/app/models/thredded/user_detail.rb
@@ -5,7 +5,9 @@ module Thredded
     include Thredded::ModerationState
 
     belongs_to :user, class_name: Thredded.user_class_name, inverse_of: :thredded_user_detail
-    validates :user_id, uniqueness: true, **(Thredded.rails_gte_51? ? {} : { presence: true })
+    validates :user_id,
+              uniqueness: { case_sensitive: true },
+              **(Thredded.rails_gte_51? ? {} : { presence: true })
 
     with_options foreign_key: :user_id, primary_key: :user_id, inverse_of: :user_detail, dependent: :nullify do
       has_many :topics, class_name: 'Thredded::Topic'

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -252,6 +252,13 @@ module Thredded # rubocop:disable Metrics/ModuleLength
     end
 
     # @api private
+    # Mainly to work around https://github.com/rails/rails/issues/36761
+    def rails_gte_600_rc_2?
+      @rails_gte_600_rc_2 = (Rails.gem_version >= Gem::Version.new('6.0.0.rc2')) if @rails_gte_600_rc_2.nil?
+      @rails_gte_600_rc_2
+    end
+
+    # @api private
     def rails_supports_csp_nonce?
       @rails_supports_csp_nonce = (Rails.gem_version >= Gem::Version.new('5.2.0')) if @rails_supports_csp_nonce.nil?
       @rails_supports_csp_nonce

--- a/spec/features/thredded/user_tracks_read_topics_and_posts_spec.rb
+++ b/spec/features/thredded/user_tracks_read_topics_and_posts_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'User tracking what they have and have not already read' do
 
     topic.view_read_topic
 
-    travel_to 1.minute.from_now do
+    travel_to 1.day.from_now do
       topic.someone_updates_topic
     end
     topic.visit_index

--- a/spec/gemfiles/rails_6_0.gemfile
+++ b/spec/gemfiles/rails_6_0.gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec path: '../../'
 eval_gemfile '../../shared.gemfile'
 
-gem 'rails', '~> 6.0.0.rc1'
+gem 'rails', '~> 6.0.0.rc2'
 gem 'rails-i18n', '~> 6.0.0.beta1'
 
 # https://github.com/rails/rails/blob/v6.0.0.rc1/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L12


### PR DESCRIPTION
Rails 6.2.0.rc2 changed join order when combining Arel and Rails joins.
Worked around by using only Arel joins in the affected query.
See https://github.com/rails/rails/issues/36761

Fixes #822