### PR TITLE
Modify ApplicationHelper#time_ago to display time in server's timezone

### DIFF
--- a/app/helpers/thredded/application_helper.rb
+++ b/app/helpers/thredded/application_helper.rb
@@ -67,6 +67,7 @@ module Thredded
     # @return [String] html_safe datetime presentation
     def time_ago(datetime, default: '-', html_options: {})
       return content_tag :time, default if datetime.nil?
+      datetime = datetime.localtime
       html_options = html_options.dup
       is_current_year = datetime.year == Time.current.year
       if datetime > 4.days.ago


### PR DESCRIPTION
Hi!

I faced the issue in our application that all times are one hour more than they should be. Perhaps this is related to daylight saving time. Didn't anyone face this issue before?
 
![Screenshot from 2025-07-10 08-42-21](https://github.com/user-attachments/assets/7ec7393e-0e11-402f-b7d0-963e54972bba)