### PR TITLE
Restrict html_pipeline version to <3

### DIFF
--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -33,7 +33,7 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
   s.add_dependency 'rails_gravatar'
 
   # post rendering
-  s.add_dependency 'html-pipeline', '>= 2.14.1'
+  s.add_dependency 'html-pipeline', '>= 2.14.1', '< 3'
   s.add_dependency 'kramdown', '>= 2.0.0'
   s.add_dependency 'kramdown-parser-gfm'
   s.add_dependency 'onebox', '>= 1.8.99'


### PR DESCRIPTION
html_pipeline v3 changes its underlying parser from Nokogiri to Selma, which means we'd have to rewrite all of the HTML pipeline / sanitization code.

Refs #979