### PR TITLE
Support Pundit 2.2.0+

### DIFF
--- a/app/controllers/thredded/application_controller.rb
+++ b/app/controllers/thredded/application_controller.rb
@@ -4,7 +4,11 @@ module Thredded
   class ApplicationController < ::ApplicationController # rubocop:disable Metrics/ClassLength
     layout :thredded_layout
     include ::Thredded::UrlsHelper
-    include Pundit
+    if defined?(Pundit::Authorization)
+      include Pundit::Authorization
+    else
+      include Pundit
+    end
 
     helper Thredded::Engine.helpers
     helper_method \


### PR DESCRIPTION
In https://github.com/varvet/pundit/pull/621, Pundit changes the module name to be included.

This patch will allow Thredded to support the newest Pundit versions, but also older versions.