### PR TITLE
Rails 7.2 Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,21 @@ jobs:
       before_install: nvm install 14
       env: DB=sqlite3
 
+    - gemfile: spec/gemfiles/rails_7_2.gemfile
+      rvm: 3.3
+      before_install: nvm install 14
+      env: DB=postgresql DB_USERNAME=postgres DB_PASSWORD=""
+      services: postgresql
+    - gemfile: spec/gemfiles/rails_7_2.gemfile
+      rvm: 3.3
+      before_install: nvm install 14
+      env: DB=mysql2 DB_USERNAME=root DB_PASSWORD=""
+      services: mysql
+    - gemfile: spec/gemfiles/rails_7_2.gemfile
+      rvm: 3.3
+      before_install: nvm install 14
+      env: DB=sqlite3
+
     - gemfile: spec/gemfiles/rails_main.gemfile
       rvm: 3.0
       before_install: nvm install 14

--- a/app/models/concerns/thredded/moderation_state.rb
+++ b/app/models/concerns/thredded/moderation_state.rb
@@ -7,7 +7,11 @@ module Thredded
     extend ActiveSupport::Concern
 
     included do
-      enum moderation_state: %i[pending_moderation approved blocked]
+      if Thredded::Compat.rails_gte_7?
+        enum :moderation_state, %i[pending_moderation approved blocked]
+      else
+        enum moderation_state: %i[pending_moderation approved blocked]
+      end
       validates :moderation_state, presence: true
     end
   end

--- a/app/models/thredded/post_moderation_record.rb
+++ b/app/models/thredded/post_moderation_record.rb
@@ -5,7 +5,7 @@ module Thredded
     include Thredded::ModerationState
 
     if Thredded::Compat.rails_gte_7?
-      enum :previous_moderation_state, moderation_states, _prefix: :previous
+      enum :previous_moderation_state, moderation_states, prefix: :previous
     else
       enum previous_moderation_state: moderation_states, _prefix: :previous
     end

--- a/app/models/thredded/post_moderation_record.rb
+++ b/app/models/thredded/post_moderation_record.rb
@@ -3,7 +3,13 @@
 module Thredded
   class PostModerationRecord < ActiveRecord::Base
     include Thredded::ModerationState
-    enum previous_moderation_state: moderation_states, _prefix: :previous
+
+    if Thredded::Compat.rails_gte_7?
+      enum :previous_moderation_state, moderation_states, _prefix: :previous
+    else
+      enum previous_moderation_state: moderation_states, _prefix: :previous
+    end
+
     validates :previous_moderation_state, presence: true
 
     scope :order_newest_first, -> { order(created_at: :desc, id: :desc) }

--- a/app/models/thredded/user_topic_follow.rb
+++ b/app/models/thredded/user_topic_follow.rb
@@ -2,7 +2,11 @@
 
 module Thredded
   class UserTopicFollow < ActiveRecord::Base
-    enum reason: %i[manual posted mentioned auto]
+    if Thredded::Compat.rails_gte_7?
+      enum :reason, %i[manual posted mentioned auto]
+    else
+      enum reason: %i[manual posted mentioned auto]
+    end
 
     belongs_to :user, inverse_of: :thredded_topic_follows, class_name: Thredded.user_class_name
     belongs_to :topic, inverse_of: :user_follows

--- a/lib/thredded/compat.rb
+++ b/lib/thredded/compat.rb
@@ -9,6 +9,12 @@ module Thredded
         @rails_gte_61
       end
 
+      # @api private
+      def rails_gte_7?
+        @rails_gte_7 = (Rails.gem_version >= Gem::Version.new('7.0.0')) if @rails_gte_7.nil?
+        @rails_gte_7
+      end
+
       if Rails.gem_version >= Gem::Version.new('7.0.0')
         # @api private
         def association_preloader(records:, associations:, scope:)

--- a/spec/gemfiles/rails_7_2.gemfile
+++ b/spec/gemfiles/rails_7_2.gemfile
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+gemspec path: '../../'
+eval_gemfile '../../shared.gemfile'
+
+gem 'rails', '7.2.0.beta3'
+gem 'rails-i18n', '~> 7.0.0'
+
+# TODO: create a new rails 7 version of dummy (probably in parallel) using import-maps ?
+gem 'webpacker', '~> 5.0'
+
+# https://github.com/rails/rails/blob/v7.0.2/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L13
+gem 'sqlite3', '~> 1.4'
+
+# https://github.com/rails/rails/blob/v7.0.2/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L4
+gem 'pg'
+
+# https://github.com/rails/rails/blob/v7.0.2/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6
+gem 'mysql2', '~> 0.5'


### PR DESCRIPTION
I'm trying to run `7.2.0.beta3` on my app and ran into an issue. Namely, the syntax for `enum` definition has changed in Rails. This PR fixes the issue and adds testing for Rails 7.2 for Thredded.