### PR TITLE
drop pinning of activesupport in rubocop gemfile

### DIFF
--- a/rubocop.gemfile
+++ b/rubocop.gemfile
@@ -8,5 +8,3 @@ gem 'rubocop-rspec', '= 3.6.0'
 gem 'rubocop-rspec_rails', '= 2.31.0'
 gem 'rubocop-rails', '= 2.32.0'
 gem 'rubocop-thread_safety', '= 0.7.2'
-# lowest version of active support we support
-gem 'activesupport', '~> 7.0.0'


### PR DESCRIPTION
(to allow for easier development switching between rails,
and the aim of the pin (to standardise errors across local and github
actions never quite worked)