### PR TITLE
fix mysql user set up script

### DIFF
--- a/script/create-db-users
+++ b/script/create-db-users
@@ -19,7 +19,8 @@ create_mysql_user() {
   if mysql -s -u"$USER" -p"$PASS" -e '' 2>/dev/null; then return; fi
   log "Creating MySQL '$USER' user. MySQL root password required."
   mysql --verbose -uroot -p <<SQL
-GRANT ALL PRIVILEGES ON \`thredded_gem_dev\`.* TO '$USER'@'localhost' IDENTIFIED BY '$PASS';
+CREATE USER '$USER'@'localhost' IDENTIFIED BY '$PASS';
+GRANT ALL PRIVILEGES ON \`thredded_gem_dev\`.* TO '$USER'@'localhost';
 GRANT ALL PRIVILEGES ON \`thredded_gem_test\`.* TO '$USER'@'localhost';
 SQL
 }


### PR DESCRIPTION
mysql 8 requires user to be created explicitly not implictly with GRANT.

compare https://dev.mysql.com/doc/refman/5.6/en/grant.htmlhttps://dev.mysql.com/doc/refman/5.6/en/grant.html
with https://dev.mysql.com/doc/refman/8.0/en/grant.html