### PR TITLE
Fix label reference for localized values

### DIFF
--- a/app/views/thredded/messageboards/_form.html.erb
+++ b/app/views/thredded/messageboards/_form.html.erb
@@ -1,16 +1,16 @@
 <%= form_for messageboard, html: { class: 'thredded--form' } do |f| %>
     <ul class="thredded--form-list">
       <li>
-        <%= f.label t('thredded.messageboard.form.title_label') %>
+        <%= f.label :name, t('thredded.messageboard.form.title_label') %>
         <%= f.text_field :name, required: true %>
         <%= render 'thredded/shared/field_errors', messages: f.object.errors[:name] %>
       </li>
       <li>
-        <%= f.label t('thredded.messageboard.form.description_label') %>
+        <%= f.label :description, t('thredded.messageboard.form.description_label') %>
         <%= f.text_field :description %>
       </li>
       <li>
-        <%= f.label t('thredded.messageboard.form.messageboard_group_id_label') %>
+        <%= f.label :messageboard_group_id, t('thredded.messageboard.form.messageboard_group_id_label') %>
         <%= f.collection_select :messageboard_group_id, Thredded::MessageboardGroup.all, :id, :name,
                                 include_blank: t('thredded.messageboard.form.no_group') %>
       </li>


### PR DESCRIPTION
In case the i18n translation is not the same value as the attribute
itself, the referenced ID in the label will not match the input
field.

Here is an example with the locale set to 'de':

Before this fix:

```
<li>
  <label for="messageboard_Name">Name</label>
  <input required="required" type="text" name="messageboard[name]" id="messageboard_name">
</li>
```

After this fix:

```
<li>
  <label for="messageboard_name">Name</label>
  <input required="required" type="text" name="messageboard[name]" id="messageboard_name">
</li>
```