### PR TITLE
Deprecated alias_attribute for a method

### DIFF
--- a/app/models/thredded/user_topic_follow.rb
+++ b/app/models/thredded/user_topic_follow.rb
@@ -16,7 +16,7 @@ module Thredded
 
     # shim to behave like postable-related (though actually only ever related to topic)
     alias_attribute :postable_id, :topic_id
-    alias_attribute :postable, :topic
+    alias postable topic
 
     # Creates a follow or finds the existing one.
     #

--- a/app/models/thredded/user_topic_follow.rb
+++ b/app/models/thredded/user_topic_follow.rb
@@ -17,6 +17,7 @@ module Thredded
     # shim to behave like postable-related (though actually only ever related to topic)
     alias_attribute :postable_id, :topic_id
     alias postable topic
+    alias postable= topic=
 
     # Creates a follow or finds the existing one.
     #


### PR DESCRIPTION

In rails 7.2 there is a bug with `postable` when accessing forums.

Seems to be a simple deprecation of `alias_attribute postable, topic` line, changing this fix the problem.

<img width="1324" alt="image" src="https://github.com/user-attachments/assets/4afb2067-a5f9-4550-9eb9-f9f5c322d624">

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/df5a745c-38b1-4057-b995-7f76477b172a">
