### PR TITLE
Replace the hard sassc-rails gem dependency with a soft dependency on a Sprockets Sass compiler

### DIFF
--- a/lib/thredded.rb
+++ b/lib/thredded.rb
@@ -29,7 +29,6 @@ require 'thredded/users_provider'
 require 'autoprefixer-rails'
 require 'timeago_js'
 require 'sprockets/es6'
-require 'sassc-rails'
 
 require 'thredded/version'
 require 'thredded/compat'

--- a/lib/thredded/engine.rb
+++ b/lib/thredded/engine.rb
@@ -22,8 +22,11 @@ module Thredded
     end
 
     config.after_initialize do |app|
-      if !Rails.env.production? && !app.assets.preprocessors.keys.include?("text/scss")
-        raise %(Thredded requires a Sass compiler to be registered in Sprockets. Please add "sassc-rails" or "dartsass-sprockets" to your application Gemfile.)
+      if !Rails.env.production? && app.assets.preprocessors.keys.exclude?('text/scss')
+        fail [
+          'Thredded requires a Sass compiler to be registered in Sprockets.',
+          %(Please add "sassc-rails" or "dartsass-sprockets" to your application Gemfile.),
+        ].join(' ')
       end
     end
   end

--- a/lib/thredded/engine.rb
+++ b/lib/thredded/engine.rb
@@ -20,5 +20,11 @@ module Thredded
         thredded_manifest.js
       ]
     end
+
+    config.after_initialize do |app|
+      if !app.assets.preprocessors.keys.include?("text/scss")
+        raise %(Thredded requires a Sass compiler to be registered in Sprockets. Please add "sassc-rails" or "dartsass-sprockets" to your application Gemfile.)
+      end
+    end
   end
 end

--- a/lib/thredded/engine.rb
+++ b/lib/thredded/engine.rb
@@ -22,7 +22,7 @@ module Thredded
     end
 
     config.after_initialize do |app|
-      if !app.assets.preprocessors.keys.include?("text/scss")
+      if !Rails.env.production? && !app.assets.preprocessors.keys.include?("text/scss")
         raise %(Thredded requires a Sass compiler to be registered in Sprockets. Please add "sassc-rails" or "dartsass-sprockets" to your application Gemfile.)
       end
     end

--- a/thredded.gemspec
+++ b/thredded.gemspec
@@ -45,7 +45,6 @@ Thredded works with SQLite, MySQL (v5.6.4+), and PostgreSQL. See the demo at htt
 
   # frontend
   s.add_dependency 'autoprefixer-rails'
-  s.add_dependency 'sassc-rails', '>= 2.0.0'
   s.add_dependency 'sprockets-es6'
   s.add_dependency 'timeago_js', '>= 3.0.2.2'
 


### PR DESCRIPTION
Hi, thanks for thredded!

Now that Ruby Sass and SassC are dead, we've been switching our Rails projects over to use the Dart Sass compiler in the form of the `dartsass-sprockets` gem. However, Thredded has a hard dependency on `sassc-rails`, and the two cannot coexist.

Here's my five-minute hack to relax the dependency. It seems to work well enough, but I'm open to other resolution strategies here.

Thoughts?