### PR TITLE
drop bare usage of url_for

### DIFF
--- a/app/views/thredded/posts_common/actions/_quote.html.erb
+++ b/app/views/thredded/posts_common/actions/_quote.html.erb
@@ -1,4 +1,4 @@
-<%= link_to t('thredded.posts.quote_btn'), url_for(post.quote_url_params),
+<%= link_to t('thredded.posts.quote_btn'), post.quote_url_params,
             'data-thredded-quote-post' => post.quote_path,
             class: 'thredded--post--quote thredded--post--dropdown--actions--item',
             rel: 'nofollow' %>


### PR DESCRIPTION
there's no need to use url_for (bare hash has the same effect where it is
used). fixes #812, replaces #813