### PR TITLE
Avoid monkey-patching `pluck`

### DIFF
--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -139,9 +139,11 @@ module Thredded
             .and(read_states[:user_id].eq(user.id))
             .and(read_states[:unread_posts_count].eq(0))
 
-        joins(:topics).merge(topics_scope).joins(
+        relation = joins(:topics).merge(topics_scope).joins(
           messageboards.outer_join(read_states).on(read_states_join_cond).join_sources
-        ).group(messageboards[:id]).pluck(
+        ).group(messageboards[:id])
+        Thredded::ArelCompat.pluck(
+          relation,
           :id,
           Arel::Nodes::Subtraction.new(topics[:id].count, read_states[:id].count)
         ).to_h

--- a/lib/thredded/arel_compat.rb
+++ b/lib/thredded/arel_compat.rb
@@ -4,27 +4,36 @@ unless Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2 || Rails::VERSIO
   require 'thredded/rails_lt_5_2_arel_case_node.rb'
 end
 
-if Rails::VERSION::MAJOR == 4
-  # Make `pluck` compatible with Arel.
-  require 'active_record/relation'
-  ActiveRecord::Relation.prepend(Module.new do
-    def pluck(*column_names)
-      super(*column_names.map do |n|
-        if n.is_a?(Arel::Node)
-          Arel.sql(n.to_sql)
-        elsif n.is_a?(Arel::Attributes::Attribute)
-          n.name
-        else
-          n
-        end
-      end)
-    end
-  end)
-end
-
 module Thredded
   module ArelCompat
     module_function
+
+    # On Rails >= 5, this method simply returns `relation.pluck(*columns)`.
+    #
+    # Rails 4 `pluck` does not support Arel nodes and attributes. This method does.
+    #
+    # This is an external method because monkey-patching `pluck` would
+    # have compatibility issues, see:
+    #
+    # https://github.com/thredded/thredded/issues/842
+    # https://blog.newrelic.com/engineering/ruby-agent-module-prepend-alias-method-chains/
+    if Rails::VERSION::MAJOR > 4
+      def pluck(relation, *columns)
+        relation.pluck(*columns)
+      end
+    else
+      def pluck(relation, *columns)
+        relation.pluck(*columns.map do |n|
+          if n.is_a?(Arel::Node)
+            Arel.sql(n.to_sql)
+          elsif n.is_a?(Arel::Attributes::Attribute)
+            n.name
+          else
+            n
+          end
+        end)
+      end
+    end
 
     # @param [#connection] engine
     # @param [Arel::Nodes::Node] a integer node


### PR DESCRIPTION
This is needed for compatibility with NewRelic RPM under Rails 4.

See #842 and https://blog.newrelic.com/engineering/ruby-agent-module-prepend-alias-method-chains/

Fixes #842