### PR TITLE
Update Onebox

### DIFF
--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -36,7 +36,7 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
   s.add_dependency 'html-pipeline'
   s.add_dependency 'kramdown', '>= 2.0.0'
   s.add_dependency 'kramdown-parser-gfm'
-  s.add_dependency 'onebox', '~> 1.8', '>= 1.8.99'
+  s.add_dependency 'onebox', '>= 1.8.99'
   # html-pipeline dependencies, see https://github.com/jch/html-pipeline#dependencies
   # for the AutolinkFilter
   s.add_dependency 'rinku'


### PR DESCRIPTION
To allow me to update the [addressable](https://github.com/sporkmonger/addressable) gem (which is desired because of CVE-2021-32740), I need to update the [onebox](https://github.com/discourse/onebox) gem.

This PR is testing whether a onebox upgrade to 2.x will cause problems