### PR TITLE
support rails 8.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         ruby: ["3.1", "3.2", "3.3"]
         node: ["14"]
-        rails_version: ["7.0", "7.1", "7.2"]
+        rails_version: ["7.0", "7.1", "7.2", "8.0"]
         db: [sqlite3, postgresql, mysql2]
         exclude:
           # Not needed version combinations (just to cut down on noise)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,10 +78,16 @@ jobs:
           - ruby: 3.2
             rails_version: 7.0
             db: sqlite3
+          - ruby: 3.2
+            rails_version: 8.0
+            db: sqlite3
+          - ruby: 3.2
+            rails_version: 8.0
+            db: mysql2
           - ruby: 3.3
             rails_version: edge
 
-          # 3.3 on edge mainly
+          # 3.3 on 8.0/edge mainly
           - ruby: 3.3
             rails_version: 7.0
           - ruby: 3.3
@@ -94,6 +100,8 @@ jobs:
             db: mysql2
 
           # Not supported version combinations
+          - ruby: 3.1
+            rails_version: 8.0
           - ruby: 3.1
             rails_version: edge
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 * drop `ContentFormatter.whitelist` just use `ContentFormatter.allowlist`
 
-# Unreleased
+# Unreleased (1.2.0)
+
+* Working with Rails 8.0, providing you can use the unreleased version of active_record_union
+* Working for Rails 7.2 [#985, #988, #991]
+* Tested agains Rails 7.0 - 8.0 and Ruby 3.0 - 3.3
+* Dropped support for EOL'd Rails (6.0, 6.1) and Ruby (2.7, 3.0) - if you needs support for rails 6.0 and 6.1, use v1.1.0
 
 See the full list of changes here: https://github.com/thredded/thredded/compare/v1.1.0...main
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-eval_gemfile File.expand_path('spec/gemfiles/rails_7.2.gemfile', __dir__)
+eval_gemfile File.expand_path('spec/gemfiles/rails_8.0.gemfile', __dir__)
 eval_gemfile File.expand_path('rubocop.gemfile', __dir__)
 eval_gemfile File.expand_path('i18n-tasks.gemfile', __dir__)
 

--- a/shared.gemfile
+++ b/shared.gemfile
@@ -40,7 +40,7 @@ gem 'db_text_search', github: 'thredded/db_text_search', branch: 'main'
 gem 'thredded-markdown_coderay', git: 'https://github.com/thredded/thredded-markdown_coderay', branch: 'main'
 gem 'thredded-markdown_katex', git: 'https://github.com/thredded/thredded-markdown_katex', branch: 'main'
 
-gem 'roadie-rails'
+gem 'roadie-rails', github: 'thredded/roadie-rails', branch: 'allow-rails-8'
 
 # converted from gemspec development dependencies
 

--- a/shared.gemfile
+++ b/shared.gemfile
@@ -40,7 +40,7 @@ gem 'db_text_search', github: 'thredded/db_text_search', branch: 'main'
 gem 'thredded-markdown_coderay', git: 'https://github.com/thredded/thredded-markdown_coderay', branch: 'main'
 gem 'thredded-markdown_katex', git: 'https://github.com/thredded/thredded-markdown_katex', branch: 'main'
 
-gem 'roadie-rails', github: 'thredded/roadie-rails', branch: 'allow-rails-8'
+gem 'roadie-rails'
 
 # converted from gemspec development dependencies
 

--- a/spec/dummy/config/initializers/backtrace_silencers.rb
+++ b/spec/dummy/config/initializers/backtrace_silencers.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
 # Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
-# Rails.backtrace_cleaner.remove_silencers!
+Rails.backtrace_cleaner.remove_silencers! if ENV['BACKTRACE']

--- a/spec/gemfiles/rails_8.0.gemfile
+++ b/spec/gemfiles/rails_8.0.gemfile
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+gemspec path: '../../'
+eval_gemfile '../../shared.gemfile'
+
+gem 'rails', '~> 8.0.0'
+gem 'rails-i18n', github: 'Shopify/rails-i18n', branch: 'schwad_rails_8'
+# waiting for https://github.com/svenfuchs/rails-i18n/pull/1130 to be merged
+
+# TODO: create a new rails 7 version of dummy (probably in parallel) using import-maps ?
+gem 'webpacker', '~> 5.0'
+
+# https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L13
+gem 'sqlite3', '>= 2.1'
+
+# https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L4
+gem 'pg', '~> 1.1'
+
+# https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6
+gem 'mysql2', '~> 0.5'

--- a/spec/gemfiles/rails_8.0.gemfile
+++ b/spec/gemfiles/rails_8.0.gemfile
@@ -5,7 +5,10 @@ gemspec path: '../../'
 eval_gemfile '../../shared.gemfile'
 
 gem 'rails', '~> 8.0.0'
+# TODO: need to depend on a rails 8.0 supporting release version of rails-i18n
 gem 'rails-i18n', github: 'Shopify/rails-i18n', branch: 'schwad_rails_8'
+# TODO: need to depend on a rails 8.0 supporting release version of active_record_union
+gem 'active_record_union', github: 'thredded/active_record_union', branch: 'master'
 # waiting for https://github.com/svenfuchs/rails-i18n/pull/1130 to be merged
 
 # TODO: create a new rails 7 version of dummy (probably in parallel) using import-maps ?

--- a/spec/gemfiles/rails_8.0.gemfile
+++ b/spec/gemfiles/rails_8.0.gemfile
@@ -8,7 +8,6 @@ gem 'rails', '~> 8.0.0'
 gem 'rails-i18n', '~> 8.0.0'
 # TODO: need to depend on a rails 8.0 supporting release version of active_record_union
 gem 'active_record_union', github: 'thredded/active_record_union', branch: 'master'
-# waiting for https://github.com/svenfuchs/rails-i18n/pull/1130 to be merged
 
 # TODO: create a new rails 7 version of dummy (probably in parallel) using import-maps ?
 gem 'webpacker', '~> 5.0'

--- a/spec/gemfiles/rails_8.0.gemfile
+++ b/spec/gemfiles/rails_8.0.gemfile
@@ -5,8 +5,7 @@ gemspec path: '../../'
 eval_gemfile '../../shared.gemfile'
 
 gem 'rails', '~> 8.0.0'
-# TODO: need to depend on a rails 8.0 supporting release version of rails-i18n
-gem 'rails-i18n', github: 'Shopify/rails-i18n', branch: 'schwad_rails_8'
+gem 'rails-i18n', '~> 8.0.0'
 # TODO: need to depend on a rails 8.0 supporting release version of active_record_union
 gem 'active_record_union', github: 'thredded/active_record_union', branch: 'master'
 # waiting for https://github.com/svenfuchs/rails-i18n/pull/1130 to be merged

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,7 @@ end
 Dir[Rails.root.join('..', '..', 'spec', 'support', '**', '*.rb')].each { |f| require f }
 
 RSpec.configure do |config| # rubocop:disable Metrics/BlockLength
+  config.backtrace_inclusion_patterns << %r{gems/([0-9.])+/gems/(?!rspec|capybara)} if ENV['BACKTRACE']
   config.filter_run_excluding migration_spec: !ENV['MIGRATION_SPEC'], configuration_spec: !ENV['CONFIGURATION_SPEC']
   config.use_transactional_fixtures = !ENV['MIGRATION_SPEC']
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
* [x] Need a release version of rails-18n once https://github.com/svenfuchs/rails-i18n/pull/1130 is merged
* [ ] Need a release version of active_union_scope master supporting rails 8.0 (e.g. https://github.com/brianhempel/active_record_union/issues/36) but would be good to have it tested on 8.0 as well (https://github.com/brianhempel/active_record_union/pull/37)
* [x] Maybe drop roadie-rails rather than rely on fork in dummy (not strictly required for testing I believe)