### PR TITLE
drop support for rails <5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 # Unreleased
 
-See the full list of changes here: https://github.com/thredded/thredded/compare/v1.0.0...main
+* Drop support for Rails < 5.2
+
+See the full list of changes here: https://github.com/thredded/thredded/compare/v1.0.0...master
 
 * ContentFormatter.whitelist is now deprecated in favour of ContentFormatter.allowlist. Will be removed in v2.0
 * Support more recent versions of html-pipeline gem

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Thredded [![Code Climate](https://codeclimate.com/github/thredded/thredded/badges/gpa.svg)](https://codeclimate.com/github/thredded/thredded) [![Travis-CI](https://api.travis-ci.org/thredded/thredded.svg?branch=main)](https://travis-ci.org/thredded/thredded/) [![Test Coverage](https://codeclimate.com/github/thredded/thredded/badges/coverage.svg)](https://codeclimate.com/github/thredded/thredded/coverage) [![Inline docs](http://inch-ci.org/github/thredded/thredded.svg?branch=main)](http://inch-ci.org/github/thredded/thredded) [![Gitter](https://badges.gitter.im/thredded/thredded.svg)](https://gitter.im/thredded/thredded?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-_Thredded_ is a Rails 4.2+ forum/messageboard engine. Its goal is to be as simple and feature rich as possible.
+_Thredded_ is a Rails 5.2+ forum/messageboard engine. Its goal is to be as simple and feature rich as possible.
 
 Some of the features currently in Thredded:
 

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.homepage    = 'https://thredded.org'
   s.summary     = 'The best Rails forums engine ever.'
   s.license     = 'MIT'
-  s.description = 'The best Rails 4.2+ forums engine ever. Its goal is to be as simple and feature rich as possible.
+  s.description = 'The best Rails 5.2+ forums engine ever. Its goal is to be as simple and feature rich as possible.
 Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at https://thredded.org/.'
 
   s.files = Dir['{app,bin,config,db,lib,vendor}/**/*'] + %w[MIT-LICENSE README.md]
@@ -29,7 +29,7 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
   s.add_dependency 'kaminari'
   s.add_dependency 'nokogiri'
   s.add_dependency 'pundit', '>= 1.1.0'
-  s.add_dependency 'rails', '>= 4.2.10', '!= 6.0.0.rc2'
+  s.add_dependency 'rails', '>= 5.2.0', '!= 6.0.0.rc2'
   s.add_dependency 'rails_gravatar'
 
   # post rendering


### PR DESCRIPTION
We no longer test on rails <5.2, and we announced this in our
change notes for 1.0 so it's logical to no longer claim
this support! Additionally should stop people installing it on earlier
rails versions from next version.