### PR TITLE
drop rails 4.2 - 5.1 support to simplify ongoing development

### DIFF
--- a/app/controllers/thredded/application_controller.rb
+++ b/app/controllers/thredded/application_controller.rb
@@ -63,15 +63,6 @@ module Thredded
       @is_thredded_moderator = !thredded_current_user.thredded_can_moderate_messageboards.empty?
     end
 
-    if Rails::VERSION::MAJOR < 5
-      # redirect_back polyfill
-      def redirect_back(fallback_location:, **args)
-        redirect_to :back, args
-      rescue ActionController::RedirectBackError
-        redirect_to fallback_location, args
-      end
-    end
-
     # @param given [Hash]
     # @return [Boolean] whether the given params are a subset of the controller's {#params}.
     def params_match?(given = {})

--- a/app/models/concerns/thredded/user_topic_read_state_common.rb
+++ b/app/models/concerns/thredded/user_topic_read_state_common.rb
@@ -29,7 +29,7 @@ module Thredded
     def calculate_post_counts
       relation = self.class.visible_posts_scope(user).where(postable_id: postable_id)
       unread_posts_count, read_posts_count =
-        Thredded::ArelCompat.pluck(relation, *self.class.post_counts_arel(read_at))[0]
+        relation.pluck(*self.class.post_counts_arel(read_at))[0]
       { unread_posts_count: unread_posts_count || 0, read_posts_count: read_posts_count || 0 }
     end
 
@@ -90,7 +90,7 @@ module Thredded
         posts = post_class.arel_table
         relation = joins(states.join(posts).on(states[:postable_id].eq(posts[:postable_id])).join_sources)
           .group(states[:id])
-        Thredded::ArelCompat.pluck(relation, states[:id], *post_counts_arel(states[:read_at], posts: posts))
+        relation.pluck(states[:id], *post_counts_arel(states[:read_at], posts: posts))
       end
     end
   end

--- a/app/models/concerns/thredded/user_topic_read_state_common.rb
+++ b/app/models/concerns/thredded/user_topic_read_state_common.rb
@@ -44,7 +44,7 @@ module Thredded
         selects << states[Arel.star] if !is_a?(ActiveRecord::Relation) || select_values.empty?
         selects += [
           Arel::Nodes::Case.new(states[:unread_posts_count].not_eq(0))
-            .when(Thredded::ArelCompat.true_value(self)).then(
+            .when(true).then(
               Arel::Nodes::Addition.new(
                 Thredded::ArelCompat.integer_division(self, states[:read_posts_count], posts_per_page), 1
               )
@@ -75,11 +75,11 @@ module Thredded
         [
           Arel::Nodes::Sum.new(
             [Arel::Nodes::Case.new(posts[:created_at].gt(read_at))
-               .when(Thredded::ArelCompat.true_value(self)).then(1).else(0)]
+               .when(true).then(1).else(0)]
           ).as('unread_posts_count'),
           Arel::Nodes::Sum.new(
             [Arel::Nodes::Case.new(posts[:created_at].gt(read_at))
-               .when(Thredded::ArelCompat.true_value(self)).then(0).else(1)]
+               .when(true).then(0).else(1)]
           ).as('read_posts_count')
         ]
       end

--- a/app/models/thredded/messageboard.rb
+++ b/app/models/thredded/messageboard.rb
@@ -142,8 +142,7 @@ module Thredded
         relation = joins(:topics).merge(topics_scope).joins(
           messageboards.outer_join(read_states).on(read_states_join_cond).join_sources
         ).group(messageboards[:id])
-        Thredded::ArelCompat.pluck(
-          relation,
+        relation.pluck(
           :id,
           Arel::Nodes::Subtraction.new(topics[:id].count, read_states[:id].count)
         ).to_h

--- a/app/models/thredded/post_moderation_record.rb
+++ b/app/models/thredded/post_moderation_record.rb
@@ -3,8 +3,7 @@
 module Thredded
   class PostModerationRecord < ActiveRecord::Base
     include Thredded::ModerationState
-    # Rails 4 doesn't support enum _prefix
-    enum previous_moderation_state: moderation_states, _prefix: :previous if Rails::VERSION::MAJOR >= 5
+    enum previous_moderation_state: moderation_states, _prefix: :previous
     validates :previous_moderation_state, presence: true
 
     scope :order_newest_first, -> { order(created_at: :desc, id: :desc) }
@@ -62,8 +61,6 @@ module Thredded
     # @param [Symbol, String] moderation_state
     # @return [Thredded::PostModerationRecord] the newly created persisted record
     def self.record!(moderator:, post:, previous_moderation_state:, moderation_state:)
-      # Rails 4 doesn't support enum _prefix
-      previous_moderation_state = moderation_states[previous_moderation_state.to_s] if Rails::VERSION::MAJOR < 5
       create!(
         previous_moderation_state: previous_moderation_state,
         moderation_state:          moderation_state,

--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -48,15 +48,6 @@ require 'thredded/collection_to_strings_with_cache_renderer'
 
 require 'thredded/webpack_assets'
 
-if Rails::VERSION::MAJOR < 5
-  begin
-    require 'where-or'
-  rescue LoadError
-    $stderr.puts "\nthredded: Please add gem 'where-or' to your Gemfile"
-    exit 1 # rubocop:disable Rails/Exit
-  end
-end
-
 module Thredded # rubocop:disable Metrics/ModuleLength
   class << self
     #== User

--- a/lib/thredded/arel_compat.rb
+++ b/lib/thredded/arel_compat.rb
@@ -15,9 +15,5 @@ module Thredded
         Arel::Nodes::Division.new(a, b)
       end
     end
-
-    def true_value(_engine)
-      true
-    end
   end
 end

--- a/lib/thredded/arel_compat.rb
+++ b/lib/thredded/arel_compat.rb
@@ -4,20 +4,6 @@ module Thredded
   module ArelCompat
     module_function
 
-    # TODO: inline this method (just use relation.pluck)
-    # On Rails >= 5, this method simply returns `relation.pluck(*columns)`.
-    #
-    # Rails 4 `pluck` does not support Arel nodes and attributes. This method does.
-    #
-    # This is an external method because monkey-patching `pluck` would
-    # have compatibility issues, see:
-    #
-    # https://github.com/thredded/thredded/issues/842
-    # https://blog.newrelic.com/engineering/ruby-agent-module-prepend-alias-method-chains/
-    def pluck(relation, *columns)
-      relation.pluck(*columns)
-    end
-
     # @param [#connection] engine
     # @param [Arel::Nodes::Node] a integer node
     # @param [Arel::Nodes::Node] b integer node

--- a/lib/thredded/collection_to_strings_with_cache_renderer.rb
+++ b/lib/thredded/collection_to_strings_with_cache_renderer.rb
@@ -99,28 +99,12 @@ module Thredded
       collection.map { |object| render_partial(partial_renderer, view_context, opts.merge(object: object)) }
     end
 
-    if Rails::VERSION::MAJOR >= 5
-      def collection_cache
-        ActionView::PartialRenderer.collection_cache
-      end
-    else
-      def collection_cache
-        Rails.application.config.action_controller.cache_store
-      end
+    def collection_cache
+      ActionView::PartialRenderer.collection_cache
     end
 
-    if Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2)
-      def combined_fragment_cache_key(view, key)
-        view.combined_fragment_cache_key(key)
-      end
-    elsif Rails::VERSION::MAJOR >= 5
-      def combined_fragment_cache_key(view, key)
-        view.fragment_cache_key(key)
-      end
-    else
-      def combined_fragment_cache_key(view, key)
-        view.controller.fragment_cache_key(key)
-      end
+    def combined_fragment_cache_key(view, key)
+      view.combined_fragment_cache_key(key)
     end
 
     if Rails::VERSION::MAJOR >= 6

--- a/lib/thredded/db_tools.rb
+++ b/lib/thredded/db_tools.rb
@@ -12,10 +12,8 @@ module Thredded
         migrate =
           if Rails.gem_version >= Gem::Version.new('6.0.0.rc2')
             -> { ActiveRecord::MigrationContext.new(paths, ActiveRecord::SchemaMigration).migrate(nil, &filter) }
-          elsif Rails::VERSION::STRING >= '5.2'
+          else # Rails 5.2
             -> { ActiveRecord::MigrationContext.new(paths).migrate(nil, &filter) }
-          else
-            -> { ActiveRecord::Migrator.migrate(paths, &filter) }
           end
         if quiet
           silence_active_record(&migrate)

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -22,13 +22,4 @@ class ApplicationController < ActionController::Base
       session.delete(:user_id) if user.nil?
     end
   end
-
-  if Rails::VERSION::MAJOR < 5
-    # redirect_back polyfill
-    def redirect_back(fallback_location:, **args)
-      redirect_to :back, args
-    rescue ActionController::RedirectBackError
-      redirect_to fallback_location, args
-    end
-  end
 end

--- a/spec/dummy/app/views/home/show.html.erb
+++ b/spec/dummy/app/views/home/show.html.erb
@@ -128,7 +128,7 @@
 
       <footer>
         <p>
-          Thredded supports Rails v4.2+.
+          Thredded supports Rails v5.2+.
           This demo app is powered by Rails v<%= Rails::VERSION::STRING %>.
         </p>
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -18,7 +18,6 @@ require 'thredded'
 require 'thredded/markdown_coderay'
 require 'thredded/markdown_katex'
 require 'rails-ujs' unless Thredded.rails_gte_51?
-require 'backport_new_renderer' if Rails::VERSION::MAJOR < 5
 
 if ENV['HEROKU']
   require 'tunemygc'
@@ -71,11 +70,7 @@ module Dummy
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
 
-    config.active_record.raise_in_transactional_callbacks = true if Rails::VERSION::MAJOR < 5
-
-    if Rails.gem_version >= Gem::Version.new('5.2.0.beta2') && Rails::VERSION::MAJOR < 6
-      config.active_record.sqlite3.represent_boolean_as_integer = true
-    end
+    config.active_record.sqlite3.represent_boolean_as_integer = true if Rails::VERSION::MAJOR < 6
 
     # Enable the asset pipeline
     config.assets.enabled = true


### PR DESCRIPTION
Outstanding tasks

* [x] remove rails 4.2 - 5.1 runs from travis 
* [x] use relation.pluck directly
* [x] inline true_value (true) and drop method
*  ~~drop database cleaner and use rails system specs~~ see #898

closes #885