### PR TITLE
Make name of spec follow convention and fix rails 6 (only) spec failure

### DIFF
--- a/spec/views/thredded/user/link_spec.rb
+++ b/spec/views/thredded/user/link_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'partial: thredded/users/link' do
+RSpec.describe 'thredded/users/link' do
   def render_partial(user)
     render partial: 'thredded/users/link', locals: { user: user }
   end


### PR DESCRIPTION
fixes #865