### PR TITLE
show preview when visiting new topic with prefilled form

### DIFF
--- a/app/assets/javascripts/thredded/components/preview_area.es6
+++ b/app/assets/javascripts/thredded/components/preview_area.es6
@@ -27,7 +27,9 @@
       }, 200, false);
 
       textarea.addEventListener('input', onChange, false);
-
+      if(textarea.value.trim() !== '') {
+        onChange();
+      }
       this.requestId = 0;
     }
 

--- a/spec/support/system/page_object/topics.rb
+++ b/spec/support/system/page_object/topics.rb
@@ -50,8 +50,8 @@ module PageObject
       visit messageboard_topics_path(messageboard)
     end
 
-    def visit_form(next_page: nil)
-      visit new_messageboard_topic_path(messageboard, next_page: next_page)
+    def visit_form(**params)
+      visit new_messageboard_topic_path(messageboard, **params)
     end
 
     def visit_latest_topic

--- a/spec/system/thredded/user_creates_new_topic_spec.rb
+++ b/spec/system/thredded/user_creates_new_topic_spec.rb
@@ -36,6 +36,16 @@ RSpec.feature 'User creates new topic' do
     end
   end
 
+  it 'with prefilled title and content which is automatically previewed', js: true do
+    topic = new_topic
+    topic.visit_form(topic: { title: 'Hello title', content: 'Hello *world*!' })
+    expect(page).to have_field('Title', with: 'Hello title')
+    expect(page).to have_field('Content', with: 'Hello *world*!')
+    within topic.preview_selector do
+      expect(page.html).to include("<p>Hello <em>world</em>!</p>\n")
+    end
+  end
+
   it 'and sees no categories in the form when none exist' do
     topic_form = new_topic
     topic_form.visit_form


### PR DESCRIPTION
when visiting a form which has prefilled content, such as

https://thredded.org/thredded/main-board/topics/new?topic[title]=Something&topic[content]=some+\n`content`**

then show the preview for the content immediately (don't have to wait
for user to type into the field)