### PR TITLE
fix an issue with the latest roadie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ env:
   global:
   - COVERAGE=1
   - TRAVIS=1
+  - FERRUM_DEFAULT_TIMEOUT=20
 
 before_script:
 - >

--- a/lib/thredded/email_transformer.rb
+++ b/lib/thredded/email_transformer.rb
@@ -17,8 +17,8 @@ module Thredded
     end
     @transformers = [Onebox, Spoiler]
 
-    # @param doc [Nokogiri::HTML::Document]
-    def self.call(doc)
+    # @param dom [Nokogiri::HTML::Document]
+    def self.call(doc, *)
       transformers.each { |transformer| transformer.call(doc) }
     end
   end


### PR DESCRIPTION
a change to roadie **seems to** enforce an extra param to the
before_transformation callback. This was always documented
so not a breaking change. It is causing test failures, eg.
https://app.travis-ci.com/github/thredded/thredded/builds/246374669