### PR TITLE
prevent Topic.last_post_at from being nil

### DIFF
--- a/app/models/thredded/topic.rb
+++ b/app/models/thredded/topic.rb
@@ -85,6 +85,8 @@ module Thredded
 
     delegate :name, to: :messageboard, prefix: true
 
+    before_create :ensure_last_post_at
+
     after_commit :update_messageboard_last_topic, on: :update, if: -> { previous_changes.include?('moderation_state') }
     after_commit :update_last_user_and_time_from_last_post!, if: -> { previous_changes.include?('moderation_state') }
 
@@ -202,6 +204,10 @@ module Thredded
         Thredded::Messageboard.reset_counters(messageboard_id, :topics, :posts)
         Thredded::Messageboard.find(messageboard_id).update_last_topic!
       end
+    end
+
+    def ensure_last_post_at
+      self.last_post_at ||= Time.zone.now
     end
   end
 end

--- a/spec/models/thredded/topic_spec.rb
+++ b/spec/models/thredded/topic_spec.rb
@@ -395,5 +395,11 @@ module Thredded
       expect(topic.categories.size).to eq 1
       expect(topic.categories.first).to eq category
     end
+
+    it 'naver has nil last_post_at' do
+      topic = Topic.create!(messageboard_id: create(:messageboard).id, title: 'some title', user_id: create(:user).id)
+      expect(topic.reload.last_post_at).not_to be_nil
+      expect(topic.last_post_at).to be_within(1).of(topic.created_at)
+    end
   end
 end


### PR DESCRIPTION
In rails 6.1+ this is (for some strange reason) firing two create_or_updates
(the second one from autosaving on the UserDetail?), and one after_commit
but with no previous_changes (so update_last_user_and_time_from_last_post! doesn't get called on create)

    Topic.create!(messageboard_id: create(:messageboard).id, title: 'some title', user_id: create(:user).id

In normal Thredded this will never happen on its own, because there will always be a post created after a topic which will fire `update_last_user_and_time_from_last_post!` and thus calculate last_post_at, but in some test situations, and perhaps other thredded scenarios prevents it from having an anomalous nil in last_post_at.