### PR TITLE
ensure db pool isn't exhausted during parallel rendering.

### DIFF
--- a/lib/thredded/collection_to_strings_with_cache_renderer.rb
+++ b/lib/thredded/collection_to_strings_with_cache_renderer.rb
@@ -86,7 +86,9 @@ module Thredded
             # https://github.com/rails/rails/blob/v6.0.2.1/actionview/lib/action_view/renderer/partial_renderer.rb#L379
             # https://github.com/rails/rails/blob/v6.0.2.1/actionview/lib/action_view/renderer/partial_renderer.rb#L348-L356
             opts[:locals] = opts[:locals].dup if opts[:locals]
-            render_partials_serial(view_context.dup, slice, opts)
+            ActiveRecord::Base.connection_pool.with_connection do
+              render_partials_serial(view_context.dup, slice, opts)
+            end
           end
         end.flat_map(&:value)
       end

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -4,11 +4,12 @@ db_host    = ENV.fetch('DB_HOST', ENV.fetch('DB_1_PORT_5432_TCP_ADDR', 'localhos
 db_port    = ENV['DB_1_PORT_5432_TCP_PORT'] || ENV['DB_PORT'] ||
   {'postgresql' => 5432, 'mysql2' => 3306}[db_adapter]
 require 'etc'
-pool_size =
+pool_size = ENV['DB_POOL'] || (
   # Web: max workers * max threads
   ENV.fetch('WEB_CONCURRENCY', 3).to_i * ENV.fetch('MAX_THREADS', 5).to_i +
   # ActiveJob Async max thread pool size
   Etc.nprocessors
+  )
 %>
 
 defaults: &defaults

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -25,7 +25,7 @@ Dummy::Application.configure do
       }
     end
   else
-    config.public_file_server.enabled = false
+    config.public_file_server.enabled = true
   end
 
   # Compress JavaScripts and CSS


### PR DESCRIPTION
~~this is draft for comment. it includes all the commits 
which I used to generate the test data, but I will separate
these out into separate PRs where relevant.~~
