### PR TITLE
use ruby 2.7 for testing rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
           packages: []
 
     - gemfile: spec/gemfiles/rails_5_2.gemfile
-      rvm: 2.6
+      rvm: 2.7
       env: DB=postgresql DB_USERNAME=postgres DB_PASSWORD=""
       services: postgresql
 


### PR DESCRIPTION
It fixes an issue installing from github on travis
(maybe fixed in 2.6.7 - travis is on 2.6.6, but 2.7 works anyway)