### PR TITLE
don't try to update topics while deleting topics or messageboards

### DIFF
--- a/app/models/concerns/thredded/post_common.rb
+++ b/app/models/concerns/thredded/post_common.rb
@@ -81,6 +81,7 @@ module Thredded
     protected
 
     def update_unread_posts_count
+      return if destroyed_by_association
       postable.user_read_states.update_post_counts!
     end
 

--- a/app/models/thredded/post.rb
+++ b/app/models/thredded/post.rb
@@ -78,6 +78,7 @@ module Thredded
     end
 
     def update_parent_last_user_and_time_from_last_post
+      return if destroyed_by_association
       postable.update_last_user_and_time_from_last_post!
       messageboard.update_last_topic!
     end

--- a/spec/models/thredded/messageboard_spec.rb
+++ b/spec/models/thredded/messageboard_spec.rb
@@ -205,4 +205,24 @@ module Thredded
         .to(eq(board_1.id => 1))
     end
   end
+
+  describe 'destroy' do
+    let(:messageboard) { create(:messageboard) }
+    let(:category) { create(:category) }
+    let(:topic) { create(:topic, messageboard: messageboard, last_user: user, categories: [category]) }
+    let(:topic2) { create(:topic, messageboard: messageboard, last_user: user) }
+    let!(:post) { create(:post, postable: topic, messageboard: messageboard, user: user) }
+    let!(:post2) { create(:post, postable: topic2, messageboard: messageboard) }
+    let!(:post3) { create(:post, postable: topic2, messageboard: messageboard, user: user) }
+    let(:user) { create(:user) }
+    let!(:user_follow) { UserTopicFollow.create_unless_exists(create(:user).id, topic2.id) }
+    let!(:user_topic_read_state) { create(:user_topic_read_state, postable: topic, user: user) }
+    let!(:notifications) { UserPostNotification.create_from_post_and_user(post, create(:user)) }
+
+    it 'will destroy post and topic' do
+      expect do
+        messageboard.destroy
+      end.to change { [Post.exists?(post.id), Topic.exists?(topic.id)] }.from([true, true]).to [false, false]
+    end
+  end
 end


### PR DESCRIPTION
this will result in less unnecessary database thrash as well as should
fix #860 and replace #861.

NB could not generate a failing messageboard destroy spec, but have left
a passing one in.