### PR TITLE
[#944] limit version of html-pipeline for HTML::Pipeline::SanitizationFilter::WHITELIST

### DIFF
--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -33,7 +33,7 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
   s.add_dependency 'rails_gravatar'
 
   # post rendering
-  s.add_dependency 'html-pipeline'
+  s.add_dependency 'html-pipeline', '< 2.14.1'
   s.add_dependency 'kramdown', '>= 2.0.0'
   s.add_dependency 'kramdown-parser-gfm'
   s.add_dependency 'onebox', '>= 1.8.99'


### PR DESCRIPTION
HTML::Pipeline::SanitizationFilter::WHITELIST was renamed to HTML::Pipeline::SanitizationFilter::ALLOWLIST in html-pipeline v2.14.1