### PR TITLE
drop support for html-pipeline below 2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 # Unreleased
 
 * Drop support for Rails 5.2 - if you need support for rails 5.2 use v1.0.x
+* fix thredded routes when main app has `include rails.application.routes.url_helpers` in its helpers [#961]
 
 See the full list of changes here: https://github.com/thredded/thredded/compare/v1.0.1...main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,11 @@
 
 * drop `ContentFormatter.whitelist` just use `ContentFormatter.allowlist`
 
-# Unreleased (plans for v1.1)
-
-* depend on html-pipeline >= 2.14.1 and drop support for earlier version
-
-# Unreleased
+# Unreleased (v1.1)
 
 * Drop support for Rails 5.2 - if you need support for rails 5.2 use v1.0.x
 * fix thredded routes when main app has `include rails.application.routes.url_helpers` in its helpers [#961]
+* Drop support for html-pipeline < 2.14.1
 
 See the full list of changes here: https://github.com/thredded/thredded/compare/v1.0.1...main
 

--- a/lib/thredded/content_formatter.rb
+++ b/lib/thredded/content_formatter.rb
@@ -8,7 +8,15 @@ module Thredded
       attr_accessor :allowlist
 
       # TODO: v2.0: drop alias and just use allowlist
-      alias_attribute :whitelist, :allowlist
+      # @deprecated use allowlist
+      def whitelist
+        ActiveSupport::Deprecation.warn(<<~MESSAGE.squish)
+          ContentFormatter.whitelist is deprecated and will be removed in Thredded 2.0.
+          Use ContentFormatter.allowlist instead
+        MESSAGE
+
+        allowlist
+      end
 
       # Filters that run before processing the markup.
       # input: markup, output: markup.

--- a/lib/thredded/content_formatter.rb
+++ b/lib/thredded/content_formatter.rb
@@ -30,17 +30,8 @@ module Thredded
       # input: sanitized html, output: html
       attr_accessor :after_sanitization_filters
 
-      # TODO: v1.1: only allow html-pipeline >= 2.14.1 and drop this
-      def sanitization_filter_uses_allowlist?
-        defined?(HTML::Pipeline::SanitizationFilter::ALLOWLIST)
-      end
-
       def sanitization_filter_allowlist_config
-        if sanitization_filter_uses_allowlist?
-          HTML::Pipeline::SanitizationFilter::ALLOWLIST
-        else
-          HTML::Pipeline::SanitizationFilter::WHITELIST
-        end
+        HTML::Pipeline::SanitizationFilter::ALLOWLIST
       end
     end
 
@@ -150,15 +141,9 @@ module Thredded
 
     # @return [Hash] options for HTML::Pipeline.new
     def content_pipeline_options
-      option = if self.class.sanitization_filter_uses_allowlist?
-                 :allowlist
-               else
-                 # TODO: v1.1: only allow html-pipeline >= 2.14.1 and drop this
-                 :whitelist
-               end
       {
         asset_root: Rails.application.config.action_controller.asset_host || '',
-        option => ContentFormatter.allowlist
+        allowlist: ContentFormatter.allowlist
       }
     end
   end

--- a/spec/gemfiles/rails_6_0.gemfile
+++ b/spec/gemfiles/rails_6_0.gemfile
@@ -17,6 +17,3 @@ gem 'pg', '>= 0.18', '< 2.0'
 
 # https://github.com/rails/rails/blob/v6.0.4/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6
 gem 'mysql2', '>= 0.4.4'
-
-# This isn't required for rails 6.0 - just want to have one version that uses an older html-pipeline
-gem 'html-pipeline', '<= 2.0'

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -33,7 +33,7 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
   s.add_dependency 'rails_gravatar'
 
   # post rendering
-  s.add_dependency 'html-pipeline'
+  s.add_dependency 'html-pipeline', '>= 2.14.1'
   s.add_dependency 'kramdown', '>= 2.0.0'
   s.add_dependency 'kramdown-parser-gfm'
   s.add_dependency 'onebox', '>= 1.8.99'


### PR DESCRIPTION
and add deprecations for 1.2