### PR TITLE
Remove warning from spec runs

### DIFF
--- a/spec/commands/thredded/autofollow_users_spec.rb
+++ b/spec/commands/thredded/autofollow_users_spec.rb
@@ -71,7 +71,7 @@ module Thredded
     end
 
     context 'with thredded_user_preferences.auto_follow_topics default true' do
-      around(:all) do |ex|
+      around do |ex|
         verbose_was = ActiveRecord::Migration.verbose
         ActiveRecord::Migration.verbose = false
         ActiveRecord::Migration.change_column_default :thredded_user_preferences, :auto_follow_topics, true


### PR DESCRIPTION
Before this fix, rspec runs would include the following warning:

> WARNING: `around(:context)` hooks are not supported and behave like `around(:example). Called from /Users/tim/workspaces/thredded/thredded/spec/commands/thredded/autofollow_users_spec.rb:74:in `block (2 levels) in <module:Thredded>'.